### PR TITLE
Apply Rust formatting and code style improvements

### DIFF
--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -17,6 +17,7 @@ pub use author_affinity::AuthorColikerWorker;
 pub use coliker::ColikerWorker;
 pub use diversity::{diversify_posts, DiversityConfig, DiversityResult};
 pub use feed_cache::{FeedCache, FeedCacheStats};
+pub use graze_common::models::FeedSuccessConfig;
 pub use liker_cache::{CacheStats, LikerCache};
 pub use params::{apply_thompson_params, get_preset, merge_params, LinkLonkParams};
 pub use proof::{compute_proof, LinkLonkProof, ProofCollector};
@@ -26,7 +27,6 @@ pub use scoring_core::{
     aggregate_coliker_weights_normalized_parallel, aggregate_coliker_weights_parallel, score_posts,
     score_posts_parallel, score_posts_topk, to_fx_hashmap, ScoredPostResult,
 };
-pub use graze_common::models::FeedSuccessConfig;
 pub use thompson::{
     FeedOutcome, FeedOutcomeDetails, SelectedParams, ThompsonConfig, ThompsonLearner,
 };

--- a/crates/graze-api/src/algorithm/scorer.rs
+++ b/crates/graze-api/src/algorithm/scorer.rs
@@ -294,10 +294,7 @@ impl Scorer {
             // Sort each co-liker's likes by time descending, assign ranks, build lookup
             let mut ranks: FxHashMap<usize, FxHashMap<&str, usize>> = FxHashMap::default();
             for (co_liker, mut entries) in per_coliker {
-                entries.sort_by(|a, b| {
-                    b.1.partial_cmp(&a.1)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                });
+                entries.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
                 for (rank, (post_idx, _)) in entries.iter().enumerate() {
                     ranks.entry(*post_idx).or_default().insert(co_liker, rank);
                 }

--- a/crates/graze-api/src/algorithm/thompson.rs
+++ b/crates/graze-api/src/algorithm/thompson.rs
@@ -313,7 +313,12 @@ impl ThompsonLearner {
                 self.config.min_colikes_default,
             ));
         let (max_user_likes_opts, max_user_likes_def) = search_space_override
-            .map(|s| (s.max_user_likes_options.as_slice(), s.max_user_likes_default))
+            .map(|s| {
+                (
+                    s.max_user_likes_options.as_slice(),
+                    s.max_user_likes_default,
+                )
+            })
             .unwrap_or((
                 self.config.max_user_likes_options.as_slice(),
                 self.config.max_user_likes_default,
@@ -428,7 +433,11 @@ impl ThompsonLearner {
             ("max_checks", max_checks_opts, max_checks_def),
             ("min_colikes", min_colikes_opts, min_colikes_def),
             ("max_user_likes", max_user_likes_opts, max_user_likes_def),
-            ("max_src_per_post", max_src_per_post_opts, max_src_per_post_def),
+            (
+                "max_src_per_post",
+                max_src_per_post_opts,
+                max_src_per_post_def,
+            ),
             ("seed_pool", seed_pool_opts, seed_pool_def),
             ("corater_decay", corater_decay_opts, corater_decay_def),
         ];
@@ -496,7 +505,9 @@ impl ThompsonLearner {
             max_algo_checks: p.max_algo_checks.unwrap_or(c.max_checks_default),
             min_co_likes: p.min_co_likes.unwrap_or(c.min_colikes_default),
             max_user_likes: p.max_user_likes.unwrap_or(c.max_user_likes_default),
-            max_sources_per_post: p.max_sources_per_post.unwrap_or(c.max_sources_per_post_default),
+            max_sources_per_post: p
+                .max_sources_per_post
+                .unwrap_or(c.max_sources_per_post_default),
             seed_sample_pool: p.seed_sample_pool.unwrap_or(c.seed_pool_default),
             corater_decay_pct: p.corater_decay_pct.unwrap_or(c.corater_decay_default),
             is_holdout: false,
@@ -830,7 +841,7 @@ mod tests {
         };
 
         let config = ThompsonConfig {
-            holdout_rate: 0.0, // 0% holdout so we hit treatment path
+            holdout_rate: 0.0,     // 0% holdout so we hit treatment path
             exploration_prob: 0.0, // No exploration
             ..Default::default()
         };

--- a/crates/graze-api/src/api/admin.rs
+++ b/crates/graze-api/src/api/admin.rs
@@ -18,9 +18,7 @@ use crate::AppState;
 use graze_common::models::{
     FeedSuccessConfig, FeedThompsonConfig, PersonalizeRequest, ThompsonSearchSpace,
 };
-use graze_common::services::special_posts::{
-    SpecialPost, SpecialPostsResponse, SponsoredPost,
-};
+use graze_common::services::special_posts::{SpecialPost, SpecialPostsResponse, SponsoredPost};
 use graze_common::{hash_did, Keys};
 
 /// GET /v1/feeds
@@ -101,7 +99,10 @@ pub async fn register_feed(
     {
         if old_uri != feed_uri {
             let _ = state.redis.hdel(Keys::SUPPORTED_FEEDS, &old_uri).await;
-            let _ = state.redis.hdel(Keys::ALGO_ID_TO_FEED_URI, &algo_id_str).await;
+            let _ = state
+                .redis
+                .hdel(Keys::ALGO_ID_TO_FEED_URI, &algo_id_str)
+                .await;
         }
     }
 
@@ -158,7 +159,11 @@ pub async fn register_feed(
 
     // Enqueue one sync so candidate pool and fallback tranches are populated quickly
     let pending_key = "pending:syncs";
-    match state.redis.sadd(pending_key, std::slice::from_ref(&algo_id_str)).await {
+    match state
+        .redis
+        .sadd(pending_key, std::slice::from_ref(&algo_id_str))
+        .await
+    {
         Ok(added) if added > 0 => {
             if let Err(e) = state.redis.lpush(Keys::SYNC_QUEUE, &algo_id_str).await {
                 warn!(algo_id, error = %e, "failed_to_queue_sync");
@@ -250,7 +255,10 @@ pub async fn deregister_feed(
     };
 
     let _ = state.redis.hdel(Keys::SUPPORTED_FEEDS, &feed_uri).await;
-    let _ = state.redis.hdel(Keys::ALGO_ID_TO_FEED_URI, &algo_id_str).await;
+    let _ = state
+        .redis
+        .hdel(Keys::ALGO_ID_TO_FEED_URI, &algo_id_str)
+        .await;
     let _ = state.redis.hdel(Keys::FEED_ACCESS, &algo_id_str).await;
     // Intentionally do not remove from FEED_URI_TO_ALGO_WRITES so interaction writes still work
 
@@ -376,11 +384,7 @@ pub async fn put_feed_thompson_config(
 ///
 /// Get global Thompson search space. Returns default if not set.
 pub async fn get_thompson_search_space(State(state): State<Arc<AppState>>) -> Response {
-    match state
-        .redis
-        .get_string(Keys::thompson_search_space())
-        .await
-    {
+    match state.redis.get_string(Keys::thompson_search_space()).await {
         Ok(Some(json_str)) => match serde_json::from_str::<ThompsonSearchSpace>(&json_str) {
             Ok(config) => (StatusCode::OK, Json(config)).into_response(),
             Err(e) => (
@@ -432,40 +436,103 @@ pub async fn put_thompson_search_space(
         }
         Ok(())
     };
-    if let Err(e) = validate(&config.min_likes_options, config.min_likes_default, "min_likes") {
-        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "ValidationError", "message": e })))
+    if let Err(e) = validate(
+        &config.min_likes_options,
+        config.min_likes_default,
+        "min_likes",
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "ValidationError", "message": e })),
+        )
             .into_response();
     }
-    if let Err(e) = validate(&config.max_likers_options, config.max_likers_default, "max_likers") {
-        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "ValidationError", "message": e })))
+    if let Err(e) = validate(
+        &config.max_likers_options,
+        config.max_likers_default,
+        "max_likers",
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "ValidationError", "message": e })),
+        )
             .into_response();
     }
-    if let Err(e) = validate(&config.max_sources_options, config.max_sources_default, "max_sources") {
-        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "ValidationError", "message": e })))
+    if let Err(e) = validate(
+        &config.max_sources_options,
+        config.max_sources_default,
+        "max_sources",
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "ValidationError", "message": e })),
+        )
             .into_response();
     }
