### PR TITLE
Simplify FxHashMap initialization in scorer

### DIFF
--- a/crates/graze-api/src/algorithm/scorer.rs
+++ b/crates/graze-api/src/algorithm/scorer.rs
@@ -337,11 +337,8 @@ impl Scorer {
             vec![]
         };
         // Map from post_id -> PostFeatures, built during the fast path when collect=true
-        let mut features_by_id: rustc_hash::FxHashMap<String, PostFeatures> = if collect {
-            rustc_hash::FxHashMap::default()
-        } else {
-            rustc_hash::FxHashMap::default()
-        };
+        let mut features_by_id: rustc_hash::FxHashMap<String, PostFeatures> =
+            rustc_hash::FxHashMap::default();
 
         if let Some(ref mut a) = audit {
             // Audit-enabled path


### PR DESCRIPTION
## Summary
Removed redundant conditional logic in the `Scorer` implementation that was initializing `FxHashMap` identically in both branches.

## Key Changes
- Simplified the `features_by_id` initialization by removing the unnecessary `if collect` conditional that had identical `FxHashMap::default()` calls in both branches
- The map is now initialized unconditionally with a single `FxHashMap::default()` call

## Implementation Details
The original code had an if-else statement where both the `true` and `false` branches performed the exact same operation (`rustc_hash::FxHashMap::default()`), making the conditional check redundant. This change eliminates that unnecessary branching while maintaining identical behavior.

https://claude.ai/code/session_01UMad53L73irVkbo63a9357