### PR TITLE
Implement guardrails and add a relevance guardrail to the holdout

### DIFF
--- a/analysis/experiments/personalization_holdout.yaml
+++ b/analysis/experiments/personalization_holdout.yaml
@@ -48,6 +48,25 @@ negative_controls:
       most likely a traffic or client mix imbalance — and the primary reading is not attributable.
     where: "source IN ('pinned', 'rotating')"
 
+# Relevance guardrail, distinct from the negative control above.
+#
+# The primary metric is like_rate, which is pure engagement. Optimising engagement alone selects for
+# engagement-bait — the standard way a recommender gets worse while its headline number improves —
+# and the remit is content that is relevant, not merely clickable. `requestLess` is the only direct
+# relevance signal the client sends: an explicit "show me less of this" rather than a proxy. If
+# personalization raises it, the engine is producing content people actively do not want, and that
+# is worth seeing next to any like-rate win rather than discovered later.
+#
+# Direction: `control` is the HOLDOUT, so diff = personalized - suppressed. A positive diff means
+# personalization produced MORE "show me less", hence max: 0.0.
+#
+# This guardrail is underpowered and is expected to stay quiet — 221 requestLess events across the
+# first 11 days. The readout prints its event count for exactly that reason. A quiet guardrail here
+# is not evidence of safety.
+guardrails:
+  - metric: request_less_rate
+    max: 0.0
+
 cuped_covariate: pre_period_like_rate
 
 population: "JSONHas(tryBase64Decode(interaction_feed_context), 'algo_id')"

--- a/analysis/graze_analysis/data.py
+++ b/analysis/graze_analysis/data.py
@@ -24,6 +24,22 @@ from .spec import ExperimentSpec
 
 SEEN = "app.bsky.feed.defs#interactionSeen"
 LIKE = "app.bsky.feed.defs#interactionLike"
+REQUEST_LESS = "app.bsky.feed.defs#requestLess"
+REQUEST_MORE = "app.bsky.feed.defs#requestMore"
+
+#: Numerator event for each supported metric name. The denominator is always `interactionSeen`,
+#: so every metric here is "events of this kind per impression".
+#:
+#: `request_less_rate` is the only *relevance* signal the client actually sends — a stated "show me
+#: less of this" rather than an engagement proxy. It matters because optimising `like_rate` alone
+#: selects for engagement-bait, which is how a recommender gets worse while its headline metric
+#: improves. Measured 2026-08-25: clickthrough events do not exist in this dataset at all (n=0), so
+#: widening the engagement metric is not available to us; requestLess/requestMore are what there is.
+METRIC_EVENTS: dict[str, str] = {
+    "like_rate": LIKE,
+    "request_less_rate": REQUEST_LESS,
+    "request_more_rate": REQUEST_MORE,
+}
 
 
 def _sql_literal(value: Any) -> str:
@@ -99,12 +115,18 @@ class ClickHouseReader:
             client.close()
 
 
-def ab_rows_sql(spec: ExperimentSpec, where_extra: str = "") -> str:
-    """SQL for an A/B design: one row per (unit, impression) with a like flag.
+def ab_rows_sql(
+    spec: ExperimentSpec, where_extra: str = "", numerator_event: str = LIKE
+) -> str:
+    """SQL for an A/B design: one row per (unit, impression) with an event flag.
 
     Note the deliberate absence of any ``source`` filter — this is intention-to-treat. Restricting
     to personalized impressions would condition on a post-treatment variable, which biases the
     estimate no matter how much data is collected.