-    if let Err(e) = validate(&config.max_checks_options, config.max_checks_default, "max_checks") {
-        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "ValidationError", "message": e })))
+    if let Err(e) = validate(
+        &config.max_checks_options,
+        config.max_checks_default,
+        "max_checks",
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "ValidationError", "message": e })),
+        )
             .into_response();
     }
-    if let Err(e) = validate(&config.min_colikes_options, config.min_colikes_default, "min_colikes") {
-        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "ValidationError", "message": e })))
+    if let Err(e) = validate(
+        &config.min_colikes_options,
+        config.min_colikes_default,
+        "min_colikes",
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "ValidationError", "message": e })),
+        )
             .into_response();
     }
-    if let Err(e) = validate(&config.max_user_likes_options, config.max_user_likes_default, "max_user_likes") {
-        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "ValidationError", "message": e })))
+    if let Err(e) = validate(
+        &config.max_user_likes_options,
+        config.max_user_likes_default,
+        "max_user_likes",
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "ValidationError", "message": e })),
+        )
             .into_response();
     }
-    if let Err(e) = validate(&config.max_sources_per_post_options, config.max_sources_per_post_default, "max_sources_per_post") {
-        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "ValidationError", "message": e })))
+    if let Err(e) = validate(
+        &config.max_sources_per_post_options,
+        config.max_sources_per_post_default,
+        "max_sources_per_post",
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "ValidationError", "message": e })),
+        )
             .into_response();
     }
