### PR TITLE
Add pool-size gate: skip personalization when the candidate pool is too small

### DIFF
--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -215,6 +215,43 @@ impl LinkLonkAlgorithm {
             "compute_personalization_start"
         );
 
+        // Step 0: Pool-size gate. Bail out before doing ANY expensive work if the
+        // feed's candidate pool is too small to personalize from. Overlap between a
+        // user's co-liker set and the pool is linear in pool size, so below a few
+        // hundred candidates the expected number of scoreable posts is < 1 and the
+        // whole pipeline reliably returns nothing. SCARD is O(1), whereas the work
+        // it skips is the co-liker walk, author-affinity supplementation, a full
+        // SMEMBERS of the pool and an HMGET of every liker count.
+        //
+        // Disabled by default (0). See Config::min_candidate_pool_for_personalization.
+        let pool_gate = self.config.min_candidate_pool_for_personalization;
+        if pool_gate > 0 {
+            let pool_size = self
+                .redis
+                .scard(&Keys::algo_posts(algo_id))
+                .await
+                .unwrap_or(0);
+            if pool_size < pool_gate {
+                info!(
+                    user_hash = %&user_hash[..8.min(user_hash.len())],
+                    algo_id,
+                    pool_size,
+                    pool_gate,
+                    "early_exit: candidate pool below personalization gate"
+                );
+                return Ok(ScoringResult {
+                    scored_posts: Vec::new(),
+                    scored_count: 0,
+                    posts_checked: pool_size,
+                    posts_skipped_no_likers: 0,
+                    posts_skipped_few_likers: 0,
+                    scoring_time_ms: 0.0,
+                    cache_hits: 0,
+                    cache_misses: 0,
+                });
+            }
+        }
+
         // Step 1: Get or compute co-likers (post-level or author-level)
         let coliker_weights = if params.use_author_affinity {
             debug!("step1_author_coliker_start");

--- a/crates/graze-api/src/config.rs
+++ b/crates/graze-api/src/config.rs
@@ -28,6 +28,20 @@ pub struct Config {
     pub inverted_min_post_likes: usize,
     pub inverted_max_likers_per_post: usize,
     pub inverted_max_posts_to_score: usize,
+    /// Skip personalization entirely when the feed's candidate pool
+    /// (`SCARD ap:{algo_id}`) is below this size. 0 disables the gate.
+    ///
+    /// Rationale (measured in prod, 25-min window, 359 scorer runs): candidate
+    /// pool size is the dominant predictor of how many posts get personalized —
+    /// r=0.604 (0.777 log-log) vs r=0.141 for co-liker source count. Requests
+    /// against a pool under 500 posts returned a MEDIAN OF ZERO scored posts
+    /// with a 74% zero rate, and accounted for 41% of all personalization
+    /// attempts. Those runs still paid for co-liker computation (27-106ms),
+    /// author-affinity supplementation (~106ms), a full SMEMBERS of the pool and
+    /// an HMGET of every liker count — to produce nothing. The 500-2k band, by
+    /// contrast, returned a median of 18, so the useful cut is at ~500, not
+    /// higher.
+    pub min_candidate_pool_for_personalization: usize,
     pub min_overlapping_colikers: usize,
 
     // ═══════════════════════════════════════════════════════════════════════════════
@@ -269,6 +283,12 @@ impl Config {
             inverted_min_post_likes: parse_usize_env("INVERTED_MIN_POST_LIKES", 10),
             inverted_max_likers_per_post: parse_usize_env("INVERTED_MAX_LIKERS_PER_POST", 30),
             inverted_max_posts_to_score: parse_usize_env("INVERTED_MAX_POSTS_TO_SCORE", 0),
+            // Defaults to 0 (gate disabled) so merging cannot silently change what
+            // users are served. Recommended rollout value: 500.
+            min_candidate_pool_for_personalization: parse_usize_env(
+                "MIN_CANDIDATE_POOL_FOR_PERSONALIZATION",
+                0,
+            ),
             min_overlapping_colikers: parse_usize_env("MIN_OVERLAPPING_COLIKERS", 1),
 
             // Liker Cache


### PR DESCRIPTION
Adds `MIN_CANDIDATE_POOL_FOR_PERSONALIZATION` (**default 0 = disabled**). When set, `compute_personalization` checks `SCARD ap:{algo_id}` up front and returns an empty `ScoringResult` if the pool is below the threshold — *before* any expensive work.

## Why

Candidate pool size is the dominant predictor of how many posts actually get personalized. Measured in prod over a 25-minute window (3 replicas, 359 scorer runs):

```
r(pool_size, scored_count) = 0.604   (0.777 log-log)
r(sources,   scored_count) = 0.141
```

| pool size | n | median scored | zero-scored | share of attempts |
|---|---|---|---|---|
| **<500** | 148 | **0** | **74%** | **41%** |
| 500–2k | 81 | 18 | 20% | 23% |
| 2k–10k | 2 | 24 | 0% | 1% |
| >10k | 128 | 92 | 3% | 36% |

**41% of personalization attempts run against a pool under 500 posts and return a median of zero** — while still paying for the co-liker walk (27–106 ms), author-affinity supplementation (~106 ms), a full `SMEMBERS` of the pool and an `HMGET` of every liker count. `SCARD` is O(1) by comparison.

Concretely: **algo 4051 takes 38% of all personalization attempts with a 317-post pool, of which only 29 posts have ≥5 likers.** Its median `scored_count` is 0.

## Why this should be quality-neutral

Those runs already produce nothing. When personalization returns empty the caller falls through to the fallback tranches exactly as it does today. The saving is compute and Valkey load — `zadd` + `zrevrangebyscore` are 26.0% + 18.7% of Valkey command CPU, and the co-liker path is what drives them.

## Why 500 and not higher

The 500–2k band still returns a median of **18** scored posts, so gating there would discard real personalization. Recommended rollout value is **500**. Defaulting to 0 keeps merging behaviour-neutral — enable per-environment once you're happy with the threshold.

## Pairs with the candidate-window widening

`SYNC_FALLBACK_MAX_AGE_HOURS` was found to be a no-op (it defaulted to 72, identical to `SYNC_PREFERRED_MAX_AGE_HOURS`, so the "pool too thin → widen the window" second pass re-queried the same window). Setting it to 336 grows thin pools ~4.4× — measured on algo 1937: pool 164 → 723, **eligible candidates 151 → 312 (2.1×)**.

But widening grows `posts_checked` ~4.4× for ~2.1× more eligible candidates, because the older posts have thinner like coverage inside the 6-day `pl:` retention (`no_likers` went 2% → 37%). **The gate is what keeps per-request cost in check on the feeds that can never benefit**, so the two changes are complementary rather than alternatives.

## Verification

- `cargo check -p graze-api` ✅
- `cargo fmt --check -p graze-api` ✅
- The 2 clippy warnings in this crate are **pre-existing** (`scorer.rs:271`, `zip(...into_iter())`) and untouched here. Note CI runs clippy with `-D warnings`, so it may be red independently of this change.
- Branched from `exclusion-lists` (current local HEAD, 2026-05-19), *not* stacked on #10, so neither PR can auto-close the other. **No image was built** — this checkout has unrelated uncommitted changes to `Cargo.toml`/`Dockerfile` and an untracked `crates/graze-feed-stats/`, and the sanctioned build path here is a published GitHub release. Please retarget the base if `exclusion-lists` isn't right.

Companion observability PR: #10 (logs `posts_skipped_no_likers` / `posts_skipped_few_likers`, which is how you'd verify this gate's effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)