### PR TITLE
Log posts_skipped_no_likers / posts_skipped_few_likers in scorer_completed

### DIFF
--- a/crates/graze-api/src/algorithm/scorer.rs
+++ b/crates/graze-api/src/algorithm/scorer.rs
@@ -472,6 +472,14 @@ impl Scorer {
             algo_id,
             scored_count,
             posts_checked = candidates.len(),
+            // Where candidates die before scoring. Both were already computed for
+            // ScoringResult but never logged, which made the "why is the feed mostly
+            // fallback?" question un-answerable without offline reconstruction:
+            //   no_likers  = candidate has zero recorded likers in apc:{algo_id}
+            //   few_likers = has likers but fewer than min_post_likes
+            posts_skipped_no_likers,
+            posts_skipped_few_likers,
+            min_post_likes = self.min_post_likes,
             cache_hits,
             cache_misses,
             scoring_time_ms = format!("{:.2}", scoring_time_ms),


### PR DESCRIPTION
## Why

Both counters are already computed in `Scorer::score` and returned on `ScoringResult`, but the `scorer_completed` debug line never emitted them. They're the two numbers that answer *"why is this feed mostly fallback?"* — without them the question can only be answered by reconstructing the candidate funnel offline against `apc:{algo_id}`, which is what I had to do.

## Measured context (25-min window, 3 replicas, prod)

- **81% of responses contain zero personalized posts**; 71.4% of served posts are `source=fallback`.
- `scored_count` p50=**4** against `posts_checked` p50=1,079 (p90 19,405) — a **0.25% yield** — and 36% of scorer runs score nothing.
- The dominant predictor of `scored_count` is **candidate pool size**: r=**0.604** (0.777 log-log) vs r=0.141 for source count. **41% of all personalization attempts run against a pool under 500 posts and return a median of zero.**

## What the two counters distinguish

| counter | meaning | implied fix |
|---|---|---|
| `posts_skipped_no_likers` | `apc:` count == 0 — pool contains posts nobody liked | grow/refresh the pool |
| `posts_skipped_few_likers` | `0 < count < min_post_likes` | threshold too high for this pool |

Different diagnoses, different fixes. `min_post_likes` is included in the line because it's Thompson-selected per request (observed spread: 5 in 35% of requests, 30 in 22%, 15 in 19%, 40 in 4%), so the skip count is uninterpretable without knowing the threshold that produced it.

## Notes

- `debug!` only — no new allocation on the hot path beyond two `usize` copies.
- Verified with `cargo check -p graze-api`.
- Branched from `exclusion-lists` (the current local HEAD, 2026-05-19). **I did not build or push an image** — this checkout has unrelated uncommitted changes to `Cargo.toml`/`Dockerfile` and an untracked `crates/graze-feed-stats/`, and the sanctioned build path here is a published GitHub release. Please retarget the base branch if `exclusion-lists` isn't right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)