-    if let Err(e) = validate(&config.seed_pool_options, config.seed_pool_default, "seed_pool") {
-        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "ValidationError", "message": e })))
+    if let Err(e) = validate(
+        &config.seed_pool_options,
+        config.seed_pool_default,
+        "seed_pool",
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "ValidationError", "message": e })),
+        )
             .into_response();
     }
-    if let Err(e) = validate(&config.corater_decay_options, config.corater_decay_default, "corater_decay") {
-        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "ValidationError", "message": e })))
+    if let Err(e) = validate(
+        &config.corater_decay_options,
+        config.corater_decay_default,
+        "corater_decay",
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "ValidationError", "message": e })),
+        )
             .into_response();
     }
 
@@ -505,7 +572,9 @@ pub async fn put_thompson_search_space(
                     if let Some(suffix) = key.strip_prefix("feed_thompson_config:") {
                         if let Ok(algo_id) = suffix.parse::<i32>() {
                             if let Ok(Some(json_str)) = state.redis.get_string(&key).await {
-                                if let Ok(cfg) = serde_json::from_str::<FeedThompsonConfig>(&json_str) {
+                                if let Ok(cfg) =
+                                    serde_json::from_str::<FeedThompsonConfig>(&json_str)
+                                {
                                     if cfg.search_space.is_some() {
                                         algo_ids_with_algo_config.push(algo_id);
                                     }
@@ -523,11 +592,7 @@ pub async fn put_thompson_search_space(
                 .thompson
                 .clear_bandits_for_global_use(&algo_ids_with_algo_config);
             info!("thompson_search_space_updated");
-            (
-                StatusCode::OK,
-                Json(json!({ "success": true })),
-            )
-                .into_response()
+            (StatusCode::OK, Json(json!({ "success": true }))).into_response()
         }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -611,11 +676,7 @@ pub async fn put_thompson_success_criteria(
     {
         Ok(()) => {
             info!("thompson_success_criteria_updated");
-            (
-                StatusCode::OK,
-                Json(json!({ "success": true })),
-            )
-                .into_response()
+            (StatusCode::OK, Json(json!({ "success": true }))).into_response()
         }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1229,19 +1290,12 @@ pub async fn add_candidates(
         .redis
         .hset_multiple(
             &meta_key,
-            &[
-                ("last_updated", &now.to_string()),
-                ("source", "admin"),
-            ],
+            &[("last_updated", &now.to_string()), ("source", "admin")],
         )
         .await;
 
     info!(algo_id, added = uri_to_id.len(), "candidates_added");
-    (
-        StatusCode::OK,
-        Json(json!({ "added": uri_to_id.len() })),
-    )
-        .into_response()
+    (StatusCode::OK, Json(json!({ "added": uri_to_id.len() }))).into_response()
 }
 
 /// DELETE /v1/feeds/:algo_id/candidates
@@ -1266,11 +1320,7 @@ pub async fn remove_candidates(
         return r;
     }
     if body.uris.is_empty() {
-        return (
-            StatusCode::OK,
-            Json(json!({ "removed": 0 })),
-        )
-            .into_response();
+        return (StatusCode::OK, Json(json!({ "removed": 0 }))).into_response();
     }
 
     let uri_to_id = match state.interner.get_ids_batch(&body.uris).await {
@@ -1304,11 +1354,7 @@ pub async fn remove_candidates(
     };
 
     info!(algo_id, removed, "candidates_removed");
-    (
-        StatusCode::OK,
-        Json(json!({ "removed": removed })),
-    )
-        .into_response()
+    (StatusCode::OK, Json(json!({ "removed": removed }))).into_response()
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1319,7 +1365,10 @@ fn special_posts_key(algo_id: i32) -> String {
     Keys::special_posts(algo_id)
 }
 
-async fn load_special_posts(state: &AppState, algo_id: i32) -> Result<SpecialPostsResponse, Response> {
+async fn load_special_posts(
+    state: &AppState,
+    algo_id: i32,
+) -> Result<SpecialPostsResponse, Response> {
     let key = special_posts_key(algo_id);
     let raw = state.redis.get_string(&key).await.map_err(|e| {
         (
@@ -1363,16 +1412,20 @@ async fn save_special_posts(
             .into_response()
     })?;
     // Persist with long TTL (10 years) when managed via admin
-    state.redis.set_ex(&key, &json, 315_360_000).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "error": "RedisError",
-                "message": format!("{}", e)
-            })),
-        )
-            .into_response()
-    })?;
+    state
+        .redis
+        .set_ex(&key, &json, 315_360_000)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": "RedisError",
+                    "message": format!("{}", e)
+                })),
+            )
+                .into_response()
+        })?;
     Ok(())
 }
 