+
+    ``numerator_event`` selects what counts as a "success". It defaults to a like, which is the
+    primary metric; guardrails pass a different event (see :data:`METRIC_EVENTS`) so the same
+    randomization can be read against a second outcome without a second query path.
     """
     control = spec.arms["control"]
     treatment = next(a for n, a in spec.arms.items() if n != "control")
@@ -136,10 +158,10 @@ WITH d AS (
     {end_clause}
     AND interaction_feed_context != ''
     {population}
-    AND interaction_event IN ('{SEEN}', '{LIKE}')
+    AND interaction_event IN ('{SEEN}', '{numerator_event}')
 )
 SELECT unit_id, arm_value,
-       countIf(ev = '{LIKE}') AS likes,
+       countIf(ev = '{numerator_event}') AS likes,
        countIf(ev = '{SEEN}') AS seen
 FROM d
 WHERE arm_value IN ({_sql_literal(control.value)}, {_sql_literal(treatment.value)}) {extra}

--- a/analysis/graze_analysis/runner.py
+++ b/analysis/graze_analysis/runner.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import numpy as np
 
 from .data import (
+    METRIC_EVENTS,
     ClickHouseReader,
     ab_rows_sql,
     cuped_covariate_sql,
@@ -109,6 +110,8 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
         _, reduction = cuped_adjust(per_unit_rate, cov)
         lines.append(f"  CUPED variance reduction: {reduction:.1%}")
 
+    lines.extend(_guardrail_lines(spec, reader))
+
     agree = primary.significant == (perm.p_value < 0.05)
     verdict = (
         "SIGNIFICANT" if primary.significant and agree else
@@ -116,6 +119,61 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
         "NOT SIGNIFICANT"
     )
     return Readout(spec.id, verdict, lines)
+
+
+def _guardrail_lines(spec: ExperimentSpec, reader: ClickHouseReader) -> list[str]:
+    """Evaluate each guardrail against the same randomization as the primary metric.
+
+    A guardrail is *not* a negative control and is deliberately handled differently. A negative
+    control that moves means the experiment is broken, so it withholds the result. A guardrail that
+    moves means the change had a cost that is real and worth seeing — the result stands, and the
+    reader decides. Withholding here would hide the very thing the guardrail exists to surface.
+
+    Breach reporting mirrors the density drift guard's discipline: BREACH only when the confidence
+    interval clears the bound (a detection), WATCH when the point estimate clears it but the
+    interval does not (a prediction). The bound's sign is in the spec's own arm direction — for the
+    holdout spec, `control` is the holdout, so a positive diff means the treatment produced *more*
+    of the event.
+    """
+    if not spec.guardrails:
+        return []
+
+    out = []
+    for g in spec.guardrails:
+        event = METRIC_EVENTS.get(g.metric)
+        if event is None:
+            out.append(
+                f"  guardrail {g.metric}: SKIPPED — unknown metric "
+                f"(known: {', '.join(sorted(METRIC_EVENTS))})"
+            )
+            continue
+
+        rows = rows_from_ab_result(
+            reader.query(ab_rows_sql(spec, numerator_event=event)), spec
+        )
+        events = int(rows.numerator.sum())
+        est = cluster_robust_rate_diff(
+            rows.unit_ids, rows.arm, rows.numerator, rows.denominator
+        )
+
+        status = "ok"
+        if g.max is not None:
+            if est.ci_low > g.max:
+                status = f"BREACH (CI low {est.ci_low:+.4f} > max {g.max:+.4f})"
+            elif est.diff > g.max:
+                status = f"watch (point {est.diff:+.4f} > max {g.max:+.4f}, CI does not clear it)"
+        if status == "ok" and g.min is not None:
+            if est.ci_high < g.min:
+                status = f"BREACH (CI high {est.ci_high:+.4f} < min {g.min:+.4f})"
+            elif est.diff < g.min:
+                status = f"watch (point {est.diff:+.4f} < min {g.min:+.4f}, CI does not clear it)"
+
+        out.append(f"  guardrail {g.metric}: {est.describe()} [{status}]")
+        # State the raw event count unconditionally. These signals are rare — measured at 221
+        # requestLess events across 11 days — and an underpowered "ok" must never be mistaken for
+        # evidence of safety.
+        out.append(f"    (n={events} {g.metric} events; a quiet guardrail here is weak evidence)")
+    return out
 
 
 def analyse_interleaving(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:

--- a/analysis/tests/test_runner_gates.py
+++ b/analysis/tests/test_runner_gates.py
@@ -112,3 +112,88 @@ def test_interleaving_detects_a_real_preference():
 
     readout = run(spec, R())
     assert "TREATMENT WINS" in readout.verdict, readout.render()
+
+
+class GuardrailReader:
+    """Routes by numerator event: the guardrail query asks for a different one.
+
+    Mirrors FakeReader but distinguishes a third query shape, so a test can give the guardrail
+    metric a different effect from the primary one.
+    """
+
+    def __init__(self, primary, control, guardrail):
+        self._primary = primary
+        self._control = control
+        self._guardrail = guardrail
+
+    def query(self, sql):
+        if "requestLess" in sql:
+            return self._guardrail
+        if "source = 'fallback'" not in sql:
+            return self._primary
+        return self._control
+
+
+def _guardrail_spec(**over):
+    return _spec(guardrails=[{"metric": "request_less_rate", "max": 0.0}], **over)
+
+
+def test_guardrail_breach_is_reported_but_does_not_withhold_the_result():
+    """A guardrail is not a negative control.
+
+    A negative control that moves means the experiment is broken, so the result is withheld. A
+    guardrail that moves means the change had a real cost — the result must still be shown, or the
+    reader cannot weigh the trade the guardrail exists to expose.
+    """
+    primary = _rows(150, 1, 20, 10000) + _rows(150, 6, 20, 250)
+    control = _rows(150, 1, 20, 10000) + _rows(150, 1, 20, 250)
+    # Treatment produces far more "show me less" — a genuine regression.
+    guardrail = _rows(150, 0, 20, 10000) + _rows(150, 5, 20, 250)
+
+    readout = analyse_ab(_guardrail_spec(), GuardrailReader(primary, control, guardrail))
+    joined = "\n".join(readout.lines)
+
+    assert "WITHHELD" not in readout.verdict, readout.render()
+    assert "guardrail request_less_rate" in joined, joined
+    assert "BREACH" in joined, joined
+    # The primary effect is still reported alongside it.
+    assert any("primary" in line for line in readout.lines), joined
+
+
+def test_quiet_guardrail_reports_its_event_count_so_it_is_not_read_as_safety():
+    """An underpowered guardrail must not read as evidence of safety.
+
+    requestLess is rare — 221 events across the holdout's first 11 days — so "ok" here usually
+    means "no power", exactly the trap the negative-control write-up hit when p=0.0555 on 3 likes
+    was described as 'nearly moved'.
+    """
+    primary = _rows(150, 1, 20, 10000) + _rows(150, 3, 20, 250)
+    control = _rows(150, 1, 20, 10000) + _rows(150, 1, 20, 250)
+    guardrail = _rows(150, 0, 20, 10000) + _rows(150, 0, 20, 250)
+
+    readout = analyse_ab(_guardrail_spec(), GuardrailReader(primary, control, guardrail))
+    joined = "\n".join(readout.lines)
+
+    assert "BREACH" not in joined, joined
+    assert "n=0 request_less_rate events" in joined, joined
+    assert "weak evidence" in joined, joined
+
+
+def test_unknown_guardrail_metric_is_skipped_loudly_not_silently():
+    """A typo'd metric name must not look like a passing guardrail."""
+    primary = _rows(150, 1, 20, 10000) + _rows(150, 3, 20, 250)
+    control = _rows(150, 1, 20, 10000) + _rows(150, 1, 20, 250)
+    spec = _spec(guardrails=[{"metric": "clickthrough_rate", "max": 0.0}])
+
+    readout = analyse_ab(spec, GuardrailReader(primary, control, []))
+    joined = "\n".join(readout.lines)
+
+    assert "SKIPPED" in joined, joined
+    assert "unknown metric" in joined, joined
+
+
+def test_spec_without_guardrails_prints_none():
+    primary = _rows(150, 1, 20, 10000) + _rows(150, 3, 20, 250)
+    control = _rows(150, 1, 20, 10000) + _rows(150, 1, 20, 250)
+    readout = analyse_ab(_spec(), FakeReader(primary, control))
+    assert "guardrail" not in "\n".join(readout.lines)


