### PR TITLE
Update atproto-record to 0.14.0

### DIFF
--- a/crates/graze-api/Cargo.toml
+++ b/crates/graze-api/Cargo.toml
@@ -67,4 +67,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # AT Protocol
-atproto-record = { version = "0.13", default-features = false }
+atproto-record = { version = "0.14", default-features = false }

--- a/crates/graze-candidate-sync/Cargo.toml
+++ b/crates/graze-candidate-sync/Cargo.toml
@@ -46,7 +46,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # AT Protocol
-atproto-record = { version = "0.13", default-features = false }
+atproto-record = { version = "0.14", default-features = false }
 
 # Metrics
 prometheus-client = "0.22"

--- a/crates/graze-common/Cargo.toml
+++ b/crates/graze-common/Cargo.toml
@@ -45,4 +45,4 @@ async-trait = "0.1"
 axum = "0.8"
 
 # AT Protocol
-atproto-record = { version = "0.13", default-features = false }
+atproto-record = { version = "0.14", default-features = false }

--- a/crates/graze-frontdoor/Cargo.toml
+++ b/crates/graze-frontdoor/Cargo.toml
@@ -43,4 +43,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # AT Protocol
-atproto-record = { version = "0.13", default-features = false }
+atproto-record = { version = "0.14", default-features = false }

--- a/crates/graze-like-streamer/Cargo.toml
+++ b/crates/graze-like-streamer/Cargo.toml
@@ -68,7 +68,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # AT Protocol
-atproto-record = { version = "0.13", default-features = false }
+atproto-record = { version = "0.14", default-features = false }
 
 # Metrics
 prometheus-client = "0.22"


### PR DESCRIPTION
## Summary
Update atproto-record dependency from 0.13 to 0.14 across all 5 workspace crates (graze-api, graze-common, graze-like-streamer, graze-candidate-sync, graze-frontdoor). The ATURI API used by graze-frontdoor remains compatible with the new version.

## Test plan
- [x] cargo check passes
- [x] All 123 unit tests pass
- [x] cargo fmt passes

🤖 Generated with Claude Code