--- a/crates/graze-api/src/api/docs.rs
+++ b/crates/graze-api/src/api/docs.rs
@@ -45,13 +45,12 @@ pub async fn docs_page(Path(name): Path<String>) -> Response {
         "configuration" => ("text/markdown; charset=utf-8", CONFIGURATION),
         "admin-api" => ("text/markdown; charset=utf-8", ADMIN_API),
         _ => {
-            return (StatusCode::NOT_FOUND, "No such doc. Use: feed-lifecycle, architecture, configuration, admin-api").into_response();
+            return (
+                StatusCode::NOT_FOUND,
+                "No such doc. Use: feed-lifecycle, architecture, configuration, admin-api",
+            )
+                .into_response();
         }
     };
-    (
-        StatusCode::OK,
-        [(header::CONTENT_TYPE, content_type)],
-        body,
-    )
-        .into_response()
+    (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], body).into_response()
 }

--- a/crates/graze-api/src/api/fallback.rs
+++ b/crates/graze-api/src/api/fallback.rs
@@ -252,7 +252,14 @@ pub fn stagger_posts(
             .collect(),
         fallback
             .into_iter()
-            .map(|u| (u, BlendedSource::Fallback { tranche: String::new() }))
+            .map(|u| {
+                (
+                    u,
+                    BlendedSource::Fallback {
+                        tranche: String::new(),
+                    },
+                )
+            })
             .collect(),
         stagger_factor,
     )
