### PR TITLE
Fix missing api_token parameter in special posts API call

### DIFF
--- a/crates/graze-common/src/services/special_posts.rs
+++ b/crates/graze-common/src/services/special_posts.rs
@@ -143,7 +143,7 @@ impl SpecialPostsClient {
                 api_token,
             } => {
                 debug!(algo_id, "special_posts_cache_miss");
-                let response = self.fetch_from_api(algo_id, api_base_url).await;
+                let response = self.fetch_from_api(algo_id, api_base_url, api_token).await;
 
                 self.store_in_cache(&cache_key, &response).await;
 


### PR DESCRIPTION
## Summary
Fixed a bug in the `SpecialPostsClient` where the `api_token` parameter was not being passed to the `fetch_from_api` method during cache misses.

## Key Changes
- Updated the `fetch_from_api` call to include the `api_token` parameter that was already available in the scope but not being forwarded to the method

## Details
The `api_token` was extracted from the cache key pattern but was not being passed along when fetching from the API. This fix ensures the authentication token is properly provided to the API request, preventing potential authentication failures when the special posts cache is empty.

https://claude.ai/code/session_01DAypw8E3QJSYZo7oK4DThH