### PR DESCRIPTION
Fixes a dead feature and uses it to close a real gap in the remit.

## The dead feature

`Guardrail` was parsed from spec YAML and then **never used**. A spec could declare `guardrails:` and the runner would silently ignore them — worse than not having the feature, because it reads as a check that is not happening.

## Why a relevance guardrail

The primary metric is `like_rate`, which is pure engagement. Optimising engagement alone selects for engagement-bait — the standard way a recommender gets worse while its headline number improves. The remit is content that is **relevant**, not merely clickable, and nothing currently measures that.

`requestLess` is the only direct relevance signal the client sends: an explicit "show me less of this" rather than a proxy.

> Note for anyone tempted to widen the *engagement* metric instead: measured 2026-08-25, this dataset contains **zero** clickthrough events. That option does not exist here. `requestLess`/`requestMore` are what there is.

## Guardrails are not negative controls

Deliberately different handling:

| | if it moves |
|---|---|
| negative control | the experiment is **broken** → withhold the result |
| guardrail | the change had a **real cost** → show the result, let the reader weigh it |

Withholding on a guardrail would hide the very thing it exists to surface.

Breach reporting borrows the drift guard's discipline: **BREACH** only when the CI clears the bound (a detection), **watch** when the point estimate clears it but the interval does not (a prediction).

## Every guardrail prints its event count

`requestLess` is rare — 221 events across the holdout's first 11 days — so "ok" usually means *no power*. This is the same trap as describing a negative control at p=0.0555 on 3 total likes as "nearly moved". The count makes it visible:

```
(n=221 request_less_rate events; a quiet guardrail here is weak evidence)
```

## Verified against production

```
guardrail request_less_rate: diff=+0.0003 (+32.4%) 95% CI [-0.0007, +0.0014] p=0.5668
  [watch (point +0.0003 > max +0.0000, CI does not clear it)]
  (n=221 request_less_rate events; a quiet guardrail here is weak evidence)
```

Correctly classified `watch` rather than BREACH — the direction that would worry us, at a magnitude the data cannot yet resolve.

## Testing

62 passing (4 new): breach is reported but does not withhold; a quiet guardrail prints its count; an unknown metric name is skipped loudly rather than silently passing; a spec without guardrails prints nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)