@@ -377,7 +384,8 @@ pub async fn get_blended_posts_with_stats(
     let personalized_count = personalized_from_linklonk.len();
 
     let mut personalized_final: Vec<(String, BlendedSource)> = personalized_from_linklonk;
-    let mut exclude_set: HashSet<String> = personalized_final.iter().map(|(u, _)| u.clone()).collect();
+    let mut exclude_set: HashSet<String> =
+        personalized_final.iter().map(|(u, _)| u.clone()).collect();
 
     // Author-affinity supplementation: if post-level personalization is thin,
     // use author-level co-likers (coarse LinkLonk) to fill the gap
@@ -420,10 +428,7 @@ pub async fn get_blended_posts_with_stats(
                     if let Some(uri) = uri_map.get(&post_id) {
                         if !exclude_set.contains(uri) {
                             exclude_set.insert(uri.clone());
-                            personalized_final.push((
-                                uri.clone(),
-                                BlendedSource::AuthorAffinity,
-                            ));
+                            personalized_final.push((uri.clone(), BlendedSource::AuthorAffinity));
                             author_affinity_count += 1;
                         }
                     }

--- a/crates/graze-api/src/api/feed.rs
+++ b/crates/graze-api/src/api/feed.rs
@@ -5,7 +5,6 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use chrono::Utc;
 use axum::{
     extract::{Query, State},
     http::{HeaderMap, StatusCode},
@@ -13,6 +12,7 @@ use axum::{
     Extension, Json,
 };
 use base64::Engine;
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{debug, error, info, warn};
@@ -110,24 +110,20 @@ fn encode_feed_context(
     is_personalization_holdout: Option<bool>,
 ) -> Option<String> {
     let (source, personalization_type, fallback_tranche, attribution, personalized) = match prov {
-        ItemProvenance::Base(BlendedSource::PostLevelPersonalization) => {
-            (
-                "personalized".to_string(),
-                Some("post_level".to_string()),
-                None,
-                None,
-                true,
-            )
-        }
-        ItemProvenance::Base(BlendedSource::AuthorAffinity) => {
-            (
-                "author_affinity".to_string(),
-                Some("author_level".to_string()),
-                None,
-                None,
-                true,
-            )
-        }
+        ItemProvenance::Base(BlendedSource::PostLevelPersonalization) => (
+            "personalized".to_string(),
+            Some("post_level".to_string()),
+            None,
+            None,
+            true,
+        ),
+        ItemProvenance::Base(BlendedSource::AuthorAffinity) => (
+            "author_affinity".to_string(),
+            Some("author_level".to_string()),
+            None,
+            None,
+            true,
+        ),
         ItemProvenance::Base(BlendedSource::Fallback { tranche }) => (
             "fallback".to_string(),
             None,
@@ -617,8 +613,7 @@ pub async fn get_feed_skeleton(
                 }
                 base_posts_tagged.push((uri, BlendedSource::Fallback { tranche }));
             }
-        }
-        else if state.config.feed_cache_enabled {
+        } else if state.config.feed_cache_enabled {
             let cache_offset = feed_cursor.offset.max(0) as isize;
 
             // Check if cache exists by getting its length
@@ -701,9 +696,7 @@ pub async fn get_feed_skeleton(
                     .flatten()
                     .and_then(|s| serde_json::from_str(&s).ok());
 
-                let holdout_override = feed_config
-                    .as_ref()
-                    .and_then(|c| c.holdout_params.as_ref());
+                let holdout_override = feed_config.as_ref().and_then(|c| c.holdout_params.as_ref());
                 let treatment_override = feed_config
                     .as_ref()
                     .and_then(|c| c.treatment_params.as_ref());
@@ -713,12 +706,13 @@ pub async fn get_feed_skeleton(
                     .or(global_search_space.as_ref());
 
                 // Select Thompson Sampling parameters for this request
-                let thompson_params: SelectedParams = state.thompson.select_params_with_holdout_and_search_space(
-                    algo_id,
-                    holdout_override,
-                    treatment_override,
-                    search_space,
-                );
+                let thompson_params: SelectedParams =
+                    state.thompson.select_params_with_holdout_and_search_space(
+                        algo_id,
+                        holdout_override,
+                        treatment_override,
+                        search_space,
+                    );
 
                 // Convert Thompson params to PersonalizationParams override
                 let params_override = PersonalizationParams {
@@ -875,7 +869,10 @@ pub async fn get_feed_skeleton(
                         // Skip request-time recording when interaction_weights is configured -
                         // we only learn from likes (interaction path), otherwise fast-response
                         // signal drowns out the like signal (~100x more common).
-                        if feed_config.as_ref().is_none_or(|c| c.interaction_weights.is_empty()) {
+                        if feed_config
+                            .as_ref()
+                            .is_none_or(|c| c.interaction_weights.is_empty())
+                        {
                             state
                                 .thompson
                                 .record_observation(algo_id, &thompson_params, success);
@@ -903,9 +900,8 @@ pub async fn get_feed_skeleton(
                         fallback_reason = Some("personalization_error");
 
                         // Record failure for Thompson learning
-                        let thompson_params: SelectedParams = state
-                            .thompson
-                            .select_params_with_holdout_and_search_space(
+                        let thompson_params: SelectedParams =
+                            state.thompson.select_params_with_holdout_and_search_space(
                                 algo_id,
                                 holdout_override,
                                 treatment_override,
@@ -997,8 +993,12 @@ pub async fn get_feed_skeleton(
         .await
         .unwrap_or_else(|_| SpecialPostsResponse::empty(algo_id));
 
-    let (final_with_provenance, updated_cursor) =
-        inject_special_posts(base_posts_tagged.clone(), &special_posts, &feed_cursor, limit);
+    let (final_with_provenance, updated_cursor) = inject_special_posts(
+        base_posts_tagged.clone(),
+        &special_posts,
+        &feed_cursor,
+        limit,
+    );
 
     // ═══════════════════════════════════════════════════════════════════
     // Build response cursor
@@ -1265,9 +1265,7 @@ pub async fn send_interactions(
     // Returns immediately; background worker batches and flushes every few seconds.
     if state.config.interactions_logging_enabled {
         if let (Some(ref did), Some(ref queue)) = (&user_did, &state.interaction_queue) {
-            queue
-                .send(did.clone(), request.interactions.clone())
-                .await;
+            queue.send(did.clone(), request.interactions.clone()).await;
         }
     }
 
@@ -1351,9 +1349,7 @@ pub async fn send_interactions(
             _ => continue,
         };
 
-        let selected_params = state
-            .thompson
-            .selected_params_from_provenance(params);
+        let selected_params = state.thompson.selected_params_from_provenance(params);
 
         // Speed gate: slow response = negative signal (learn to avoid these params)
         if response_time_ms > config.speed_gate_ms {

--- a/crates/graze-api/src/api/mod.rs
+++ b/crates/graze-api/src/api/mod.rs
@@ -54,7 +54,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             post(personalize::author_affinity_diagnostic),
         )
         // Feed management
-        .route("/v1/feeds", get(admin::list_feeds).post(admin::register_feed))
+        .route(
+            "/v1/feeds",
+            get(admin::list_feeds).post(admin::register_feed),
+        )
         .route("/v1/feeds/:algo_id", delete(admin::deregister_feed))
         .route("/v1/feeds/status/:algo_id", get(admin::feed_status))
         .route(
@@ -107,8 +110,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         .route(
             "/v1/thompson/success-criteria",
-            get(admin::get_thompson_success_criteria)
-                .put(admin::put_thompson_success_criteria),
+            get(admin::get_thompson_success_criteria).put(admin::put_thompson_success_criteria),
         )
         // Audit user management
         .route("/v1/audit/users", post(admin::add_audit_users))

--- a/crates/graze-api/src/api/special_posts.rs
+++ b/crates/graze-api/src/api/special_posts.rs
@@ -258,7 +258,12 @@ mod tests {
     #[test]
     fn test_inject_pinned_first_page_only() {
         let base_posts: Vec<(String, BlendedSource)> = (0..10)
-            .map(|i| (format!("post{}", i), BlendedSource::PostLevelPersonalization))
+            .map(|i| {
+                (
+                    format!("post{}", i),
+                    BlendedSource::PostLevelPersonalization,
+                )
+            })
             .collect();
         let special_posts = SpecialPostsResponse {
             algorithm_id: 1,
@@ -287,7 +292,12 @@ mod tests {
     #[test]
     fn test_no_duplicate_injection() {
         let base_posts: Vec<(String, BlendedSource)> = (0..10)
-            .map(|i| (format!("post{}", i), BlendedSource::PostLevelPersonalization))
+            .map(|i| {
+                (
+                    format!("post{}", i),
+                    BlendedSource::PostLevelPersonalization,
+                )
+            })
             .collect();
         let special_posts = SpecialPostsResponse {
             algorithm_id: 1,
@@ -304,8 +314,14 @@ mod tests {
 
         let (posts2, _cursor2) = inject_special_posts(base_posts, &special_posts, &cursor1, 10);
 
-        let rotating_count = posts2.iter().filter(|(u, _)| u == "at://rotating/post/1").count();
-        let sponsored_count = posts2.iter().filter(|(u, _)| u == "at://sponsored/post/1").count();
+        let rotating_count = posts2
+            .iter()
+            .filter(|(u, _)| u == "at://rotating/post/1")
+            .count();
+        let sponsored_count = posts2
+            .iter()
+            .filter(|(u, _)| u == "at://sponsored/post/1")
+            .count();
         assert_eq!(rotating_count, 0);
         assert_eq!(sponsored_count, 0);
     }
@@ -330,7 +346,12 @@ mod tests {
     #[test]
     fn test_max_interspersed_cap() {
         let base_posts: Vec<(String, BlendedSource)> = (0..10)
-            .map(|i| (format!("post{}", i), BlendedSource::PostLevelPersonalization))
+            .map(|i| {
+                (
+                    format!("post{}", i),
+                    BlendedSource::PostLevelPersonalization,
+                )
+            })
             .collect();
         let special_posts = SpecialPostsResponse {
             algorithm_id: 1,

--- a/crates/graze-api/src/config.rs
+++ b/crates/graze-api/src/config.rs
@@ -238,9 +238,13 @@ impl Config {
             redis_pool_size: parse_usize_env("REDIS_POOL_SIZE", 100),
             redis_connect_max_retries: parse_u32_env("REDIS_CONNECT_MAX_RETRIES", 10),
             redis_connect_initial_delay_ms: parse_u64_env("REDIS_CONNECT_INITIAL_DELAY_MS", 500),
-            redis_requests_logger_url: std::env::var("REDIS_REQUESTS_LOGGER")
-                .ok()
-                .and_then(|s| if s.trim().is_empty() { None } else { Some(s) }),
+            redis_requests_logger_url: std::env::var("REDIS_REQUESTS_LOGGER").ok().and_then(|s| {
+                if s.trim().is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            }),
 
             // Inverted Algorithm
             inverted_algorithm_enabled: parse_bool_env("INVERTED_ALGORITHM_ENABLED", true),
@@ -303,15 +307,9 @@ impl Config {
                 .to_lowercase()
                 .trim()
                 .to_string(),
-            interactions_batch_interval_ms: parse_u64_env(
-                "INTERACTIONS_BATCH_INTERVAL_MS",
-                3000,
-            ),
+            interactions_batch_interval_ms: parse_u64_env("INTERACTIONS_BATCH_INTERVAL_MS", 3000),
             interactions_batch_size: parse_usize_env("INTERACTIONS_BATCH_SIZE", 200),
-            interactions_queue_capacity: parse_usize_env(
-                "INTERACTIONS_QUEUE_CAPACITY",
-                5000,
-            ),
+            interactions_queue_capacity: parse_usize_env("INTERACTIONS_QUEUE_CAPACITY", 5000),
 
             // Special Posts
             special_posts_source: default_env("SPECIAL_POSTS_SOURCE", "remote")
@@ -412,9 +410,13 @@ impl Config {
             read_only_mode: parse_bool_env("READ_ONLY_MODE", false),
 
             // Admin API key (empty string = auth disabled)
-            admin_api_key: std::env::var("ADMIN_API_KEY")
-                .ok()
-                .and_then(|s| if s.is_empty() { None } else { Some(s) }),
+            admin_api_key: std::env::var("ADMIN_API_KEY").ok().and_then(|s| {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            }),
 
             // Personalization Holdout (A/B test)
             personalization_holdout_rate: parse_f64_env("PERSONALIZATION_HOLDOUT_RATE", 0.5),

--- a/crates/graze-api/src/interaction_queue.rs
+++ b/crates/graze-api/src/interaction_queue.rs
@@ -55,8 +55,7 @@ pub async fn run_interaction_worker(
 
     info!(
         batch_interval_ms,
-        batch_size,
-        "Interaction queue worker started"
+        batch_size, "Interaction queue worker started"
     );
 
     loop {
@@ -101,7 +100,10 @@ pub async fn run_interaction_worker(
 
     // Flush remaining on shutdown
     if !batch.is_empty() {
-        info!(remaining = batch.len(), "Flushing remaining interactions on shutdown");
+        info!(
+            remaining = batch.len(),
+            "Flushing remaining interactions on shutdown"
+        );
         if let Err(e) = interactions.persist_interactions_batch(&batch).await {
             warn!(error = %e, "Failed to persist final interaction batch");
         }

--- a/crates/graze-api/src/main.rs
+++ b/crates/graze-api/src/main.rs
@@ -14,9 +14,9 @@ use graze_api::interaction_queue;
 use graze_api::metrics::Metrics;
 use graze_api::AppState;
 use graze_common::{
-    maybe_run_metrics_server, ClickHouseConfig, ClickHouseInteractionWriter,
-    InteractionsClient, InteractionsConfig, NoOpInteractionWriter, RedisClient, RedisConfig,
-    SpecialPostsClient, SpecialPostsSource, UriInterner,
+    maybe_run_metrics_server, ClickHouseConfig, ClickHouseInteractionWriter, InteractionsClient,
+    InteractionsConfig, NoOpInteractionWriter, RedisClient, RedisConfig, SpecialPostsClient,
+    SpecialPostsSource, UriInterner,
 };
 
 #[tokio::main]
@@ -74,7 +74,10 @@ async fn main() -> anyhow::Result<()> {
             };
             match RedisClient::new(&logger_config).await {
                 Ok(client) => {
-                    debug!(redis_requests_logger = "configured", "Requests logger Redis connected");
+                    debug!(
+                        redis_requests_logger = "configured",
+                        "Requests logger Redis connected"
+                    );
                     Some(Arc::new(client))
                 }
                 Err(e) => {
@@ -159,7 +162,10 @@ async fn main() -> anyhow::Result<()> {
         let queue_sender = interaction_queue::InteractionQueueSender::new(tx);
         let shutdown_tx_for_signal = shutdown_tx.clone();
         // Store shutdown_tx for the shutdown signal
-        (Some(queue_sender), Some((worker_handle, shutdown_tx_for_signal)))
+        (
+            Some(queue_sender),
+            Some((worker_handle, shutdown_tx_for_signal)),
+        )
     } else {
         (None, None)
     };

--- a/crates/graze-candidate-sync/src/config.rs
+++ b/crates/graze-candidate-sync/src/config.rs
@@ -113,9 +113,13 @@ impl Config {
                 .to_lowercase()
                 .trim()
                 .to_string(),
-            candidate_http_url: std::env::var("CANDIDATE_HTTP_URL")
-                .ok()
-                .and_then(|s| if s.trim().is_empty() { None } else { Some(s.trim().to_string()) }),
+            candidate_http_url: std::env::var("CANDIDATE_HTTP_URL").ok().and_then(|s| {
+                if s.trim().is_empty() {
+                    None
+                } else {
+                    Some(s.trim().to_string())
+                }
+            }),
 
             // ClickHouse (when candidate_source is clickhouse)
             clickhouse_host: default_env("CLICKHOUSE_HOST", "localhost"),

--- a/crates/graze-common/src/lib.rs
+++ b/crates/graze-common/src/lib.rs
@@ -13,6 +13,11 @@ pub mod models;
 pub mod redis;
 pub mod services;
 
+pub use clickhouse::{
+    AdminOnlyCandidateSource, CandidateQueryParams, CandidateSource, ClickHouseCandidateSource,
+    ClickHouseConfig, ClickHouseInteractionWriter, HttpCandidateSource, InteractionWriter,
+    NoOpInteractionWriter,
+};
 pub use error::{GrazeError, Result};
 pub use redis::{
     // New date-based functions
@@ -32,11 +37,6 @@ pub use redis::{
     ScriptManager,
     DAY_TRANCHES,
     DEFAULT_RETENTION_DAYS,
-};
-pub use clickhouse::{
-    AdminOnlyCandidateSource, CandidateQueryParams, CandidateSource, ClickHouseCandidateSource,
-    ClickHouseConfig, ClickHouseInteractionWriter, HttpCandidateSource, InteractionWriter,
-    NoOpInteractionWriter,
 };
 pub use services::{
     InteractionsClient, InteractionsConfig, SpecialPost, SpecialPostsClient, SpecialPostsResponse,

--- a/crates/graze-common/src/models/feed_context.rs
+++ b/crates/graze-common/src/models/feed_context.rs
@@ -31,7 +31,10 @@ pub struct FeedContextProvenance {
 
     /// When personalized: post_level (exact post co-likers) | author_level (author-affinity co-likers).
     /// Omitted for non-personalized sources.
-    #[serde(rename = "personalization_type", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "personalization_type",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub personalization_type: Option<String>,
 
     /// When source is fallback: popular | velocity | discovery. Otherwise omitted.
@@ -64,7 +67,10 @@ pub struct FeedContextProvenance {
 
     /// True if this request was in the personalization holdout (control group for A/B test).
     /// These requests skip LinkLonk entirely and serve only the non-personalized fallback blend.
-    #[serde(rename = "is_personalization_holdout", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "is_personalization_holdout",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub is_personalization_holdout: Option<bool>,
 }
 
@@ -73,7 +79,10 @@ pub struct FeedContextProvenance {
 pub struct ProvenanceParams {
     #[serde(rename = "min_post_likes", skip_serializing_if = "Option::is_none")]
     pub min_post_likes: Option<usize>,
-    #[serde(rename = "max_likers_per_post", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "max_likers_per_post",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub max_likers_per_post: Option<usize>,
     #[serde(rename = "max_total_sources", skip_serializing_if = "Option::is_none")]
     pub max_total_sources: Option<usize>,
@@ -83,7 +92,10 @@ pub struct ProvenanceParams {
     pub min_co_likes: Option<usize>,
     #[serde(rename = "max_user_likes", skip_serializing_if = "Option::is_none")]
     pub max_user_likes: Option<usize>,
-    #[serde(rename = "max_sources_per_post", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "max_sources_per_post",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub max_sources_per_post: Option<usize>,
     #[serde(rename = "seed_sample_pool", skip_serializing_if = "Option::is_none")]
     pub seed_sample_pool: Option<usize>,

--- a/crates/graze-common/src/services/interactions.rs
+++ b/crates/graze-common/src/services/interactions.rs
@@ -107,7 +107,11 @@ impl InteractionsClient {
             }
         }
         // Fallback: durable write-through map (accept interactions after deregister)
-        match self.redis.hget(Keys::FEED_URI_TO_ALGO_WRITES, feed_uri).await {
+        match self
+            .redis
+            .hget(Keys::FEED_URI_TO_ALGO_WRITES, feed_uri)
+            .await
+        {
             Ok(Some(algo_id_str)) => match algo_id_str.parse::<i32>() {
                 Ok(id) => {
                     debug!(feed_uri = %feed_uri, algo_id = id, "algo_id from FEED_URI_TO_ALGO_WRITES (deregistered feed)");
@@ -319,5 +323,4 @@ mod tests {
         let decoded = InteractionsClient::decode_feed_context(&encoded);
         assert!(decoded.is_none());
     }
-
 }


### PR DESCRIPTION
This PR applies comprehensive formatting and code style improvements across the codebase to improve consistency and readability.

## Summary
Applied rustfmt and manual formatting adjustments to align with Rust style conventions. The changes focus on line length, import organization, and consistent code formatting without modifying any functional logic.

## Key Changes

- **Import organization**: Reordered imports alphabetically and grouped by category in multiple files (feed.rs, lib.rs, main.rs)
- **Line wrapping**: Reformatted long lines to improve readability, particularly in:
  - Function calls with multiple arguments
  - Match expressions and conditional statements
  - Validation chains in admin.rs
  - Type annotations and return statements
- **Serde attribute formatting**: Improved formatting of `#[serde(...)]` attributes in feed_context.rs for better readability
- **Method chaining**: Adjusted formatting of chained method calls (e.g., `.await` placement) for consistency
- **Closure formatting**: Reformatted closures and map operations to be more readable
- **Response construction**: Simplified and reformatted response tuple construction throughout the codebase

## Files Modified
- crates/graze-api/src/api/admin.rs
- crates/graze-api/src/api/feed.rs
- crates/graze-api/src/api/special_posts.rs
- crates/graze-api/src/api/fallback.rs
- crates/graze-api/src/api/docs.rs
- crates/graze-api/src/api/mod.rs
- crates/graze-api/src/config.rs
- crates/graze-api/src/main.rs
- crates/graze-api/src/interaction_queue.rs
- crates/graze-api/src/algorithm/thompson.rs
- crates/graze-api/src/algorithm/scorer.rs
- crates/graze-api/src/algorithm/mod.rs
- crates/graze-candidate-sync/src/config.rs
- crates/graze-common/src/lib.rs
- crates/graze-common/src/models/feed_context.rs
- crates/graze-common/src/services/interactions.rs

## Notes
No functional changes were made. All modifications are purely stylistic to improve code consistency and maintainability.

https://claude.ai/code/session_015jsm2Y5BaxQS43x3iZMA4D