### PR TITLE
Land production state, and record why a response was not personalized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/graze-like-streamer",
     "crates/graze-candidate-sync",
     "crates/graze-frontdoor",
+    "crates/graze-feed-stats",
 ]
 
 [workspace.package]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN --mount=type=ssh \
     -p graze-api \
     -p graze-like-streamer \
     -p graze-candidate-sync \
-    -p graze-frontdoor
+    -p graze-frontdoor \
+    -p graze-feed-stats
 
 # Stage 2: Final runtime image
 FROM --platform=linux/amd64 gcr.io/distroless/cc-debian12
@@ -38,9 +39,12 @@ WORKDIR /app
 COPY --from=builder /app/target/release/graze-api /app/graze-api
 COPY --from=builder /app/target/release/graze-like-streamer /app/graze-like-streamer
 COPY --from=builder /app/target/release/graze-candidate-sync /app/graze-candidate-sync
+# Phase A of the durable co-liker profile design; built by -p graze-candidate-sync.
+COPY --from=builder /app/target/release/graze-build-coliker-profiles /app/graze-build-coliker-profiles
 COPY --from=builder /app/target/release/graze-backfill-ula /app/graze-backfill-ula
 COPY --from=builder /app/target/release/graze-backfill /app/graze-backfill
 COPY --from=builder /app/target/release/graze-frontdoor /app/graze-frontdoor
+COPY --from=builder /app/target/release/graze-feed-stats /app/graze-feed-stats
 COPY --from=builder /app/target/release/graze-migrate-tranches /app/graze-migrate-tranches
 COPY --from=builder /app/target/release/graze-migrate-dates /app/graze-migrate-dates
 COPY --from=builder /app/target/release/graze-verify-migration /app/graze-verify-migration

--- a/crates/graze-api/src/algorithm/coliker.rs
+++ b/crates/graze-api/src/algorithm/coliker.rs
@@ -19,7 +19,7 @@
 use std::collections::HashMap;
 
 use rand::seq::SliceRandom;
-use rand::thread_rng;
+use rand::SeedableRng;
 use rustc_hash::FxHashSet;
 use std::sync::Arc;
 use std::time::Instant;
@@ -32,18 +32,151 @@ use crate::algorithm::scoring_core::{
 };
 use crate::config::Config;
 use crate::error::Result;
-use graze_common::{Keys, RedisClient, DEFAULT_RETENTION_DAYS};
+use graze_common::services::UriInterner;
+use graze_common::{author_did_from_at_uri, hash_did, Keys, RedisClient, DEFAULT_RETENTION_DAYS};
+
+/// Rescale stored durable-profile scores into scorer weights.
+///
+/// Stored scores are `Σ 1/L_j` (order 1e-3..1e2); the scorer expects live-path magnitudes
+/// (~2e-7) and clamps at `max_coliker_weight` (1e-6). Dividing by the maximum puts the top
+/// entry exactly at `target` and everything else below it, so:
+///
+/// - ranking is preserved exactly (a positive affine map on positive scores);
+/// - no weight can reach the clamp, provided `target < max_coliker_weight`, which keeps
+///   `weight.min(cap)` from flattening the profile into ties;
+/// - a 12-member profile is not handed systematically larger weights than a 128-member one,
+///   which is why this normalises by max rather than by sum.
+///
+/// Returns `None` when nothing usable survives — no entries, or no positive finite score
+/// (which would also make the division ill-defined).
+fn profile_weights_from_scores(
+    entries: Vec<(String, f64)>,
+    target: f64,
+) -> Option<HashMap<String, f64>> {
+    let max_score = entries
+        .iter()
+        .map(|(_, s)| *s)
+        .filter(|s| s.is_finite())
+        .fold(0.0_f64, f64::max);
+
+    if max_score <= 0.0 || !target.is_finite() || target <= 0.0 {
+        return None;
+    }
+
+    let weights: HashMap<String, f64> = entries
+        .into_iter()
+        .filter(|(hash, s)| !hash.is_empty() && s.is_finite() && *s > 0.0)
+        .map(|(hash, score)| (hash, target * (score / max_score)))
+        .collect();
+
+    if weights.is_empty() {
+        None
+    } else {
+        Some(weights)
+    }
+}
 
 /// Computes and caches co-liker aggregations for users.
 pub struct ColikerWorker {
     redis: Arc<RedisClient>,
     config: Arc<Config>,
+    /// Needed only by the per-feed seeding path, to resolve seed post IDs to author DIDs. The
+    /// interner has its own LRU, so hot posts cost nothing and a full miss costs one pipelined
+    /// lookup for the whole seed.
+    interner: Arc<UriInterner>,
+}
+
+/// A per-(user, day) deterministic RNG for seed sampling.
+///
+/// Stable within a request — which is what makes any two rankers in one request comparable — and
+/// across a day, which matches how long the derived weights are cached anyway.
+pub(crate) fn daily_rng(user_hash: &str) -> rand::rngs::StdRng {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = rustc_hash::FxHasher::default();
+    user_hash.hash(&mut hasher);
+    graze_common::today_date().hash(&mut hasher);
+    rand::rngs::StdRng::seed_from_u64(hasher.finish())
+}
+
+/// What the per-feed seed filter did, for telemetry.
+///
+/// Recorded because the whole hypothesis is falsifiable through these numbers: if `kept` is
+/// routinely near `seen`, the filter is inert and the experiment cannot show anything; if `kept`
+/// collapses to near zero, the treatment is really "no personalization" wearing a ranker's name,
+/// which would look like a ranking result while being a coverage result.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SeedFilterStats {
+    /// Seed posts considered.
+    pub seen: usize,
+    /// Seed posts whose author is in the feed's pool.
+    pub kept: usize,
+    /// Seed posts whose author could not be resolved, and were therefore kept.
+    pub unresolved: usize,
+}
+
+impl SeedFilterStats {
+    /// Fraction of the seed retained, or 1.0 for an empty seed.
+    pub fn keep_rate(&self) -> f64 {
+        if self.seen == 0 {
+            return 1.0;
+        }
+        self.kept as f64 / self.seen as f64
+    }
 }
 
 impl ColikerWorker {
     /// Create a new co-liker worker.
-    pub fn new(redis: Arc<RedisClient>, config: Arc<Config>) -> Self {
-        Self { redis, config }
+    pub fn new(redis: Arc<RedisClient>, config: Arc<Config>, interner: Arc<UriInterner>) -> Self {
+        Self {
+            redis,
+            config,
+            interner,
+        }
+    }
+
+    /// Load the durable co-liker profile (`ucl:{hash}`) built offline from long-range like
+    /// history, converted to scorer weights.
+    ///
+    /// Returns `None` when no profile exists — the common case, since profiles are only
+    /// built for users with ≥20 likes of history who requested a feed recently.
+    ///
+    /// # Weight conversion
+    ///
+    /// Stored scores are `Σ 1/L_j` over overlapping posts (order 1e-3..1e2), whereas the
+    /// live path produces weights around 2e-7 and the scorer clamps at
+    /// `max_coliker_weight` (1e-6). Absolute magnitude is load-bearing *only* at that clamp
+    /// and at `score > 0.0`, so a rank-preserving rescale that puts the top entry at
+    /// `durable_profile_weight_target` reproduces the live regime without needing the live
+    /// normalization terms. Scaling by the max (rather than the sum) keeps a small profile
+    /// from being handed systematically larger per-entry weights than a large one.
+    pub async fn get_durable_profile(
+        &self,
+        user_hash: &str,
+    ) -> Result<Option<HashMap<String, f64>>> {
+        let key = Keys::user_colikers(user_hash);
+        let Some(packed) = self.redis.get_bytes(&key).await? else {
+            return Ok(None);
+        };
+
+        let entries = graze_common::decode_profile(&packed);
+        let target = self.config.durable_profile_weight_target;
+
+        let Some(weights) = profile_weights_from_scores(entries, target) else {
+            debug!(
+                user_hash = %&user_hash[..8.min(user_hash.len())],
+                "durable_profile_unusable"
+            );
+            return Ok(None);
+        };
+
+        debug!(
+            user_hash = %&user_hash[..8.min(user_hash.len())],
+            profile_size = weights.len(),
+            weight_target = target,
+            "durable_profile_loaded"
+        );
+
+        Ok(Some(weights))
     }
 
     /// Get or compute co-liker weights for a user.
@@ -114,6 +247,177 @@ impl ColikerWorker {
             seed_sample_pool,
         )
         .await
+    }
+
+    /// Derive co-liker weights from a seed restricted to authors this feed actually carries.
+    ///
+    /// **The hypothesis.** LinkLonk scopes step 1 of its walk to a channel; we have only ever scoped
+    /// step 3 to the feed pool. Measured cost of scoping late: 34-56% of a user's top-128 co-likers
+    /// contribute zero coverage on a given feed, and *none* of those were inactive accounts — they
+    /// are active people who like different things. Filtering the seed instead should spend the same
+    /// co-liker budget on people whose tastes overlap this feed.
+    ///
+    /// **The risk, stated plainly.** Users with little in-topic history get a smaller seed, and a
+    /// smaller seed could reduce coverage rather than sharpen it. Three independent measurements say
+    /// coverage is *not* seed-limited here (23x seed -> 1.1x coverage; 13,623 co-likers -> 44
+    /// covered versus 455 -> 95; 117 seed -> 4 versus 9 seed -> 55), and this is the direct test of
+    /// that. `SeedFilterStats` is returned so the experiment can distinguish a ranking result from a
+    /// coverage collapse.
+    ///
+    /// Falls back to the unfiltered seed when `apa:{algo}` is missing — a sync that has not run yet
+    /// must not silently turn personalization off.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn get_or_compute_colikes_per_feed(
+        &self,
+        algo_id: i32,
+        user_hash: &str,
+        max_user_likes: usize,
+        max_sources_per_post: usize,
+        max_total_sources: usize,
+        time_window_seconds: u64,
+        recency_half_life_seconds: u64,
+        force_refresh: bool,
+        seed_sample_pool: usize,
+    ) -> Result<(HashMap<String, f64>, SeedFilterStats)> {
+        if !self.config.coliker_enabled {
+            return Ok((HashMap::new(), SeedFilterStats::default()));
+        }
+
+        let cache_key = Keys::colikes_per_feed(algo_id, user_hash);
+        if !force_refresh {
+            let ttl = self.redis.ttl(&cache_key).await?;
+            if ttl > self.config.coliker_refresh_threshold_seconds as i64 {
+                let cached = self.get_cached_colikes(&cache_key).await?;
+                if !cached.is_empty() {
+                    // Stats are not cached: they describe the derivation, not the result, and a
+                    // fabricated value here would be indistinguishable from a measured one.
+                    return Ok((cached, SeedFilterStats::default()));
+                }
+            }
+        }
+
+        let start_time = Instant::now();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        let min_time = now - time_window_seconds as f64;
+
+        // Fetch a wider seed than the unfaceted path, because the filter is about to discard some of
+        // it. Without this the treatment would be confounded: a smaller *post-filter* seed than the
+        // control's would make the comparison partly about seed size rather than seed composition.
+        let fetch_limit = seed_sample_pool.max(max_user_likes) * 2;
+        let user_likes_keys = Keys::user_likes_retention(user_hash, DEFAULT_RETENTION_DAYS);
+        let candidate_seed = self
+            .redis
+            .zrevrangebyscore_merged(&user_likes_keys, now, min_time, fetch_limit)
+            .await?;
+
+        if candidate_seed.is_empty() {
+            return Ok((HashMap::new(), SeedFilterStats::default()));
+        }
+
+        let (mut seed, stats) = self
+            .filter_seed_to_pool_authors(algo_id, candidate_seed)
+            .await?;
+
+        if seed.len() > max_user_likes {
+            if seed_sample_pool > 0 {
+                seed.shuffle(&mut daily_rng(user_hash));
+            }
+            seed.truncate(max_user_likes);
+        }
+
+        debug!(
+            user_hash = %&user_hash[..8.min(user_hash.len())],
+            algo_id,
+            seed_seen = stats.seen,
+            seed_kept = stats.kept,
+            seed_unresolved = stats.unresolved,
+            keep_rate = stats.keep_rate(),
+            seed_used = seed.len(),
+            "per_feed_seed_filtered"
+        );
+
+        let weights = self
+            .colikes_from_seed(
+                user_hash,
+                seed,
+                max_sources_per_post,
+                max_total_sources,
+                now,
+                min_time,
+                recency_half_life_seconds,
+                start_time,
+            )
+            .await?;
+        Ok((weights, stats))
+    }
+
+    /// Keep only seed posts whose author appears in `apa:{algo}`.
+    ///
+    /// Two round trips regardless of seed size: one batched interner lookup, one `SMISMEMBER`.
+    async fn filter_seed_to_pool_authors(
+        &self,
+        algo_id: i32,
+        seed: Vec<(String, f64)>,
+    ) -> Result<(Vec<(String, f64)>, SeedFilterStats)> {
+        let authors_key = Keys::algo_pool_authors(algo_id);
+        if !self.redis.exists(&authors_key).await? {
+            // No pool author set (sync has not run, or it expired). Filtering against an absent set
+            // would drop every seed post, so pass the seed through untouched instead.
+            let seen = seed.len();
+            return Ok((
+                seed,
+                SeedFilterStats {
+                    seen,
+                    kept: seen,
+                    unresolved: seen,
+                },
+            ));
+        }
+
+        let post_ids: Vec<String> = seed.iter().map(|(id, _)| id.clone()).collect();
+        let uris = self.interner.get_uris_batch(&post_ids).await?;
+
+        // Resolve each seed post to an author hash. A post whose URI is no longer interned (its
+        // `id2uri:` shard expired) is unresolvable, and is kept rather than dropped: a lookup
+        // failure is not evidence that the feed lacks that author.
+        let mut resolved: Vec<(usize, String)> = Vec::with_capacity(post_ids.len());
+        let mut unresolved_idx: Vec<usize> = Vec::new();
+        for (i, post_id) in post_ids.iter().enumerate() {
+            match uris.get(post_id).and_then(|u| author_did_from_at_uri(u)) {
+                Some(did) => resolved.push((i, hash_did(did))),
+                None => unresolved_idx.push(i),
+            }
+        }
+
+        let probe: Vec<String> = resolved.iter().map(|(_, h)| h.clone()).collect();
+        let flags = self.redis.sismember_multi(&authors_key, &probe).await?;
+
+        let mut keep = vec![false; seed.len()];
+        for idx in &unresolved_idx {
+            keep[*idx] = true;
+        }
+        let mut in_pool = 0usize;
+        for ((i, _), is_member) in resolved.iter().zip(flags.iter()) {
+            if *is_member {
+                keep[*i] = true;
+                in_pool += 1;
+            }
+        }
+
+        let stats = SeedFilterStats {
+            seen: seed.len(),
+            kept: in_pool + unresolved_idx.len(),
+            unresolved: unresolved_idx.len(),
+        };
+        let filtered: Vec<(String, f64)> = seed
+            .into_iter()
+            .zip(keep.iter())
+            .filter_map(|(entry, k)| if *k { Some(entry) } else { None })
+            .collect();
+        Ok((filtered, stats))
     }
 
     /// Check if user has new likes since the co-likers cache was computed.
@@ -192,13 +496,54 @@ impl ColikerWorker {
             return Ok(HashMap::new());
         }
 
-        // Random seed sampling: shuffle and truncate to max_user_likes
+        // Random seed sampling: shuffle and truncate to max_user_likes.
+        //
+        // Seeded per (user, day) rather than from `thread_rng`. The shuffle exists to vary *which*
+        // of a user's likes seed the walk, which is a between-user and between-day property; drawing
+        // it fresh per request bought nothing and cost a great deal. It made the same ranker return
+        // different rankings when run twice in one request, which the interleaving self-check
+        // measured as a 6% spurious disagreement floor — noise indistinguishable from a treatment
+        // effect in every experiment that would ever run through the harness.
+        //
+        // Determinism here is also nearly free behaviourally: the derived weights are cached with a
+        // TTL, so a user's seed sample was already fixed for the life of that cache entry. Rotating
+        // daily keeps the variety the shuffle was for.
         if seed_sample_pool > 0 && user_likes.len() > max_user_likes {
-            user_likes.shuffle(&mut thread_rng());
+            user_likes.shuffle(&mut daily_rng(user_hash));
             user_likes.truncate(max_user_likes);
         }
 
-        // Parse likes into list of (post_id, like_time)
+        self.colikes_from_seed(
+            user_hash,
+            user_likes,
+            max_sources_per_post,
+            max_total_sources,
+            now,
+            min_time,
+            recency_half_life_seconds,
+            start_time,
+        )
+        .await
+    }
+
+    /// Derive co-liker weights from an already-chosen seed.
+    ///
+    /// Split out of [`Self::compute_colikes`] so the per-feed variant can substitute a *filtered*
+    /// seed without duplicating steps 2 and 3. Both paths therefore share byte-identical
+    /// aggregation, which is what makes an interleaved comparison of the two a comparison of the
+    /// seed alone.
+    #[allow(clippy::too_many_arguments)]
+    async fn colikes_from_seed(
+        &self,
+        user_hash: &str,
+        user_likes: Vec<(String, f64)>,
+        max_sources_per_post: usize,
+        max_total_sources: usize,
+        now: f64,
+        min_time: f64,
+        recency_half_life_seconds: u64,
+        start_time: Instant,
+    ) -> Result<HashMap<String, f64>> {
         let liked_posts: Vec<(String, f64)> = user_likes;
 
         // Step 2: Fetch co-likers for ALL posts using pipelined requests
@@ -268,7 +613,7 @@ impl ColikerWorker {
 
                 source_hashes
                     .into_iter()
-                    .zip(counts.into_iter())
+                    .zip(counts)
                     .map(|(hash, count)| {
                         let c = count.and_then(|s| s.parse::<i64>().ok()).unwrap_or(1);
                         (hash.to_string(), c)
@@ -406,5 +751,170 @@ impl ColikerWorker {
         }
 
         Ok((true, ttl))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `max_coliker_weight` default — weights must stay strictly under this or the
+    /// scorer's `weight.min(cap)` flattens the profile into ties and ranking degenerates
+    /// to bare membership.
+    const CAP: f64 = 0.000001;
+    const TARGET: f64 = 0.0000002;
+
+    fn entries(scores: &[f64]) -> Vec<(String, f64)> {
+        scores
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (format!("{:016x}", i), *s))
+            .collect()
+    }
+
+    #[test]
+    fn top_entry_lands_on_target_and_nothing_reaches_the_cap() {
+        let w = profile_weights_from_scores(entries(&[12.5, 3.25, 0.125]), TARGET).unwrap();
+        let max = w.values().cloned().fold(0.0_f64, f64::max);
+        assert!((max - TARGET).abs() < f64::EPSILON * TARGET.max(1.0));
+        for v in w.values() {
+            assert!(*v <= TARGET, "{} exceeded target", v);
+            assert!(*v < CAP, "{} would hit max_coliker_weight", v);
+        }
+    }
+
+    #[test]
+    fn ranking_is_preserved_exactly() {
+        let scores = [50.0, 12.5, 12.4, 3.25, 0.001];
+        let w = profile_weights_from_scores(entries(&scores), TARGET).unwrap();
+        let mut ordered: Vec<(String, f64)> = w.into_iter().collect();
+        ordered.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
+        let got: Vec<usize> = ordered
+            .iter()
+            .map(|(h, _)| usize::from_str_radix(h, 16).unwrap())
+            .collect();
+        assert_eq!(got, vec![0, 1, 2, 3, 4], "input was already descending");
+    }
+
+    #[test]
+    fn small_profile_is_not_advantaged_over_a_large_one() {
+        // Normalising by max (not sum) means profile size does not inflate per-entry
+        // weight: both profiles' top entry lands on exactly the same value.
+        let small = profile_weights_from_scores(entries(&[4.0, 2.0]), TARGET).unwrap();
+        let large = profile_weights_from_scores(entries(&[4.0; 128]), TARGET).unwrap();
+        let smax = small.values().cloned().fold(0.0_f64, f64::max);
+        let lmax = large.values().cloned().fold(0.0_f64, f64::max);
+        assert_eq!(smax, lmax);
+    }
+
+    #[test]
+    fn rejects_profiles_with_no_usable_signal() {
+        assert!(profile_weights_from_scores(vec![], TARGET).is_none());
+        assert!(profile_weights_from_scores(entries(&[0.0, 0.0]), TARGET).is_none());
+        assert!(profile_weights_from_scores(entries(&[-1.0]), TARGET).is_none());
+        assert!(profile_weights_from_scores(entries(&[f64::NAN]), TARGET).is_none());
+        assert!(profile_weights_from_scores(entries(&[f64::INFINITY]), TARGET).is_none());
+    }
+
+    #[test]
+    fn drops_individual_bad_entries_but_keeps_the_profile() {
+        let mixed = vec![
+            ("0000000000000001".to_string(), 5.0),
+            ("0000000000000002".to_string(), f64::NAN),
+            ("0000000000000003".to_string(), 0.0),
+            (String::new(), 9.0), // empty hash
+            ("0000000000000004".to_string(), 2.5),
+        ];
+        let w = profile_weights_from_scores(mixed, TARGET).unwrap();
+        assert_eq!(w.len(), 2);
+        assert!(w.contains_key("0000000000000001"));
+        assert!(w.contains_key("0000000000000004"));
+    }
+
+    #[test]
+    fn non_positive_target_is_rejected() {
+        assert!(profile_weights_from_scores(entries(&[1.0]), 0.0).is_none());
+        assert!(profile_weights_from_scores(entries(&[1.0]), -1.0).is_none());
+        assert!(profile_weights_from_scores(entries(&[1.0]), f64::NAN).is_none());
+    }
+}
+
+#[cfg(test)]
+mod per_feed_seed_tests {
+    use super::*;
+    use rand::seq::SliceRandom;
+
+    #[test]
+    fn keep_rate_reports_the_share_retained() {
+        let stats = SeedFilterStats {
+            seen: 128,
+            kept: 32,
+            unresolved: 0,
+        };
+        assert!((stats.keep_rate() - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn empty_seed_reports_a_full_keep_rate_not_a_division_by_zero() {
+        // 0/0 must not become NaN: a NaN would propagate into the telemetry and make the
+        // coverage-versus-ranking distinction unreadable exactly when the seed is empty.
+        let stats = SeedFilterStats::default();
+        assert_eq!(stats.keep_rate(), 1.0);
+        assert!(stats.keep_rate().is_finite());
+    }
+
+    #[test]
+    fn unresolved_seed_posts_count_as_kept() {
+        // A post whose URI shard expired cannot be tested for pool membership. Dropping it would
+        // shrink the seed for a lookup failure, which is not evidence about the feed's authors.
+        let stats = SeedFilterStats {
+            seen: 10,
+            kept: 4,
+            unresolved: 3,
+        };
+        assert!(stats.kept >= stats.unresolved);
+        assert!(stats.keep_rate() > 0.0);
+    }
+
+    #[test]
+    fn seed_shuffle_is_stable_within_a_day_for_one_user() {
+        // This is the property the interleaving self-check needs: the same ranker run twice must
+        // choose the same seed. A `thread_rng` shuffle here produced a 6% spurious disagreement
+        // floor in production.
+        let seed: Vec<u32> = (0..64).collect();
+        let mut a = seed.clone();
+        let mut b = seed.clone();
+        a.shuffle(&mut daily_rng("user-hash-abc"));
+        b.shuffle(&mut daily_rng("user-hash-abc"));
+        assert_eq!(
+            a, b,
+            "the same user must get the same seed order within a day"
+        );
+    }
+
+    #[test]
+    fn seed_shuffle_still_differs_between_users() {
+        // Determinism must not become "everyone samples identically", which would collapse the
+        // between-user seed variety the shuffle exists to provide.
+        let seed: Vec<u32> = (0..64).collect();
+        let mut a = seed.clone();
+        let mut b = seed.clone();
+        a.shuffle(&mut daily_rng("user-hash-abc"));
+        b.shuffle(&mut daily_rng("user-hash-xyz"));
+        assert_ne!(a, b, "different users must get different seed orders");
+    }
+
+    #[test]
+    fn seed_shuffle_actually_permutes() {
+        let seed: Vec<u32> = (0..64).collect();
+        let mut shuffled = seed.clone();
+        shuffled.shuffle(&mut daily_rng("user-hash-abc"));
+        assert_ne!(
+            shuffled, seed,
+            "a deterministic shuffle must still be a shuffle"
+        );
+        let mut sorted = shuffled.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, seed, "shuffling must not add or drop entries");
     }
 }

--- a/crates/graze-api/src/algorithm/diversity.rs
+++ b/crates/graze-api/src/algorithm/diversity.rs
@@ -19,6 +19,13 @@ pub struct DiversityConfig {
     pub diminishing_factor: f64,
     /// MMR lambda: balance between relevance (0.0) and diversity (1.0).
     pub mmr_lambda: f64,
+    /// Preserve the input order instead of re-sorting by diversity-adjusted score.
+    ///
+    /// Required by interleaving: a team-draft order encodes which ranker contributed each
+    /// position, and re-sorting by adjusted score destroys that assignment. In this mode the
+    /// per-author cap still applies, but surviving items keep their incoming order and their
+    /// original scores.
+    pub preserve_order: bool,
 }
 
 impl Default for DiversityConfig {
@@ -28,6 +35,7 @@ impl Default for DiversityConfig {
             max_posts_per_author: 3,
             diminishing_factor: 0.5,
             mmr_lambda: 0.3,
+            preserve_order: false,
         }
     }
 }
@@ -91,6 +99,48 @@ pub fn diversify_posts(
             posts,
             posts_demoted: 0,
             posts_removed_by_cap: 0,
+        };
+    }
+
+    if config.preserve_order {
+        // Cap-only pass: keep the incoming order (and original scores) so an interleaved draft
+        // survives, while still preventing one author from flooding the feed.
+        let mut author_counts: FxHashMap<String, usize> = FxHashMap::default();
+        let mut selected: Vec<(f64, String, String)> = Vec::with_capacity(limit);
+        let mut posts_removed_by_cap = 0;
+
+        for (score, post_id) in scored_posts {
+            if selected.len() >= limit {
+                break;
+            }
+            let Some(uri) = post_uris.get(post_id) else {
+                continue;
+            };
+            let Some(author) = extract_author_did(uri) else {
+                continue;
+            };
+            let count = author_counts.entry(author.to_string()).or_insert(0);
+            if *count >= config.max_posts_per_author {
+                posts_removed_by_cap += 1;
+                continue;
+            }
+            *count += 1;
+            selected.push((*score, post_id.clone(), uri.clone()));
+        }
+
+        let unique_authors = author_counts.len();
+        debug!(
+            total_candidates = scored_posts.len(),
+            selected_count = selected.len(),
+            unique_authors,
+            posts_removed_by_cap,
+            "diversity_preserve_order"
+        );
+        return DiversityResult {
+            posts: selected,
+            unique_authors,
+            posts_demoted: 0,
+            posts_removed_by_cap,
         };
     }
 
@@ -245,6 +295,7 @@ mod tests {
             max_posts_per_author: 3,
             diminishing_factor: 0.5,
             mmr_lambda: 0.0, // Disable MMR for this test
+            preserve_order: false,
         };
 
         let result = diversify_posts(&posts, &uris, &config, 10);
@@ -279,6 +330,7 @@ mod tests {
             max_posts_per_author: 2,
             diminishing_factor: 0.5,
             mmr_lambda: 0.0,
+            preserve_order: false,
         };
 
         let result = diversify_posts(&posts, &uris, &config, 10);
@@ -319,6 +371,7 @@ mod tests {
             max_posts_per_author: 3,
             diminishing_factor: 0.5,
             mmr_lambda: 0.3,
+            preserve_order: false,
         };
 
         let result = diversify_posts(&posts, &uris, &config, 4);
@@ -327,5 +380,89 @@ mod tests {
         assert_eq!(result.unique_authors, 2);
         // First post should still be post1 (highest score)
         assert_eq!(result.posts[0].1, "post1");
+    }
+
+    /// Interleaving encodes the ranker assignment in the *order* of the list, so diversity must
+    /// be able to cap authors without re-sorting. Without this, a team-draft order is destroyed
+    /// and per-item attribution becomes meaningless.
+    #[test]
+    fn preserve_order_keeps_input_order_and_scores() {
+        let scored = vec![
+            (0.10, "p1".to_string()),
+            (0.90, "p2".to_string()),
+            (0.50, "p3".to_string()),
+        ];
+        let mut uris = FxHashMap::default();
+        uris.insert(
+            "p1".to_string(),
+            "at://did:a/app.bsky.feed.post/1".to_string(),
+        );
+        uris.insert(
+            "p2".to_string(),
+            "at://did:b/app.bsky.feed.post/2".to_string(),
+        );
+        uris.insert(
+            "p3".to_string(),
+            "at://did:c/app.bsky.feed.post/3".to_string(),
+        );
+
+        let config = DiversityConfig {
+            enabled: true,
+            max_posts_per_author: 3,
+            diminishing_factor: 0.5,
+            mmr_lambda: 0.3,
+            preserve_order: true,
+        };
+        let out = diversify_posts(&scored, &uris, &config, 10);
+        let ids: Vec<&str> = out.posts.iter().map(|(_, id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["p1", "p2", "p3"], "input order must survive");
+        // Scores must be untouched (the default path rewrites them with adjusted scores).
+        assert_eq!(out.posts[0].0, 0.10);
+        assert_eq!(out.posts[1].0, 0.90);
+        assert_eq!(out.posts_demoted, 0);
+    }
+
+    /// Order preservation must not cost us the author cap, or one author could flood a feed.
+    #[test]
+    fn preserve_order_still_applies_the_author_cap() {
+        let scored: Vec<(f64, String)> = (0..5).map(|i| (1.0, format!("p{}", i))).collect();
+        let mut uris = FxHashMap::default();
+        for i in 0..5 {
+            uris.insert(
+                format!("p{}", i),
+                format!("at://did:same/app.bsky.feed.post/{}", i),
+            );
+        }
+        let config = DiversityConfig {
+            enabled: true,
+            max_posts_per_author: 2,
+            diminishing_factor: 0.5,
+            mmr_lambda: 0.3,
+            preserve_order: true,
+        };
+        let out = diversify_posts(&scored, &uris, &config, 10);
+        assert_eq!(out.posts.len(), 2, "cap must hold");
+        assert_eq!(out.posts_removed_by_cap, 3);
+        // And the survivors are the FIRST two, not an arbitrary pair.
+        let ids: Vec<&str> = out.posts.iter().map(|(_, id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["p0", "p1"]);
+    }
+
+    /// The ordinary path must be unchanged by the new flag.
+    #[test]
+    fn default_path_still_resorts_by_adjusted_score() {
+        let scored = vec![(0.10, "p1".to_string()), (0.90, "p2".to_string())];
+        let mut uris = FxHashMap::default();
+        uris.insert(
+            "p1".to_string(),
+            "at://did:a/app.bsky.feed.post/1".to_string(),
+        );
+        uris.insert(
+            "p2".to_string(),
+            "at://did:b/app.bsky.feed.post/2".to_string(),
+        );
+        let out = diversify_posts(&scored, &uris, &DiversityConfig::default(), 10);
+        let ids: Vec<&str> = out.posts.iter().map(|(_, id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["p2", "p1"], "highest score first");
     }
 }

--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -12,6 +12,7 @@ mod proof;
 mod scorer;
 mod scoring_core;
 mod thompson;
+mod walk;
 
 pub use author_affinity::AuthorColikerWorker;
 pub use coliker::ColikerWorker;
@@ -28,18 +29,20 @@ pub use scoring_core::{
     score_posts_parallel, score_posts_topk, to_fx_hashmap, ScoredPostResult,
 };
 pub use thompson::{
-    FeedOutcome, FeedOutcomeDetails, SelectedParams, ThompsonConfig, ThompsonLearner,
+    FeedOutcome, FeedOutcomeDetails, HashExperiment, SelectedParams, ThompsonConfig,
+    ThompsonLearner,
 };
 
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::audit::AuditCollector;
 use crate::config::Config;
 use crate::error::Result;
+use crate::experiment::{interleave, Ranker};
 use graze_common::models::{PersonalizationParams, PersonalizeResponse, ResponseMeta, ScoredPost};
 use graze_common::services::UriInterner;
 use graze_common::{Keys, RedisClient};
@@ -52,19 +55,45 @@ pub struct LinkLonkAlgorithm {
     coliker: ColikerWorker,
     author_coliker: AuthorColikerWorker,
     scorer: Scorer,
+    /// Scorer for the durable-profile arm. Identical to `scorer` except for
+    /// `min_post_likes`, which the durable arm relaxes to reach candidates the live arm
+    /// discards. Kept as a separate instance so the live arm's configuration is provably
+    /// unchanged — there is no per-call flag that could leak across arms.
+    profile_scorer: Scorer,
     liker_cache: Arc<LikerCache>,
 }
 
 impl LinkLonkAlgorithm {
     /// Create a new LinkLonk algorithm instance.
     pub fn new(redis: Arc<RedisClient>, interner: Arc<UriInterner>, config: Arc<Config>) -> Self {
-        let coliker = ColikerWorker::new(redis.clone(), config.clone());
+        let coliker = ColikerWorker::new(redis.clone(), config.clone(), interner.clone());
         let author_coliker = AuthorColikerWorker::new(redis.clone(), config.clone());
         let liker_cache = Arc::new(LikerCache::new(
             config.liker_cache_max_size,
             config.liker_cache_ttl_seconds,
         ));
         let scorer = Scorer::new(redis.clone(), liker_cache.clone(), config.clone());
+
+        // The durable arm gets its own scorer with relaxed candidate filters. Cloning the
+        // config and overriding just those fields keeps every other knob in lockstep with
+        // the live arm, so the two arms stay comparable.
+        //
+        // It also gets its OWN liker cache. The scorer writes fetched liker lists back into
+        // its cache after scoring, so a shared cache would let the durable arm's longer
+        // lists (max_likers_per_post 100 vs 30) leak into the live arm and silently change
+        // what the live path scores. A separate cache is what makes "strictly additive"
+        // actually true.
+        let profile_scorer = {
+            let mut profile_config = (*config).clone();
+            profile_config.inverted_min_post_likes = config.durable_profile_min_post_likes;
+            profile_config.inverted_max_likers_per_post =
+                config.durable_profile_max_likers_per_post;
+            let profile_liker_cache = Arc::new(LikerCache::new(
+                config.liker_cache_max_size,
+                config.liker_cache_ttl_seconds,
+            ));
+            Scorer::new(redis.clone(), profile_liker_cache, Arc::new(profile_config))
+        };
 
         Self {
             redis,
@@ -73,6 +102,7 @@ impl LinkLonkAlgorithm {
             coliker,
             author_coliker,
             scorer,
+            profile_scorer,
             liker_cache,
         }
     }
@@ -142,9 +172,50 @@ impl LinkLonkAlgorithm {
             } else {
                 // Need to compute fresh results
                 let audit_ref = audit.as_mut().map(|a| &mut **a);
-                let compute_result = self
+                let mut compute_result = self
                     .compute_personalization(&user_hash, algo_id, &params, audit_ref)
                     .await?;
+
+                // Interleaving: blend a second ranker's list into this one so the user acts as
+                // their own control. Runs only for enrolled users, and only on a fresh compute —
+                // cached pages replay the draft that was already stored.
+                if let Some((control, treatment, control_first)) =
+                    self.interleave_assignment(Some(user_did), algo_id)
+                {
+                    // Derive co-liker weights ONCE and score both arms from them, so the arms differ
+                    // only by traversal. Deriving per arm reintroduces the seed-sampling shuffle as
+                    // noise (see `score_with_ranker`).
+                    let weights = self
+                        .coliker
+                        .get_or_compute_colikes(
+                            &user_hash,
+                            params.max_user_likes,
+                            params.max_sources_per_post,
+                            params.max_total_sources,
+                            (params.time_window_hours * 3600.0) as u64,
+                            (params.recency_half_life_hours * 3600.0) as u64,
+                            false,
+                            params.seed_sample_pool,
+                        )
+                        .await?;
+
+                    if !weights.is_empty() {
+                        let control_result = self
+                            .score_with_ranker(&user_hash, algo_id, &params, &weights, control)
+                            .await?;
+                        let treatment_result = self
+                            .score_with_ranker(&user_hash, algo_id, &params, &weights, treatment)
+                            .await?;
+                        compute_result = self.apply_interleaving(
+                            control_result,
+                            treatment_result,
+                            control,
+                            treatment,
+                            control_first,
+                            limit,
+                        );
+                    }
+                }
 
                 // Capture scoring stats before converting
                 let stats = Some((
@@ -156,7 +227,13 @@ impl LinkLonkAlgorithm {
                 // Use computed posts directly instead of re-fetching from Redis!
                 // Apply cursor and limit to the computed results
                 let posts = self
-                    .convert_scored_posts_to_response(&compute_result.scored_posts, limit, cursor)
+                    .convert_scored_posts_to_response(
+                        &compute_result.scored_posts,
+                        limit,
+                        cursor,
+                        &compute_result.ranker_by_post,
+                        compute_result.requires_preserved_order,
+                    )
                     .await?;
                 (posts, false, Some(0), stats)
             };
@@ -198,6 +275,216 @@ impl LinkLonkAlgorithm {
     /// This can use either post-level co-likers (standard LinkLonk) or
     /// author-level co-likers (coarse LinkLonk) based on `params.use_author_affinity`.
     #[allow(clippy::needless_option_as_deref)]
+    /// Resolve this user's interleaving assignment, if any.
+    ///
+    /// Returns `(treatment_ranker, control_drafts_first)`. `None` means serve normally: the
+    /// experiment is off, the user is not enrolled, a ranker name is invalid, or control and
+    /// treatment are the same ranker (which would produce zero competitive pairs anyway).
+    fn interleave_assignment(
+        &self,
+        user_did: Option<&str>,
+        algo_id: i32,
+    ) -> Option<(Ranker, Ranker, bool)> {
+        if !self.config.interleave_enabled {
+            return None;
+        }
+        let did = user_did?;
+
+        let control = Ranker::parse(&self.config.interleave_control);
+        let treatment = Ranker::parse(&self.config.interleave_treatment);
+        let (Some(control), Some(treatment)) = (control, treatment) else {
+            // Fail loudly rather than silently comparing the control against itself.
+            warn!(
+                algo_id,
+                control = %self.config.interleave_control,
+                treatment = %self.config.interleave_treatment,
+                "interleave_invalid_ranker_name"
+            );
+            return None;
+        };
+        // Identical rankers normally mean a misconfiguration, but with the self-check flag it is
+        // a deliberate, feed-neutral validation of the harness itself.
+        if control == treatment && !self.config.interleave_self_check {
+            return None;
+        }
+
+        // Enrolment reuses the hash-experiment primitive: stable per user, orthogonal to time
+        // and to bandit state.
+        let exp = HashExperiment {
+            dimension: "interleave".to_string(),
+            values: vec![1],
+            traffic_pct: self.config.interleave_traffic_pct,
+            salt: self.config.interleave_salt.clone(),
+        };
+        exp.assign(did)?;
+
+        Some((
+            control,
+            treatment,
+            interleave::control_drafts_first(did, &self.config.interleave_salt),
+        ))
+    }
+
+    /// Score with a specific ranker from **already-derived** co-liker weights.
+    ///
+    /// Sharing the weights between arms is not merely an optimisation. Deriving them per arm made
+    /// "the same ranker twice" produce different rankings — the production self-check measured 123
+    /// competitive pairs and 32 co-liker derivations across 15 drafts, because
+    /// `seed_sample_pool > 0` shuffles the seed with `thread_rng` on every derivation
+    /// (`coliker.rs:283`, `scorer.rs:662`). That run-to-run noise is indistinguishable from a real
+    /// treatment effect and would consume the sensitivity interleaving exists to buy.
+    ///
+    /// Sharing also halves the co-liker work, measured at 27-106 ms per derivation.
+    async fn score_with_ranker(
+        &self,
+        user_hash: &str,
+        algo_id: i32,
+        params: &LinkLonkParams,
+        weights: &std::collections::HashMap<String, f64>,
+        ranker: Ranker,
+    ) -> Result<ScoringResult> {
+        // `PerFeedSeeded` is the one ranker so far that differs in the *weights* rather than the
+        // traversal, so it derives its own and ignores the shared ones. That is the treatment, not a
+        // regression of the shared-weight fix: rankers that differ only by traversal still share, so
+        // the self-check's null stays null. Any two rankers in one request are still reproducible,
+        // because seed sampling is now deterministic per (user, day).
+        if ranker == Ranker::PerFeedSeeded {
+            let (per_feed_weights, stats) = self
+                .coliker
+                .get_or_compute_colikes_per_feed(
+                    algo_id,
+                    user_hash,
+                    params.max_user_likes,
+                    params.max_sources_per_post,
+                    params.max_total_sources,
+                    (params.time_window_hours * 3600.0) as u64,
+                    (params.recency_half_life_hours * 3600.0) as u64,
+                    false,
+                    params.seed_sample_pool,
+                )
+                .await?;
+            if per_feed_weights.is_empty() {
+                return Ok(ScoringResult::default());
+            }
+            let mut result = self
+                .scorer
+                .score(user_hash, algo_id, &per_feed_weights, params, None)
+                .await?;
+            result.seed_keep_rate = Some(stats.keep_rate());
+            return Ok(result);
+        }
+
+        // The sampled walk derives its own candidates from the graph, so it neither needs nor uses
+        // the shared co-liker weights. It falls back to exhaustive scoring for very small seeds, where
+        // sampling variance is worst and enumeration is cheap anyway.
+        if ranker == Ranker::SampledWalk {
+            let seed_is_large_enough = self
+                .scorer
+                .seed_size_at_least(user_hash, params, self.scorer.walk_min_seed_for_sampling())
+                .await?;
+            if seed_is_large_enough {
+                return self
+                    .scorer
+                    .score_sampled_walk(user_hash, algo_id, params)
+                    .await;
+            }
+            if weights.is_empty() {
+                return Ok(ScoringResult::default());
+            }
+            return self
+                .scorer
+                .score(user_hash, algo_id, weights, params, None)
+                .await;
+        }
+
+        if weights.is_empty() {
+            return Ok(ScoringResult::default());
+        }
+        match ranker {
+            Ranker::Inverted => {
+                self.scorer
+                    .score_inverted(user_hash, algo_id, weights, params, None)
+                    .await
+            }
+            // Remaining variants land with their stages; until then they fall back to the
+            // production traversal, so a misconfigured experiment degrades to "no difference"
+            // rather than to an error.
+            _ => {
+                self.scorer
+                    .score(user_hash, algo_id, weights, params, None)
+                    .await
+            }
+        }
+    }
+
+    /// Team-draft the control and treatment lists into a single ranking.
+    ///
+    /// The draft order *is* the ranking, so `DIVERSITY_PRESERVE_ORDER` must be on for the
+    /// assignment to survive — a warning fires if it is not, because silently re-sorting would
+    /// scramble attribution and make the experiment unreadable rather than merely noisy.
+    fn apply_interleaving(
+        &self,
+        control: ScoringResult,
+        treatment: ScoringResult,
+        control_ranker: Ranker,
+        treatment_ranker: Ranker,
+        control_first: bool,
+        limit: usize,
+    ) -> ScoringResult {
+        // Draft wider than `limit` so pagination and the author cap have material to work with.
+        let draft_limit = (limit * 4).max(limit);
+        let draft = interleave::team_draft(
+            &control.scored_posts,
+            &treatment.scored_posts,
+            control_ranker,
+            treatment_ranker,
+            control_first,
+            draft_limit,
+        );
+
+        let mut scored_posts = Vec::with_capacity(draft.items.len());
+        let mut ranker_by_post = std::collections::HashMap::new();
+        for item in draft.items {
+            if let Some(r) = item.ranker {
+                ranker_by_post.insert(item.post_id.clone(), r.as_str().to_string());
+            }
+            scored_posts.push((item.score, item.post_id));
+        }
+
+        info!(
+            control_scored = control.scored_count,
+            treatment_scored = treatment.scored_count,
+            treatment_ranker = treatment_ranker.as_str(),
+            competitive_pairs = draft.competitive_pairs,
+            shared_items = draft.shared_items,
+            control_first = draft.control_first,
+            drafted = scored_posts.len(),
+            "interleave_draft"
+        );
+
+        ScoringResult {
+            scored_count: scored_posts.len(),
+            scored_posts,
+            ranker_by_post,
+            // The draft order IS the ranking; downstream must not re-sort it.
+            requires_preserved_order: true,
+            // Keep the control arm's funnel counters so existing dashboards stay comparable.
+            posts_checked: control.posts_checked,
+            posts_skipped_no_likers: control.posts_skipped_no_likers,
+            posts_skipped_few_likers: control.posts_skipped_few_likers,
+            posts_skipped_low_overlap: control.posts_skipped_low_overlap,
+            scoring_time_ms: control.scoring_time_ms + treatment.scoring_time_ms,
+            cache_hits: control.cache_hits,
+            cache_misses: control.cache_misses,
+            overlap_sum: control.overlap_sum,
+            overlap_max: control.overlap_max,
+            overlap_hist: control.overlap_hist,
+            // Whichever arm faceted the seed reported its keep rate; carry it so an interleaved
+            // readout can still tell a ranking effect from a coverage collapse.
+            seed_keep_rate: treatment.seed_keep_rate.or(control.seed_keep_rate),
+        }
+    }
+
     pub async fn compute_personalization(
         &self,
         user_hash: &str,
@@ -214,6 +501,85 @@ impl LinkLonkAlgorithm {
             min_co_likes = params.min_co_likes,
             "compute_personalization_start"
         );
+
+        // Step 0: Pool-size gate. Bail out before doing ANY expensive work if the
+        // feed's candidate pool is too small to personalize from. Overlap between a
+        // user's co-liker set and the pool is linear in pool size, so below a few
+        // hundred candidates the expected number of scoreable posts is < 1 and the
+        // whole pipeline reliably returns nothing. SCARD is O(1), whereas the work
+        // it skips is the co-liker walk, author-affinity supplementation, a full
+        // SMEMBERS of the pool and an HMGET of every liker count.
+        //
+        // Disabled by default (0). See Config::min_candidate_pool_for_personalization.
+        let pool_gate = self.config.min_candidate_pool_for_personalization;
+        if pool_gate > 0 {
+            let pool_size = self
+                .redis
+                .scard(&Keys::algo_posts(algo_id))
+                .await
+                .unwrap_or(0);
+            if pool_size < pool_gate {
+                info!(
+                    user_hash = %&user_hash[..8.min(user_hash.len())],
+                    algo_id,
+                    pool_size,
+                    pool_gate,
+                    "early_exit: candidate pool below personalization gate"
+                );
+                return Ok(ScoringResult {
+                    posts_checked: pool_size,
+                    ..Default::default()
+                });
+            }
+        }
+
+        // Step 0b: Like-density gate. A feed whose candidates are mostly unliked cannot be
+        // personalized by any co-liker method — there is no like signal to rank — so the walk is pure
+        // waste there. Distinct from the pool-size gate above because size does not predict density:
+        // algo 8352 (596 posts) is 22% scoreable while algo 5395 (1,000 posts) is 2%.
+        //
+        // Reads the histogram candidate-sync publishes into `am:{algo}`, so this costs one HGET against
+        // counts that were already computed during the sync. Disabled by default (0.0).
+        //
+        // Fails OPEN: a missing or unparseable field means "sync has not published this yet", and
+        // treating absence as "not viable" would silently disable personalization for every feed the
+        // moment this deploys ahead of the candidate-sync change.
+        let density_gate = self.config.min_pool_scoreable_share;
+        if density_gate > 0.0 {
+            let field = format!("scoreable_{}", self.config.inverted_min_post_likes);
+            let meta_key = Keys::algo_meta(algo_id);
+            let scoreable = self
+                .redis
+                .hget(&meta_key, &field)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|v| v.parse::<f64>().ok());
+            let post_count = self
+                .redis
+                .hget(&meta_key, "post_count")
+                .await
+                .ok()
+                .flatten()
+                .and_then(|v| v.parse::<f64>().ok());
+            if let (Some(scoreable), Some(post_count)) = (scoreable, post_count) {
+                if post_count > 0.0 {
+                    let share = scoreable / post_count;
+                    if share < density_gate {
+                        info!(
+                            user_hash = %&user_hash[..8.min(user_hash.len())],
+                            algo_id,
+                            scoreable,
+                            post_count,
+                            share = format!("{:.4}", share),
+                            density_gate,
+                            "early_exit: pool like-density below personalization gate"
+                        );
+                        return Ok(ScoringResult::default());
+                    }
+                }
+            }
+        }
 
         // Step 1: Get or compute co-likers (post-level or author-level)
         let coliker_weights = if params.use_author_affinity {
@@ -247,28 +613,34 @@ impl LinkLonkAlgorithm {
         };
 
         if coliker_weights.is_empty() {
+            // This is the branch the durable-profile work targets: the user has no likes in
+            // the 6-day window, so the live path derives no co-likers and they get 100%
+            // fallback. Measured: 13,196 such users per 3 days against 21,597 who are
+            // personalizable at all. See DESIGN-durable-coliker-profiles.md.
+            //
+            // Attaching here makes the change strictly additive — anyone the live path can
+            // already serve never reaches this code, so there is no regression surface.
+            if self.config.durable_profile_shadow_mode || self.config.durable_profile_enabled {
+                if let Some(result) = self
+                    .try_durable_profile(user_hash, algo_id, params, audit)
+                    .await?
+                {
+                    return Ok(result);
+                }
+            }
+
             debug!(
                 user_hash = %&user_hash[..8.min(user_hash.len())],
                 algo_id,
                 use_author_affinity = params.use_author_affinity,
                 "early_exit: no coliker weights found"
             );
-            return Ok(ScoringResult {
-                scored_posts: Vec::new(),
-                scored_count: 0,
-                posts_checked: 0,
-                posts_skipped_no_likers: 0,
-                posts_skipped_few_likers: 0,
-                scoring_time_ms: 0.0,
-                cache_hits: 0,
-                cache_misses: 0,
-            });
+            return Ok(ScoringResult::default());
         }
 
         // Step 2: Score posts using co-liker weights
         let scoring_result = self
-            .scorer
-            .score(user_hash, algo_id, &coliker_weights, params, audit)
+            .score_with_lookup_comparison(user_hash, algo_id, &coliker_weights, params, audit)
             .await?;
 
         debug!(
@@ -284,6 +656,177 @@ impl LinkLonkAlgorithm {
         Ok(scoring_result)
     }
 
+    /// Run the scorer, optionally computing the co-liker-first arm alongside the post-first one
+    /// and logging a per-request A/B.
+    ///
+    /// Three modes, from the two flags:
+    /// - neither set: post-first only, byte-identical to before this method existed.
+    /// - `INVERTED_LOOKUP_SHADOW_MODE=1`: both arms computed, comparison logged as
+    ///   `lookup_arm_comparison`, **post-first served**. Doubles scoring latency for affected
+    ///   requests, which is why it is opt-in and meant to be run briefly.
+    /// - `INVERTED_LOOKUP_ENABLED=1`: inverted served. If shadow is also on, post-first is still
+    ///   computed for comparison; otherwise only the inverted arm runs and the request gets the
+    ///   full cost saving.
+    ///
+    /// The audit collector goes to whichever arm is actually served, so audit output always
+    /// describes the response the user received.
+    async fn score_with_lookup_comparison(
+        &self,
+        user_hash: &str,
+        algo_id: i32,
+        coliker_weights: &std::collections::HashMap<String, f64>,
+        params: &LinkLonkParams,
+        audit: Option<&mut AuditCollector>,
+    ) -> Result<ScoringResult> {
+        let shadow = self.config.inverted_lookup_shadow_mode;
+        let serve_inverted = self.config.inverted_lookup_enabled;
+
+        if !shadow && !serve_inverted {
+            return self
+                .scorer
+                .score(user_hash, algo_id, coliker_weights, params, audit)
+                .await;
+        }
+
+        let t_post = Instant::now();
+        let (served, other, other_label) = if serve_inverted {
+            let inv = self
+                .scorer
+                .score_inverted(user_hash, algo_id, coliker_weights, params, audit)
+                .await?;
+            let post = if shadow {
+                Some(
+                    self.scorer
+                        .score(user_hash, algo_id, coliker_weights, params, None)
+                        .await?,
+                )
+            } else {
+                None
+            };
+            (inv, post, "post_first")
+        } else {
+            let post = self
+                .scorer
+                .score(user_hash, algo_id, coliker_weights, params, audit)
+                .await?;
+            let inv = Some(
+                self.scorer
+                    .score_inverted(user_hash, algo_id, coliker_weights, params, None)
+                    .await?,
+            );
+            (post, inv, "inverted")
+        };
+
+        if let Some(ref o) = other {
+            let (post_arm, inv_arm) = if serve_inverted {
+                (o, &served)
+            } else {
+                (&served, o)
+            };
+            info!(
+                user_hash = %&user_hash[..8.min(user_hash.len())],
+                algo_id,
+                colikers = coliker_weights.len(),
+                served_arm = if serve_inverted { "inverted" } else { "post_first" },
+                other_arm = other_label,
+                // the headline comparison
+                post_scored = post_arm.scored_count,
+                inv_scored = inv_arm.scored_count,
+                post_ms = format!("{:.1}", post_arm.scoring_time_ms),
+                inv_ms = format!("{:.1}", inv_arm.scoring_time_ms),
+                // where each arm loses candidates
+                post_checked = post_arm.posts_checked,
+                inv_checked = inv_arm.posts_checked,
+                post_no_likers = post_arm.posts_skipped_no_likers,
+                inv_unreached = inv_arm.posts_skipped_no_likers,
+                post_few_likers = post_arm.posts_skipped_few_likers,
+                inv_few_likers = inv_arm.posts_skipped_few_likers,
+                post_low_overlap = post_arm.posts_skipped_low_overlap,
+                inv_low_overlap = inv_arm.posts_skipped_low_overlap,
+                // ranking shape: overlap_count feeds a nonlinear paths_boost
+                post_overlap_mean = format!("{:.2}", post_arm.overlap_mean()),
+                inv_overlap_mean = format!("{:.2}", inv_arm.overlap_mean()),
+                post_overlap_max = post_arm.overlap_max,
+                inv_overlap_max = inv_arm.overlap_max,
+                post_overlap_hist = %post_arm.overlap_hist_str(),
+                inv_overlap_hist = %inv_arm.overlap_hist_str(),
+                total_ms = t_post.elapsed().as_millis() as u64,
+                "lookup_arm_comparison"
+            );
+        }
+
+        Ok(served)
+    }
+
+    /// Score against the durable co-liker profile (`ucl:`) for a user the live path could
+    /// not serve.
+    ///
+    /// Returns:
+    /// - `Ok(None)` when there is no profile, **or** when only shadow mode is on. In shadow
+    ///   mode the arm is fully computed and logged, then discarded, so the caller falls
+    ///   through to its normal early-exit and the response is byte-identical to today.
+    /// - `Ok(Some(result))` only when `durable_profile_enabled` is set (Phase C).
+    ///
+    /// The emitted `durable_profile_shadow` line is the Phase B deliverable: it carries the
+    /// `overlap_count` mean/max/histogram, which is what determines whether a ~128-member
+    /// profile distorts `paths_boost = overlap_count^num_paths_power` relative to the live
+    /// arm, versus merely rescaling it.
+    async fn try_durable_profile(
+        &self,
+        user_hash: &str,
+        algo_id: i32,
+        params: &LinkLonkParams,
+        audit: Option<&mut AuditCollector>,
+    ) -> Result<Option<ScoringResult>> {
+        let shadow_start = Instant::now();
+
+        let Some(profile) = self.coliker.get_durable_profile(user_hash).await? else {
+            return Ok(None);
+        };
+        let profile_size = profile.len();
+
+        // Shadow runs must not contribute to an audit trail for a response they do not
+        // affect; only the serving path gets the collector.
+        let serving = self.config.durable_profile_enabled;
+        let result = self
+            .profile_scorer
+            .score(
+                user_hash,
+                algo_id,
+                &profile,
+                params,
+                if serving { audit } else { None },
+            )
+            .await?;
+
+        info!(
+            user_hash = %&user_hash[..8.min(user_hash.len())],
+            algo_id,
+            serving,
+            profile_size,
+            min_post_likes = self.config.durable_profile_min_post_likes,
+            max_likers_per_post = self.config.durable_profile_max_likers_per_post,
+            scored_count = result.scored_count,
+            posts_checked = result.posts_checked,
+            posts_skipped_no_likers = result.posts_skipped_no_likers,
+            posts_skipped_few_likers = result.posts_skipped_few_likers,
+            posts_skipped_low_overlap = result.posts_skipped_low_overlap,
+            overlap_mean = format!("{:.2}", result.overlap_mean()),
+            overlap_max = result.overlap_max,
+            overlap_observed = result.overlap_observed(),
+            overlap_hist = %result.overlap_hist_str(),
+            scoring_time_ms = format!("{:.2}", result.scoring_time_ms),
+            total_time_ms = shadow_start.elapsed().as_millis() as u64,
+            "durable_profile_shadow"
+        );
+
+        if serving {
+            Ok(Some(result))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Get cached posts from Redis with diversity re-ranking.
     async fn get_cached_posts(
         &self,
@@ -291,6 +834,9 @@ impl LinkLonkAlgorithm {
         limit: usize,
         cursor: Option<&str>,
     ) -> Result<Vec<ScoredPost>> {
+        // The Redis result cache stores only (score, post_id); interleaving attribution for
+        // cached pages comes from the `fsc:` tag instead, not from here.
+        let ranker_by_post: std::collections::HashMap<String, String> = Default::default();
         // Parse cursor to get max score
         let (max_score, offset) = Self::parse_cursor(cursor);
 
@@ -315,9 +861,9 @@ impl LinkLonkAlgorithm {
         }
 
         // Get URIs for all candidate posts
-        let ids_to_lookup: Vec<i64> = cursor_filtered
+        let ids_to_lookup: Vec<String> = cursor_filtered
             .iter()
-            .filter_map(|(_, post_id)| post_id.parse::<i64>().ok())
+            .map(|(_, post_id)| post_id.clone())
             .collect();
 
         let id_to_uri = self
@@ -330,8 +876,7 @@ impl LinkLonkAlgorithm {
         let post_uris: FxHashMap<String, String> = cursor_filtered
             .iter()
             .filter_map(|(_, post_id)| {
-                let id = post_id.parse::<i64>().ok()?;
-                let uri = id_to_uri.get(&id)?.clone();
+                let uri = id_to_uri.get(post_id)?.clone();
                 Some((post_id.clone(), uri))
             })
             .collect();
@@ -342,6 +887,8 @@ impl LinkLonkAlgorithm {
             max_posts_per_author: self.config.max_posts_per_author,
             diminishing_factor: self.config.author_diminishing_factor,
             mmr_lambda: self.config.diversity_mmr_lambda,
+            // Interleaving sets this per request; default ordering behaviour otherwise.
+            preserve_order: self.config.diversity_preserve_order,
         };
 
         let diversity_result =
@@ -352,6 +899,9 @@ impl LinkLonkAlgorithm {
             .posts
             .into_iter()
             .map(|(score, post_id, uri)| ScoredPost {
+                // Carry the interleaving attribution alongside the post so the response layer
+                // can credit engagement to the right ranker.
+                ranker: ranker_by_post.get(&post_id).cloned(),
                 uri,
                 post_id,
                 score,
@@ -369,6 +919,8 @@ impl LinkLonkAlgorithm {
         scored_posts: &[(f64, String)],
         limit: usize,
         cursor: Option<&str>,
+        ranker_by_post: &std::collections::HashMap<String, String>,
+        requires_preserved_order: bool,
     ) -> Result<Vec<ScoredPost>> {
         let (max_score, offset) = Self::parse_cursor(cursor);
 
@@ -385,9 +937,9 @@ impl LinkLonkAlgorithm {
         }
 
         // Get URIs for all candidate posts (needed for diversity author extraction)
-        let ids_to_lookup: Vec<i64> = cursor_filtered
+        let ids_to_lookup: Vec<String> = cursor_filtered
             .iter()
-            .filter_map(|(_, post_id)| post_id.parse::<i64>().ok())
+            .map(|(_, post_id)| post_id.clone())
             .collect();
 
         let id_to_uri = self
@@ -400,8 +952,7 @@ impl LinkLonkAlgorithm {
         let post_uris: FxHashMap<String, String> = cursor_filtered
             .iter()
             .filter_map(|(_, post_id)| {
-                let id = post_id.parse::<i64>().ok()?;
-                let uri = id_to_uri.get(&id)?.clone();
+                let uri = id_to_uri.get(post_id)?.clone();
                 Some((post_id.clone(), uri))
             })
             .collect();
@@ -412,6 +963,11 @@ impl LinkLonkAlgorithm {
             max_posts_per_author: self.config.max_posts_per_author,
             diminishing_factor: self.config.author_diminishing_factor,
             mmr_lambda: self.config.diversity_mmr_lambda,
+            // Interleaving sets this per request; default ordering behaviour otherwise.
+            // Enforced, not just configured: an interleaved draft is meaningless
+            // if diversity re-sorts it, so forgetting the env var cannot
+            // silently invalidate an experiment.
+            preserve_order: self.config.diversity_preserve_order || requires_preserved_order,
         };
 
         let diversity_result =
@@ -429,6 +985,9 @@ impl LinkLonkAlgorithm {
             .posts
             .into_iter()
             .map(|(score, post_id, uri)| ScoredPost {
+                // Carry the interleaving attribution alongside the post so the response layer
+                // can credit engagement to the right ranker.
+                ranker: ranker_by_post.get(&post_id).cloned(),
                 uri,
                 post_id,
                 score,

--- a/crates/graze-api/src/algorithm/params.rs
+++ b/crates/graze-api/src/algorithm/params.rs
@@ -21,7 +21,7 @@ pub struct LinkLonkParams {
     pub min_co_likes: usize,         // Minimum shared likes to be considered a source
 
     // Time windowing
-    pub time_window_hours: f64, // 7 days default: sample user likes from this window (up to max_user_likes)
+    pub time_window_hours: f64, // 6 days default: sample user likes from this window (up to max_user_likes)
     pub recency_half_life_hours: f64, // 1 day default (aggressive decay for fresh content)
 
     // Scoring adjustments
@@ -61,7 +61,7 @@ impl Default for LinkLonkParams {
             max_sources_per_post: 500, // Increased from 100 to capture more co-likers
             max_total_sources: 10000,  // Curator search space: at least 10k (main For You–style)
             min_co_likes: 1,
-            time_window_hours: 168.0, // 7 days
+            time_window_hours: 144.0, // 6 days
             recency_half_life_hours: 24.0,
             specificity_power: 1.0,
             popularity_power: 1.0,
@@ -225,7 +225,7 @@ mod tests {
     fn test_default_params() {
         let params = LinkLonkParams::default();
         assert_eq!(params.max_user_likes, 500);
-        assert_eq!(params.time_window_hours, 168.0);
+        assert_eq!(params.time_window_hours, 144.0);
         assert_eq!(params.result_ttl_seconds, 300);
     }
 
@@ -256,7 +256,7 @@ mod tests {
         let args = params.to_lua_args(1000000.0, true, false);
         assert_eq!(args.len(), 17);
         assert_eq!(args[0], "500"); // max_user_likes
-        assert_eq!(args[4], "604800"); // time_window_seconds (7 * 24 * 3600)
+        assert_eq!(args[4], "518400"); // time_window_seconds (6 * 24 * 3600)
         assert_eq!(args[11], "1"); // use_precomputed_colikes
         assert_eq!(args[13], "0"); // use_algo_likers
         assert_eq!(args[14], "0.3"); // num_paths_power

--- a/crates/graze-api/src/algorithm/proof.rs
+++ b/crates/graze-api/src/algorithm/proof.rs
@@ -414,17 +414,15 @@ impl ProofCollector {
         let uri_start = Instant::now();
 
         // Collect all post IDs that need URI resolution
-        let mut post_ids: Vec<i64> = Vec::new();
+        let mut post_ids: Vec<String> = Vec::new();
         for (post_id, _) in &self.user_likes {
-            if let Ok(id) = post_id.parse::<i64>() {
-                post_ids.push(id);
-            }
+            post_ids.push(post_id.clone());
         }
         for post in &self.scored_posts {
-            if let Ok(id) = post.post_id.parse::<i64>() {
-                post_ids.push(id);
-            }
+            post_ids.push(post.post_id.clone());
         }
+        post_ids.sort();
+        post_ids.dedup();
 
         // Batch resolve URIs
         let id_to_uri = self
@@ -445,8 +443,7 @@ impl ProofCollector {
             .iter()
             .take(20) // Sample first 20
             .map(|(post_id, ts)| {
-                let id = post_id.parse::<i64>().ok();
-                let uri = id.and_then(|i| id_to_uri.get(&i).cloned());
+                let uri = id_to_uri.get(post_id).cloned();
                 LikedPostProof {
                     post_id: post_id.clone(),
                     uri,
@@ -473,8 +470,7 @@ impl ProofCollector {
                             .iter()
                             .take(5)
                             .map(|(post_id, coliker_time, user_time)| {
-                                let id = post_id.parse::<i64>().ok();
-                                let uri = id.and_then(|i| id_to_uri.get(&i).cloned());
+                                let uri = id_to_uri.get(post_id).cloned();
                                 SharedPostProof {
                                     post_id: post_id.clone(),
                                     uri,
@@ -502,8 +498,7 @@ impl ProofCollector {
             .iter()
             .take(20)
             .map(|p| {
-                let id = p.post_id.parse::<i64>().ok();
-                let uri = id.and_then(|i| id_to_uri.get(&i).cloned());
+                let uri = id_to_uri.get(&p.post_id).cloned();
                 let author_did = uri.as_ref().and_then(|u| {
                     u.strip_prefix("at://")
                         .and_then(|s| s.split('/').next())

--- a/crates/graze-api/src/algorithm/scorer.rs
+++ b/crates/graze-api/src/algorithm/scorer.rs
@@ -9,13 +9,15 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use rand::seq::SliceRandom;
-use rand::thread_rng;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::debug;
 
 use crate::algorithm::liker_cache::LikerCache;
 use crate::algorithm::params::LinkLonkParams;
 use crate::audit::{AuditCollector, PostBreakdownData};
+use rand::Rng;
+
+use crate::algorithm::walk;
 use crate::config::Config;
 use crate::error::Result;
 use graze_common::{Keys, RedisClient, DEFAULT_RETENTION_DAYS};
@@ -23,8 +25,26 @@ use graze_common::{Keys, RedisClient, DEFAULT_RETENTION_DAYS};
 /// Maximum results to return from scorer (early termination optimization).
 const DEFAULT_MAX_SCORER_RESULTS: usize = 500;
 
+/// Overlap-count histogram buckets: `1, 2, 3-4, 5-8, 9-16, 17-32, 33-64, 65+`.
+pub const OVERLAP_BUCKETS: usize = 8;
+
+/// Bucket an `overlap_count` for the [`ScoringResult::overlap_hist`] histogram.
+#[inline]
+fn overlap_bucket(n: usize) -> usize {
+    match n {
+        0..=1 => 0,
+        2 => 1,
+        3..=4 => 2,
+        5..=8 => 3,
+        9..=16 => 4,
+        17..=32 => 5,
+        33..=64 => 6,
+        _ => 7,
+    }
+}
+
 /// Result of scoring operation, including the scored posts themselves.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ScoringResult {
     /// The scored posts: (score, post_id)
     pub scored_posts: Vec<(f64, String)>,
@@ -36,6 +56,72 @@ pub struct ScoringResult {
     /// Cache statistics for this scoring run
     pub cache_hits: usize,
     pub cache_misses: usize,
+    /// Candidates dropped by `min_overlapping_colikers`. Previously invisible, and needed
+    /// to tell "no reachable candidates" apart from "reachable but too thinly overlapped".
+    pub posts_skipped_low_overlap: usize,
+    /// Sum of `overlap_count` over scored posts. Use [`Self::overlap_mean`] rather than
+    /// dividing by `scored_count`, which is truncated to `DEFAULT_MAX_SCORER_RESULTS`.
+    pub overlap_sum: usize,
+    /// Largest `overlap_count` seen on a scored post.
+    pub overlap_max: usize,
+    /// True when this result is an interleaved draft, so the order carries the ranker
+    /// assignment and **must not** be re-sorted downstream.
+    ///
+    /// Enforced rather than merely configured: forgetting `DIVERSITY_PRESERVE_ORDER` would let
+    /// diversity re-sort by adjusted score, scrambling attribution and silently invalidating the
+    /// experiment rather than producing an obvious failure.
+    pub requires_preserved_order: bool,
+    /// Which ranker produced each scored post, keyed by post id.
+    ///
+    /// A map rather than a parallel vector deliberately: diversity filters and reorders the
+    /// scored list, and a map survives both without needing to be threaded through every
+    /// transformation. Empty outside interleaving experiments.
+    pub ranker_by_post: std::collections::HashMap<String, String>,
+    /// Distribution of `overlap_count` over scored posts. `overlap_count` feeds a
+    /// *nonlinear* `paths_boost = overlap_count^num_paths_power`, so a durable profile
+    /// (~128 co-likers) versus a live one (~127 but drawn from 6 days) can shift ranking
+    /// shape rather than merely rescale it. This histogram is what makes that visible.
+    pub overlap_hist: [u32; OVERLAP_BUCKETS],
+    /// Fraction of the co-liker seed retained by per-feed author faceting, when that ranker ran.
+    ///
+    /// Carried on the result so a readout can tell a *ranking* effect apart from a *coverage*
+    /// collapse: a keep rate near zero means the treatment was effectively "no personalization",
+    /// which would otherwise look like a ranking finding.
+    pub seed_keep_rate: Option<f64>,
+}
+
+impl ScoringResult {
+    /// Number of posts the overlap stats were gathered over.
+    ///
+    /// This is the count *before* `post_scores` is truncated to
+    /// `DEFAULT_MAX_SCORER_RESULTS`, so it can exceed `scored_count`. Deriving it from the
+    /// histogram keeps [`Self::overlap_mean`] exact without a redundant counter.
+    pub fn overlap_observed(&self) -> usize {
+        self.overlap_hist.iter().map(|c| *c as usize).sum()
+    }
+
+    /// Mean `overlap_count` across posts that cleared the overlap gate and scored.
+    pub fn overlap_mean(&self) -> f64 {
+        let observed = self.overlap_observed();
+        if observed == 0 {
+            0.0
+        } else {
+            self.overlap_sum as f64 / observed as f64
+        }
+    }
+
+    /// Histogram rendered for structured logs, e.g. `1:4,2:9,3-4:2`.
+    pub fn overlap_hist_str(&self) -> String {
+        const LABELS: [&str; OVERLAP_BUCKETS] =
+            ["1", "2", "3-4", "5-8", "9-16", "17-32", "33-64", "65+"];
+        self.overlap_hist
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| **c > 0)
+            .map(|(i, c)| format!("{}:{}", LABELS[i], c))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
 }
 
 /// Scorer for the inverted LinkLonk algorithm.
@@ -52,6 +138,17 @@ pub struct Scorer {
     min_overlapping_colikers: usize,
     read_only: bool,
     liker_cache_enabled: bool,
+    inverted_coliker_like_days: u32,
+    inverted_coliker_like_limit: usize,
+    /// Sampled-walk knobs. Flattened like the rest so the hot path never dereferences the config.
+    walk_count: usize,
+    walk_max_users: usize,
+    walk_user_like_limit: usize,
+    walk_early_stop_np: usize,
+    walk_early_stop_nv: u32,
+    walk_popularity_power: f64,
+    walk_min_visits: u32,
+    walk_min_seed_for_sampling: usize,
 }
 
 impl Scorer {
@@ -67,48 +164,372 @@ impl Scorer {
             min_overlapping_colikers: config.min_overlapping_colikers,
             read_only: config.read_only_mode,
             liker_cache_enabled: config.liker_cache_enabled,
+            inverted_coliker_like_days: config.inverted_coliker_like_days,
+            inverted_coliker_like_limit: config.inverted_coliker_like_limit,
+            walk_count: config.walk_count,
+            walk_max_users: config.walk_max_users,
+            walk_user_like_limit: config.walk_user_like_limit,
+            walk_early_stop_np: config.walk_early_stop_np,
+            walk_early_stop_nv: config.walk_early_stop_nv,
+            walk_popularity_power: config.walk_popularity_power,
+            walk_min_visits: config.walk_min_visits,
+            walk_min_seed_for_sampling: config.walk_min_seed_for_sampling,
         }
     }
 
-    /// Score posts for a user using the inverted algorithm.
+    /// Score by walking the like graph **co-liker-first** instead of post-first.
     ///
-    /// If `audit` is provided, detailed scoring information will be collected.
-    /// Returns scored posts directly to avoid re-fetching from Redis.
-    pub async fn score(
+    /// # Why
+    ///
+    /// [`Self::score`] iterates candidates and fetches `pl:{post}` for each one. That costs one
+    /// key per candidate — with `INVERTED_MAX_POSTS_TO_SCORE = 0` (unlimited) that measured
+    /// **~118,000 Redis ops for a single request** on algo 2323 (19,667 candidates). It also
+    /// takes only the `max_likers_per_post` *most recent* likers of each post, so a co-liker who
+    /// liked it earlier is invisible: **72–100% of the candidates that actually overlap have more
+    /// than 30 likers**, and modelling `min(1, 30/L)` reproduced production almost exactly.
+    ///
+    /// This method inverts the traversal: for each of the user's ~128 co-likers, read their
+    /// recent likes from `ul:{coliker}` and intersect with the pool. Cost scales with the number
+    /// of **co-likers** rather than candidates, and one `ZREVRANGEBYSCORE` returns 500 members as
+    /// cheaply as 30 — so the per-post truncation bias disappears entirely.
+    ///
+    /// Measured on 10 live seeded users against algo 2323: **1.88× the scoreable coverage** for
+    /// **810–3,570 ops instead of ~118,000 (33–145× fewer)**.
+    ///
+    /// # What replaces the old bias
+    ///
+    /// Truncation moves from "the N most recent likers of each post" to "the N most recent likes
+    /// of each co-liker" (`inverted_coliker_like_limit`). That is far weaker: the median seeded
+    /// user has only ~16 likes in the window so it rarely binds, it is one cap per *person*
+    /// rather than per *post* so it cannot systematically hide old likes on popular content, and
+    /// because ops do not scale with the limit it can be set generously for free.
+    ///
+    /// # Counter semantics (for comparing arms)
+    ///
+    /// `scored_count` is directly comparable to [`Self::score`]. `posts_checked` is the pool size
+    /// after exclusions, as there. `posts_skipped_no_likers` becomes "pool posts no co-liker
+    /// reached" — the analogous dead-end, though not the identical measurement. Cache counters are
+    /// unused: this path is not backed by the post-keyed `LikerCache` (a co-liker-keyed cache is a
+    /// follow-up; the op count is already small enough that it was not worth the risk in v1).
+    /// The configured seed floor below which sampling is not worth its variance.
+    pub fn walk_min_seed_for_sampling(&self) -> usize {
+        self.walk_min_seed_for_sampling
+    }
+
+    /// Whether the user has at least `floor` likes in the scoring window.
+    ///
+    /// Deliberately a `ZCARD`-style existence check rather than a full fetch: the caller only needs to
+    /// choose a strategy, and paying for the seed twice would hand back the latency sampling is meant
+    /// to save.
+    pub async fn seed_size_at_least(
+        &self,
+        user_hash: &str,
+        params: &LinkLonkParams,
+        floor: usize,
+    ) -> Result<bool> {
+        if floor == 0 {
+            return Ok(true);
+        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        let min_time = now - params.time_window_hours * 3600.0;
+        let keys = Keys::user_likes_retention(user_hash, DEFAULT_RETENTION_DAYS);
+        let seed = self
+            .redis
+            .zrevrangebyscore_merged(&keys, now, min_time, floor)
+            .await?;
+        Ok(seed.len() >= floor)
+    }
+
+    /// Score by sampled random walk over the like graph.
+    ///
+    /// See `algorithm/walk.rs` for why sampling escapes the cost/bias dilemma that both enumerative
+    /// paths hit. Two batched phases rather than a round trip per step:
+    ///
+    /// 1. Fetch liker lists for the user's seed posts, and sample `(seed, co-liker)` pairs from them
+    ///    with the walk budget allocated by seed degree.
+    /// 2. Fetch the sampled co-likers' like lists in one pipeline, and tally visits that land in the
+    ///    feed pool.
+    ///
+    /// Ignores `source_weights` entirely — the walk *is* the derivation, so there is nothing to reuse
+    /// from the co-liker path. Deterministic per (user, day), like every other sampling site, so the
+    /// interleaving harness's null stays null.
+    pub async fn score_sampled_walk(
         &self,
         user_hash: &str,
         algo_id: i32,
-        source_weights: &HashMap<String, f64>,
         params: &LinkLonkParams,
-        mut audit: Option<&mut AuditCollector>,
     ) -> Result<ScoringResult> {
         let start_time = Instant::now();
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs_f64();
-        let time_window_seconds = params.time_window_hours * 3600.0;
-        let min_time = now - time_window_seconds;
+        let min_time = now - params.time_window_hours * 3600.0;
+
+        let algo_posts_key = Keys::algo_posts(algo_id);
+        let algo_counts_key = Keys::algo_posts_counts(algo_id);
+        let user_likes_keys = Keys::user_likes_retention(user_hash, DEFAULT_RETENTION_DAYS);
+        let user_seen_key = Keys::user_seen(user_hash);
+        let seen_limit = if params.max_seen_posts > 0 {
+            (params.max_seen_posts as isize) - 1
+        } else {
+            -1
+        };
+
+        let (algo_posts_result, user_likes_result, seen_posts_result) = tokio::join!(
+            self.redis.smembers(&algo_posts_key),
+            self.redis.zrevrangebyscore_merged(
+                &user_likes_keys,
+                now,
+                min_time,
+                params.max_user_likes
+            ),
+            self.redis.zrevrange(&user_seen_key, 0, seen_limit)
+        );
+
+        let algo_posts: Vec<String> = algo_posts_result?;
+        let seed: Vec<(String, f64)> = user_likes_result?;
+        if algo_posts.is_empty() || seed.is_empty() {
+            return Ok(ScoringResult {
+                scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
+                ..Default::default()
+            });
+        }
+
+        let mut excluded: FxHashSet<String> = seed.iter().map(|(id, _)| id.clone()).collect();
+        excluded.extend(seen_posts_result.unwrap_or_default());
+        let pool: FxHashSet<&str> = algo_posts
+            .iter()
+            .map(|s| s.as_str())
+            .filter(|p| !excluded.contains(*p))
+            .collect();
+        let pool_size = pool.len();
+        if pool_size == 0 {
+            return Ok(ScoringResult {
+                scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
+                ..Default::default()
+            });
+        }
+
+        // Phase 1: liker lists for the seed. Bounded per post by the walk's own sampling rather than
+        // by a hard truncation, so this fetch is deliberately generous — the bias the post-first path
+        // carries comes from cutting these lists to the 30 most recent.
+        let seed_key_groups: Vec<Vec<String>> = seed
+            .iter()
+            .map(|(id, _)| Keys::post_likers_retention_bounded(id, DEFAULT_RETENTION_DAYS))
+            .collect();
+        let seed_likers = self
+            .redis
+            .zrevrangebyscore_merged_multi(
+                &seed_key_groups,
+                now,
+                min_time,
+                self.inverted_coliker_like_limit,
+            )
+            .await?;
+
+        // Only likers who liked BEFORE the user count, matching every other path: a person who liked
+        // after you is not evidence that they led you anywhere.
+        let candidates_per_seed: Vec<Vec<String>> = seed_likers
+            .into_iter()
+            .zip(seed.iter())
+            .map(|(likers, (_, user_like_time))| {
+                likers
+                    .into_iter()
+                    .filter(|(h, t)| t < user_like_time && h != user_hash)
+                    .map(|(h, _)| h)
+                    .collect()
+            })
+            .collect();
+
+        let degrees: Vec<usize> = candidates_per_seed.iter().map(|v| v.len()).collect();
+        let budget = walk::allocate_walks(&degrees, self.walk_count);
+
+        // Sample (seed, co-liker) pairs. Recording which seed produced each co-liker is what lets the
+        // multi-hit booster see breadth later.
+        let mut rng = crate::algorithm::coliker::daily_rng(user_hash);
+        let mut sampled: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        for (seed_idx, walks) in budget.iter().enumerate() {
+            let pool_of_likers = &candidates_per_seed[seed_idx];
+            if pool_of_likers.is_empty() || *walks == 0 {
+                continue;
+            }
+            for _ in 0..*walks {
+                let pick = &pool_of_likers[rng.gen_range(0..pool_of_likers.len())];
+                let entry = sampled.entry(pick.clone()).or_default();
+                if !entry.contains(&seed_idx) {
+                    entry.push(seed_idx);
+                }
+                if sampled.len() >= self.walk_max_users {
+                    break;
+                }
+            }
+            if sampled.len() >= self.walk_max_users {
+                break;
+            }
+        }
+
+        if sampled.is_empty() {
+            return Ok(ScoringResult {
+                posts_checked: pool_size,
+                posts_skipped_no_likers: pool_size,
+                scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
+                ..Default::default()
+            });
+        }
+
+        // Phase 2: one pipelined fetch of the sampled co-likers' likes.
+        let walkers: Vec<&String> = sampled.keys().collect();
+        let walker_key_groups: Vec<Vec<String>> = walkers
+            .iter()
+            .map(|h| Keys::user_likes_retention(h, self.inverted_coliker_like_days))
+            .collect();
+        let walker_likes = self
+            .redis
+            .zrevrangebyscore_merged_multi(
+                &walker_key_groups,
+                now,
+                min_time,
+                self.walk_user_like_limit,
+            )
+            .await?;
+
+        let mut tallies: FxHashMap<String, walk::VisitTally> = FxHashMap::default();
+        let mut visits = 0usize;
+        let mut early_stopped = false;
+        for (i, likes) in walker_likes.into_iter().enumerate() {
+            let seeds_reached = &sampled[walkers[i]];
+            for (post_id, _) in likes {
+                if !pool.contains(post_id.as_str()) {
+                    continue;
+                }
+                visits += 1;
+                let tally = tallies.entry(post_id).or_default();
+                // One slot per originating seed, so `per_seed` length is the breadth the booster
+                // rewards and its values are the depth it discounts.
+                while tally.per_seed.len() < seeds_reached.len() {
+                    tally.per_seed.push(0);
+                }
+                for slot in tally.per_seed.iter_mut().take(seeds_reached.len()) {
+                    *slot += 1;
+                }
+            }
+            if walk::early_stop_reached(&tallies, self.walk_early_stop_np, self.walk_early_stop_nv)
+            {
+                early_stopped = true;
+                break;
+            }
+        }
+
+        if tallies.is_empty() {
+            return Ok(ScoringResult {
+                posts_checked: pool_size,
+                posts_skipped_no_likers: pool_size,
+                scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
+                ..Default::default()
+            });
+        }
+
+        // Liker counts only for visited candidates — the same saving the inverted path found.
+        let visited: Vec<&str> = tallies.keys().map(|s| s.as_str()).collect();
+        let count_strs = self.redis.hmget(&algo_counts_key, &visited).await?;
+        let liker_counts: FxHashMap<String, usize> = visited
+            .iter()
+            .zip(count_strs)
+            .map(|(id, opt)| {
+                (
+                    (*id).to_string(),
+                    opt.and_then(|s| s.parse().ok()).unwrap_or(0),
+                )
+            })
+            .collect();
+
+        let below_min: usize = liker_counts
+            .values()
+            .filter(|c| **c < self.min_post_likes)
+            .count();
+        let mut ranked = walk::rank_from_tallies(
+            &tallies,
+            &liker_counts,
+            self.walk_popularity_power,
+            self.walk_min_visits,
+        );
+        ranked.retain(|(_, id)| liker_counts.get(id).copied().unwrap_or(0) >= self.min_post_likes);
+        ranked.truncate(DEFAULT_MAX_SCORER_RESULTS);
+
+        // Mean breadth is the load-bearing number for this whole ranker. The multi-hit booster only
+        // does anything if candidates are reached from *several* seeds, and the enumerative paths
+        // measure `overlap_mean` at approximately 1.0 — i.e. they essentially never see breadth. If
+        // this comes back near 1.0 too, the walk is not finding structure the other paths miss and the
+        // booster is inert, which would make a null result expected rather than surprising.
+        let breadth_sum: usize = tallies.values().map(|t| t.breadth()).sum();
+        let breadth_mean = breadth_sum as f64 / tallies.len().max(1) as f64;
+        let multi_seed_candidates = tallies.values().filter(|t| t.breadth() > 1).count();
+
+        let scored_count = ranked.len();
+        let scoring_time_ms = start_time.elapsed().as_secs_f64() * 1000.0;
+        debug!(
+            user_hash = %&user_hash[..8.min(user_hash.len())],
+            algo_id,
+            seed = seed.len(),
+            breadth_mean = format!("{:.3}", breadth_mean),
+            multi_seed_candidates,
+            budget_spent = budget.iter().sum::<usize>(),
+            walkers = walkers.len(),
+            pool_size,
+            visits,
+            candidates = tallies.len(),
+            below_min_post_likes = below_min,
+            early_stopped,
+            scored_count,
+            scoring_time_ms = format!("{:.2}", scoring_time_ms),
+            "scorer_sampled_walk_completed"
+        );
+
+        Ok(ScoringResult {
+            scored_count,
+            scored_posts: ranked,
+            posts_checked: pool_size,
+            posts_skipped_few_likers: below_min,
+            scoring_time_ms,
+            ..Default::default()
+        })
+    }
+
+    pub async fn score_inverted(
+        &self,
+        user_hash: &str,
+        algo_id: i32,
+        source_weights: &HashMap<String, f64>,
+        params: &LinkLonkParams,
+        audit: Option<&mut AuditCollector>,
+    ) -> Result<ScoringResult> {
+        let start_time = Instant::now();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        let min_time = now - params.time_window_hours * 3600.0;
         let recency_half_life_seconds = params.recency_half_life_hours * 3600.0;
 
-        // Convert to FxHashMap for faster lookups in the hot scoring loop
-        let source_weights: FxHashMap<&String, f64> =
+        if source_weights.is_empty() {
+            return Ok(ScoringResult {
+                scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
+                ..Default::default()
+            });
+        }
+
+        let source_weights_fx: FxHashMap<&String, f64> =
             source_weights.iter().map(|(k, v)| (k, *v)).collect();
 
-        // Keys for data
-        let result_key = Keys::cached_result(algo_id, user_hash);
         let algo_posts_key = Keys::algo_posts(algo_id);
         let algo_counts_key = Keys::algo_posts_counts(algo_id);
         let user_likes_keys = Keys::user_likes_retention(user_hash, DEFAULT_RETENTION_DAYS);
         let user_seen_key = Keys::user_seen(user_hash);
 
-        // Step 1: Load algo posts, user's likes, and seen posts IN PARALLEL
-        // If seed_sample_pool > 0, fetch a larger pool for random sampling
-        let fetch_limit = if params.seed_sample_pool > 0 {
-            params.seed_sample_pool.max(params.max_user_likes)
-        } else {
-            params.max_user_likes
-        };
         let seen_limit = if params.max_seen_posts > 0 {
             (params.max_seen_posts as isize) - 1
         } else {
@@ -116,163 +537,200 @@ impl Scorer {
         };
         let (algo_posts_result, user_likes_result, seen_posts_result) = tokio::join!(
             self.redis.smembers(&algo_posts_key),
-            self.redis
-                .zrevrangebyscore_merged(&user_likes_keys, now, min_time, fetch_limit),
+            self.redis.zrevrangebyscore_merged(
+                &user_likes_keys,
+                now,
+                min_time,
+                params.max_user_likes
+            ),
             self.redis.zrevrange(&user_seen_key, 0, seen_limit)
         );
 
         let algo_posts: Vec<String> = algo_posts_result?;
-        let mut user_likes = user_likes_result?;
-        let seen_posts: Vec<String> = seen_posts_result.unwrap_or_default();
-
-        // Random seed sampling: shuffle and truncate to max_user_likes
-        if params.seed_sample_pool > 0 && user_likes.len() > params.max_user_likes {
-            user_likes.shuffle(&mut thread_rng());
-            user_likes.truncate(params.max_user_likes);
-        }
-
         if algo_posts.is_empty() {
-            debug!(
-                user_hash = %&user_hash[..8.min(user_hash.len())],
-                algo_id,
-                "early_exit: no candidates in algo posts set"
-            );
             return Ok(ScoringResult {
-                scored_posts: Vec::new(),
-                scored_count: 0,
-                posts_checked: 0,
-                posts_skipped_no_likers: 0,
-                posts_skipped_few_likers: 0,
                 scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
-                cache_hits: 0,
-                cache_misses: 0,
+                ..Default::default()
             });
         }
 
-        let mut excluded_posts: FxHashSet<String> =
-            user_likes.into_iter().map(|(id, _)| id).collect();
-        excluded_posts.extend(seen_posts);
+        let mut excluded: FxHashSet<String> =
+            user_likes_result?.into_iter().map(|(id, _)| id).collect();
+        excluded.extend(seen_posts_result.unwrap_or_default());
 
-        // Step 2: Filter posts (remove already liked or seen)
-        let mut candidates: Vec<String> = algo_posts
-            .into_iter()
-            .filter(|p| !excluded_posts.contains(p))
+        // The pool becomes a membership set rather than a list to iterate. This is the one
+        // structural requirement of the inverted path: testing membership with SISMEMBER per
+        // returned post would cost more than the scan it replaces, so the pool must be resident.
+        let pool: FxHashSet<&str> = algo_posts
+            .iter()
+            .map(|s| s.as_str())
+            .filter(|p| !excluded.contains(*p))
+            .collect();
+        let pool_size = pool.len();
+        if pool_size == 0 {
+            return Ok(ScoringResult {
+                scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
+                ..Default::default()
+            });
+        }
+
+        // One key group per co-liker. Bounded to `inverted_coliker_like_days` because pool posts
+        // are capped at SYNC_PREFERRED_MAX_AGE_HOURS (72h), so a like on a pool post cannot be
+        // older than that plus a margin — older shards can only return posts that fail the pool
+        // test anyway.
+        let colikers: Vec<&String> = source_weights.keys().collect();
+        let coliker_key_groups: Vec<Vec<String>> = colikers
+            .iter()
+            .map(|h| Keys::user_likes_retention(h, self.inverted_coliker_like_days))
             .collect();
 
-        if self.max_posts_to_score > 0 && candidates.len() > self.max_posts_to_score {
-            candidates.truncate(self.max_posts_to_score);
+        let fetched = self
+            .redis
+            .zrevrangebyscore_merged_multi(
+                &coliker_key_groups,
+                now,
+                min_time,
+                self.inverted_coliker_like_limit,
+            )
+            .await?;
+
+        // Invert: (co-liker → posts) becomes (post → co-likers), keeping only pool members.
+        let mut hits: FxHashMap<&str, Vec<(String, f64)>> = FxHashMap::default();
+        let mut coliker_likes_seen = 0usize;
+        for (i, likes) in fetched.into_iter().enumerate() {
+            let coliker = colikers[i];
+            for (post_id, like_time) in likes {
+                coliker_likes_seen += 1;
+                if let Some(pool_post) = pool.get(post_id.as_str()) {
+                    hits.entry(*pool_post)
+                        .or_default()
+                        .push((coliker.clone(), like_time));
+                }
+            }
         }
 
-        if candidates.is_empty() {
+        let posts_reached = hits.len();
+        if posts_reached == 0 {
             return Ok(ScoringResult {
-                scored_posts: Vec::new(),
-                scored_count: 0,
-                posts_checked: 0,
-                posts_skipped_no_likers: 0,
-                posts_skipped_few_likers: 0,
+                posts_checked: pool_size,
+                posts_skipped_no_likers: pool_size,
                 scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
-                cache_hits: 0,
-                cache_misses: 0,
+                ..Default::default()
             });
         }
 
-        // Step 3: Get pre-computed liker counts from hash (faster than ZCARD)
-        let post_id_refs: Vec<&str> = candidates.iter().map(|s| s.as_str()).collect();
-        let count_strs = self.redis.hmget(&algo_counts_key, &post_id_refs).await?;
-
-        // Parse counts, defaulting to 0 for missing entries
+        // Liker counts only for posts a co-liker actually reached — a few hundred instead of the
+        // whole pool. This is the second, quieter saving of the inversion.
+        let hit_ids: Vec<&str> = hits.keys().copied().collect();
+        let count_strs = self.redis.hmget(&algo_counts_key, &hit_ids).await?;
         let liker_counts: Vec<usize> = count_strs
             .into_iter()
             .map(|opt| opt.and_then(|s| s.parse().ok()).unwrap_or(0))
             .collect();
 
-        // Step 4: Filter by min likes and prepare fetch list
-        let mut posts_skipped_no_likers = 0;
-        let mut posts_skipped_few_likers = 0;
-        let mut posts_to_score: Vec<(&str, usize)> = Vec::with_capacity(candidates.len());
-
-        for (post_id, count) in candidates.iter().zip(liker_counts.iter()) {
-            if *count == 0 {
-                posts_skipped_no_likers += 1;
-            } else if *count < self.min_post_likes {
+        let mut posts_to_score: Vec<(&str, usize)> = Vec::with_capacity(hit_ids.len());
+        let mut all_likers: Vec<Vec<(String, f64)>> = Vec::with_capacity(hit_ids.len());
+        let mut posts_skipped_few_likers = 0usize;
+        for (post_id, count) in hit_ids.iter().zip(liker_counts.iter()) {
+            // A post reached by a co-liker has at least one liker by construction, so the
+            // "no likers" bucket cannot apply here; only min_post_likes can reject it.
+            if *count < self.min_post_likes {
                 posts_skipped_few_likers += 1;
-            } else {
-                posts_to_score.push((post_id.as_str(), *count));
+                continue;
+            }
+            if let Some(likers) = hits.remove(*post_id) {
+                posts_to_score.push((*post_id, *count));
+                all_likers.push(likers);
             }
         }
 
         if posts_to_score.is_empty() {
             return Ok(ScoringResult {
-                scored_posts: Vec::new(),
-                scored_count: 0,
-                posts_checked: candidates.len(),
-                posts_skipped_no_likers,
+                posts_checked: pool_size,
+                posts_skipped_no_likers: pool_size.saturating_sub(posts_reached),
                 posts_skipped_few_likers,
                 scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
-                cache_hits: 0,
-                cache_misses: 0,
+                ..Default::default()
             });
         }
 
-        // Step 5: Fetch likers - check local cache first, then batch fetch misses
-        let mut cache_hits = 0;
-        let mut cache_misses = 0;
-        let mut all_likers: Vec<Vec<(String, f64)>> = Vec::with_capacity(posts_to_score.len());
-        let mut cache_miss_indices: Vec<usize> = Vec::new();
-        let mut cache_miss_post_ids: Vec<&str> = Vec::new();
+        let (mut post_scores, posts_skipped_low_overlap, overlap_sum, overlap_max, overlap_hist) =
+            self.score_prepared(
+                &posts_to_score,
+                &all_likers,
+                &source_weights_fx,
+                params,
+                now,
+                recency_half_life_seconds,
+                audit,
+            );
 
-        // Check cache for each post
-        if self.liker_cache_enabled {
-            for (i, (post_id, _)) in posts_to_score.iter().enumerate() {
-                if let Some(entry) = self.liker_cache.get(post_id) {
-                    // Filter by time window - use owned version to avoid extra clone
-                    let filtered =
-                        LikerCache::filter_likers_by_time_owned(entry.likers, min_time, now);
-                    all_likers.push(filtered);
-                    cache_hits += 1;
-                } else {
-                    // Mark for fetching
-                    all_likers.push(Vec::new()); // Placeholder
-                    cache_miss_indices.push(i);
-                    cache_miss_post_ids.push(post_id);
-                    cache_misses += 1;
-                }
-            }
-        } else {
-            // Cache disabled - fetch all
-            for (post_id, _) in &posts_to_score {
-                all_likers.push(Vec::new());
-                cache_miss_indices.push(all_likers.len() - 1);
-                cache_miss_post_ids.push(post_id);
-            }
-            cache_misses = posts_to_score.len();
-        }
+        post_scores.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        post_scores.truncate(DEFAULT_MAX_SCORER_RESULTS);
+        let scored_count = post_scores.len();
+        let scoring_time_ms = start_time.elapsed().as_secs_f64() * 1000.0;
 
-        // Batch fetch cache misses from Redis using date-based keys
-        if !cache_miss_post_ids.is_empty() {
-            // Build date-based key groups for each post
-            let post_key_groups: Vec<Vec<String>> = cache_miss_post_ids
-                .iter()
-                .map(|post_id| Keys::post_likers_retention(post_id, DEFAULT_RETENTION_DAYS))
-                .collect();
+        debug!(
+            user_hash = %&user_hash[..8.min(user_hash.len())],
+            algo_id,
+            colikers = colikers.len(),
+            coliker_likes_seen,
+            pool_size,
+            posts_reached,
+            posts_skipped_few_likers,
+            posts_skipped_low_overlap,
+            scored_count,
+            // ops = one merged fetch per co-liker key group, plus SMEMBERS/likes/seen/HMGET
+            redis_key_groups = colikers.len(),
+            scoring_time_ms = format!("{:.2}", scoring_time_ms),
+            "scorer_inverted_completed"
+        );
 
-            // Fetch from all date-based keys and merge results per post
-            let fetched_likers = self
-                .redis
-                .zrevrangebyscore_merged_multi(
-                    &post_key_groups,
-                    now,
-                    min_time,
-                    self.max_likers_per_post,
-                )
-                .await?;
+        Ok(ScoringResult {
+            scored_posts: post_scores,
+            scored_count,
+            posts_checked: pool_size,
+            posts_skipped_no_likers: pool_size.saturating_sub(posts_reached),
+            posts_skipped_few_likers,
+            scoring_time_ms,
+            cache_hits: 0,
+            cache_misses: colikers.len(),
+            posts_skipped_low_overlap,
+            overlap_sum,
+            overlap_max,
+            overlap_hist,
+            seed_keep_rate: None,
+            ranker_by_post: Default::default(),
+            requires_preserved_order: false,
+        })
+    }
 
-            // Fill in results for scoring
-            for (idx, likers) in cache_miss_indices.iter().zip(fetched_likers.into_iter()) {
-                all_likers[*idx] = likers;
-            }
-        }
-
+    /// Score a prepared candidate set. **Both the post-first and co-liker-first paths call
+    /// this**, so the ranking math cannot diverge between them.
+    ///
+    /// Inputs are the two parallel arrays the two lookup strategies both produce:
+    /// `posts_to_score[i] = (post_id, total_liker_count)` and `all_likers[i] =
+    /// [(liker_hash, like_time), ...]` restricted to the retention/time window.
+    ///
+    /// Returns `(post_scores, posts_skipped_low_overlap, overlap_sum, overlap_max,
+    /// overlap_hist)`; sorting and truncation stay with the caller.
+    #[allow(clippy::too_many_arguments)]
+    fn score_prepared(
+        &self,
+        posts_to_score: &[(&str, usize)],
+        all_likers: &[Vec<(String, f64)>],
+        source_weights: &FxHashMap<&String, f64>,
+        params: &LinkLonkParams,
+        now: f64,
+        recency_half_life_seconds: f64,
+        mut audit: Option<&mut AuditCollector>,
+    ) -> (
+        Vec<(f64, String)>,
+        usize,
+        usize,
+        usize,
+        [u32; OVERLAP_BUCKETS],
+    ) {
         // Step 5b: Build corater rank map for decay (zero-cost when corater_decay == 0.0)
         // For each co-liker, ranks their likes across candidate posts by recency.
         // rank 0 = most recent like, rank 1 = second most recent, etc.
@@ -309,6 +767,12 @@ impl Scorer {
         let estimated_capacity =
             (posts_to_score.len() / 5).clamp(100, DEFAULT_MAX_SCORER_RESULTS * 2);
         let mut post_scores: Vec<(f64, String)> = Vec::with_capacity(estimated_capacity);
+
+        // Overlap observability, accumulated identically in both the audit and fast paths.
+        let mut posts_skipped_low_overlap = 0usize;
+        let mut overlap_sum = 0usize;
+        let mut overlap_max = 0usize;
+        let mut overlap_hist = [0u32; OVERLAP_BUCKETS];
 
         if let Some(ref mut a) = audit {
             // Audit-enabled path
@@ -352,10 +816,14 @@ impl Scorer {
 
                 // Skip posts without enough overlapping co-likers (prevents single-user contamination)
                 if overlap_count < self.min_overlapping_colikers {
+                    posts_skipped_low_overlap += 1;
                     continue;
                 }
 
                 if score > 0.0 {
+                    overlap_sum += overlap_count;
+                    overlap_max = overlap_max.max(overlap_count);
+                    overlap_hist[overlap_bucket(overlap_count)] += 1;
                     // (1) Num paths exponent: boost posts with more distinct co-liker paths
                     let num_paths = overlap_count.max(1) as f64;
                     let paths_boost = num_paths.powf(params.num_paths_power);
@@ -413,10 +881,14 @@ impl Scorer {
 
                 // Skip posts without enough overlapping co-likers (prevents single-user contamination)
                 if overlap_count < self.min_overlapping_colikers {
+                    posts_skipped_low_overlap += 1;
                     continue;
                 }
 
                 if score > 0.0 {
+                    overlap_sum += overlap_count;
+                    overlap_max = overlap_max.max(overlap_count);
+                    overlap_hist[overlap_bucket(overlap_count)] += 1;
                     // (1) Num paths exponent: boost posts with more distinct co-liker paths
                     let num_paths = overlap_count.max(1) as f64;
                     let paths_boost = num_paths.powf(params.num_paths_power);
@@ -435,6 +907,229 @@ impl Scorer {
             }
         }
 
+        (
+            post_scores,
+            posts_skipped_low_overlap,
+            overlap_sum,
+            overlap_max,
+            overlap_hist,
+        )
+    }
+
+    /// Score posts for a user using the inverted algorithm.
+    ///
+    /// If `audit` is provided, detailed scoring information will be collected.
+    /// Returns scored posts directly to avoid re-fetching from Redis.
+    pub async fn score(
+        &self,
+        user_hash: &str,
+        algo_id: i32,
+        source_weights: &HashMap<String, f64>,
+        params: &LinkLonkParams,
+        audit: Option<&mut AuditCollector>,
+    ) -> Result<ScoringResult> {
+        let start_time = Instant::now();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        let time_window_seconds = params.time_window_hours * 3600.0;
+        let min_time = now - time_window_seconds;
+        let recency_half_life_seconds = params.recency_half_life_hours * 3600.0;
+
+        // Convert to FxHashMap for faster lookups in the hot scoring loop
+        let source_weights: FxHashMap<&String, f64> =
+            source_weights.iter().map(|(k, v)| (k, *v)).collect();
+
+        // Keys for data
+        let result_key = Keys::cached_result(algo_id, user_hash);
+        let algo_posts_key = Keys::algo_posts(algo_id);
+        let algo_counts_key = Keys::algo_posts_counts(algo_id);
+        let user_likes_keys = Keys::user_likes_retention(user_hash, DEFAULT_RETENTION_DAYS);
+        let user_seen_key = Keys::user_seen(user_hash);
+
+        // Step 1: Load algo posts, user's likes, and seen posts IN PARALLEL
+        // If seed_sample_pool > 0, fetch a larger pool for random sampling
+        let fetch_limit = if params.seed_sample_pool > 0 {
+            params.seed_sample_pool.max(params.max_user_likes)
+        } else {
+            params.max_user_likes
+        };
+        let seen_limit = if params.max_seen_posts > 0 {
+            (params.max_seen_posts as isize) - 1
+        } else {
+            -1
+        };
+        let (algo_posts_result, user_likes_result, seen_posts_result) = tokio::join!(
+            self.redis.smembers(&algo_posts_key),
+            self.redis
+                .zrevrangebyscore_merged(&user_likes_keys, now, min_time, fetch_limit),
+            self.redis.zrevrange(&user_seen_key, 0, seen_limit)
+        );
+
+        let algo_posts: Vec<String> = algo_posts_result?;
+        let mut user_likes = user_likes_result?;
+        let seen_posts: Vec<String> = seen_posts_result.unwrap_or_default();
+
+        // Random seed sampling: shuffle and truncate to max_user_likes.
+        //
+        // Deterministic per (user, day) for the same reason as the matching block in `coliker.rs`:
+        // a fresh draw per request made one ranker disagree with itself, which the interleaving
+        // self-check measured as a 6% spurious disagreement floor.
+        if params.seed_sample_pool > 0 && user_likes.len() > params.max_user_likes {
+            user_likes.shuffle(&mut crate::algorithm::coliker::daily_rng(user_hash));
+            user_likes.truncate(params.max_user_likes);
+        }
+
+        if algo_posts.is_empty() {
+            debug!(
+                user_hash = %&user_hash[..8.min(user_hash.len())],
+                algo_id,
+                "early_exit: no candidates in algo posts set"
+            );
+            return Ok(ScoringResult {
+                scored_posts: Vec::new(),
+                scored_count: 0,
+                posts_checked: 0,
+                posts_skipped_no_likers: 0,
+                posts_skipped_few_likers: 0,
+                scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
+                ..Default::default()
+            });
+        }
+
+        let mut excluded_posts: FxHashSet<String> =
+            user_likes.into_iter().map(|(id, _)| id).collect();
+        excluded_posts.extend(seen_posts);
+
+        // Step 2: Filter posts (remove already liked or seen)
+        let mut candidates: Vec<String> = algo_posts
+            .into_iter()
+            .filter(|p| !excluded_posts.contains(p))
+            .collect();
+
+        if self.max_posts_to_score > 0 && candidates.len() > self.max_posts_to_score {
+            candidates.truncate(self.max_posts_to_score);
+        }
+
+        if candidates.is_empty() {
+            return Ok(ScoringResult {
+                scored_posts: Vec::new(),
+                scored_count: 0,
+                posts_checked: 0,
+                posts_skipped_no_likers: 0,
+                posts_skipped_few_likers: 0,
+                scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
+                ..Default::default()
+            });
+        }
+
+        // Step 3: Get pre-computed liker counts from hash (faster than ZCARD)
+        let post_id_refs: Vec<&str> = candidates.iter().map(|s| s.as_str()).collect();
+        let count_strs = self.redis.hmget(&algo_counts_key, &post_id_refs).await?;
+
+        // Parse counts, defaulting to 0 for missing entries
+        let liker_counts: Vec<usize> = count_strs
+            .into_iter()
+            .map(|opt| opt.and_then(|s| s.parse().ok()).unwrap_or(0))
+            .collect();
+
+        // Step 4: Filter by min likes and prepare fetch list
+        let mut posts_skipped_no_likers = 0;
+        let mut posts_skipped_few_likers = 0;
+        let mut posts_to_score: Vec<(&str, usize)> = Vec::with_capacity(candidates.len());
+
+        for (post_id, count) in candidates.iter().zip(liker_counts.iter()) {
+            if *count == 0 {
+                posts_skipped_no_likers += 1;
+            } else if *count < self.min_post_likes {
+                posts_skipped_few_likers += 1;
+            } else {
+                posts_to_score.push((post_id.as_str(), *count));
+            }
+        }
+
+        if posts_to_score.is_empty() {
+            return Ok(ScoringResult {
+                scored_posts: Vec::new(),
+                scored_count: 0,
+                posts_checked: candidates.len(),
+                posts_skipped_no_likers,
+                posts_skipped_few_likers,
+                scoring_time_ms: start_time.elapsed().as_secs_f64() * 1000.0,
+                ..Default::default()
+            });
+        }
+
+        // Step 5: Fetch likers - check local cache first, then batch fetch misses
+        let mut cache_hits = 0;
+        let mut cache_misses = 0;
+        let mut all_likers: Vec<Vec<(String, f64)>> = Vec::with_capacity(posts_to_score.len());
+        let mut cache_miss_indices: Vec<usize> = Vec::new();
+        let mut cache_miss_post_ids: Vec<&str> = Vec::new();
+
+        // Check cache for each post
+        if self.liker_cache_enabled {
+            for (i, (post_id, _)) in posts_to_score.iter().enumerate() {
+                if let Some(entry) = self.liker_cache.get(post_id) {
+                    // Filter by time window - use owned version to avoid extra clone
+                    let filtered =
+                        LikerCache::filter_likers_by_time_owned(entry.likers, min_time, now);
+                    all_likers.push(filtered);
+                    cache_hits += 1;
+                } else {
+                    // Mark for fetching
+                    all_likers.push(Vec::new()); // Placeholder
+                    cache_miss_indices.push(i);
+                    cache_miss_post_ids.push(post_id);
+                    cache_misses += 1;
+                }
+            }
+        } else {
+            // Cache disabled - fetch all
+            for (post_id, _) in &posts_to_score {
+                all_likers.push(Vec::new());
+                cache_miss_indices.push(all_likers.len() - 1);
+                cache_miss_post_ids.push(post_id);
+            }
+            cache_misses = posts_to_score.len();
+        }
+
+        // Batch fetch cache misses from Redis using date-based keys
+        if !cache_miss_post_ids.is_empty() {
+            // Build date-based key groups for each post
+            let post_key_groups: Vec<Vec<String>> = cache_miss_post_ids
+                .iter()
+                .map(|post_id| Keys::post_likers_retention_bounded(post_id, DEFAULT_RETENTION_DAYS))
+                .collect();
+
+            // Fetch from all date-based keys and merge results per post
+            let fetched_likers = self
+                .redis
+                .zrevrangebyscore_merged_multi(
+                    &post_key_groups,
+                    now,
+                    min_time,
+                    self.max_likers_per_post,
+                )
+                .await?;
+
+            // Fill in results for scoring
+            for (idx, likers) in cache_miss_indices.iter().zip(fetched_likers) {
+                all_likers[*idx] = likers;
+            }
+        }
+
+        let (mut post_scores, posts_skipped_low_overlap, overlap_sum, overlap_max, overlap_hist) =
+            self.score_prepared(
+                &posts_to_score,
+                &all_likers,
+                &source_weights,
+                params,
+                now,
+                recency_half_life_seconds,
+                audit,
+            );
         // Sort and truncate
         post_scores.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
         post_scores.truncate(DEFAULT_MAX_SCORER_RESULTS);
@@ -472,6 +1167,19 @@ impl Scorer {
             algo_id,
             scored_count,
             posts_checked = candidates.len(),
+            // Where candidates die before scoring. Both were already computed for
+            // ScoringResult but never logged, which made the "why is the feed mostly
+            // fallback?" question un-answerable without offline reconstruction:
+            //   no_likers  = candidate has zero recorded likers in apc:{algo_id}
+            //   few_likers = has likers but fewer than min_post_likes
+            posts_skipped_no_likers,
+            posts_skipped_few_likers,
+            //   low_overlap = had likers, but fewer than min_overlapping_colikers of them
+            //                 were in this user's co-liker set
+            posts_skipped_low_overlap,
+            min_post_likes = self.min_post_likes,
+            min_overlapping_colikers = self.min_overlapping_colikers,
+            overlap_max,
             cache_hits,
             cache_misses,
             scoring_time_ms = format!("{:.2}", scoring_time_ms),
@@ -487,6 +1195,85 @@ impl Scorer {
             scoring_time_ms,
             cache_hits,
             cache_misses,
+            posts_skipped_low_overlap,
+            overlap_sum,
+            overlap_max,
+            overlap_hist,
+            seed_keep_rate: None,
+            ranker_by_post: Default::default(),
+            requires_preserved_order: false,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlap_buckets_cover_every_count_monotonically() {
+        // Boundaries matter: paths_boost is nonlinear in overlap_count, so the histogram
+        // must not smear adjacent magnitudes together.
+        assert_eq!(overlap_bucket(0), 0);
+        assert_eq!(overlap_bucket(1), 0);
+        assert_eq!(overlap_bucket(2), 1);
+        assert_eq!(overlap_bucket(3), 2);
+        assert_eq!(overlap_bucket(4), 2);
+        assert_eq!(overlap_bucket(5), 3);
+        assert_eq!(overlap_bucket(8), 3);
+        assert_eq!(overlap_bucket(9), 4);
+        assert_eq!(overlap_bucket(16), 4);
+        assert_eq!(overlap_bucket(17), 5);
+        assert_eq!(overlap_bucket(32), 5);
+        assert_eq!(overlap_bucket(33), 6);
+        assert_eq!(overlap_bucket(64), 6);
+        assert_eq!(overlap_bucket(65), 7);
+        assert_eq!(overlap_bucket(170), 7); // observed max on a real lurker profile
+
+        let mut last = 0;
+        for n in 0..500 {
+            let b = overlap_bucket(n);
+            assert!(b >= last && b < OVERLAP_BUCKETS);
+            last = b;
+        }
+    }
+
+    #[test]
+    fn overlap_mean_divides_by_observed_not_truncated_scored_count() {
+        // scored_count is truncated to DEFAULT_MAX_SCORER_RESULTS while the overlap stats
+        // are gathered pre-truncation; dividing by scored_count would overstate the mean.
+        let r = ScoringResult {
+            scored_count: 500,
+            overlap_sum: 3_000,
+            overlap_hist: [0, 0, 0, 1_000, 0, 0, 0, 0],
+            ..Default::default()
+        };
+        assert_eq!(r.overlap_observed(), 1_000);
+        assert_eq!(r.overlap_mean(), 3.0);
+    }
+
+    #[test]
+    fn overlap_mean_is_zero_when_nothing_scored() {
+        assert_eq!(ScoringResult::default().overlap_mean(), 0.0);
+        assert_eq!(ScoringResult::default().overlap_observed(), 0);
+    }
+
+    #[test]
+    fn overlap_hist_str_lists_only_populated_buckets() {
+        let r = ScoringResult {
+            overlap_hist: [4, 9, 2, 0, 0, 0, 0, 1],
+            ..Default::default()
+        };
+        assert_eq!(r.overlap_hist_str(), "1:4,2:9,3-4:2,65+:1");
+        assert_eq!(ScoringResult::default().overlap_hist_str(), "");
+    }
+
+    #[test]
+    fn default_result_serves_nothing() {
+        // The empty early-exit paths rely on Default meaning "no personalization".
+        let r = ScoringResult::default();
+        assert!(r.scored_posts.is_empty());
+        assert_eq!(r.scored_count, 0);
+        assert_eq!(r.posts_skipped_low_overlap, 0);
     }
 }

--- a/crates/graze-api/src/algorithm/thompson.rs
+++ b/crates/graze-api/src/algorithm/thompson.rs
@@ -108,6 +108,48 @@ pub struct SelectedParams {
     pub is_exploration: bool,
     /// True = fixed params from feed treatment_params override (don't record for learning).
     pub is_treatment_override: bool,
+    /// True = one dimension was forced by a user-hash randomized experiment. Excluded from
+    /// bandit learning, since the value was not chosen by the bandit.
+    pub is_hash_experiment: bool,
+}
+
+/// A randomized A/B assignment keyed on the user DID, deliberately independent of the bandit.
+///
+/// Thompson assignment is *adaptive*, so comparing arms retrospectively is confounded: arm choice
+/// correlates with time (bandit state moves), and like rates vary strongly by time of day. That is
+/// what invalidated the `max_total_sources` analysis in THEORIES-personalization.md T19 — the
+/// apparent effect showed up just as strongly on fallback posts, which the parameter cannot touch.
+///
+/// Hashing the DID gives assignment that is orthogonal to time and to bandit state, and stable per
+/// user across requests and deploys — a real randomized experiment.
+#[derive(Debug, Clone)]
+pub struct HashExperiment {
+    /// Bandit dimension name, e.g. `max_sources`.
+    pub dimension: String,
+    /// Values to randomize between.
+    pub values: Vec<usize>,
+    /// Percentage of users enrolled (0-100). The remainder keep normal Thompson selection.
+    pub traffic_pct: u32,
+    /// Bump to re-randomize the assignment.
+    pub salt: String,
+}
+
+impl HashExperiment {
+    /// Which arm this user is assigned, or `None` if not enrolled.
+    ///
+    /// Membership and arm are drawn from different parts of one salted hash so that enrolling a
+    /// larger share of traffic does not reshuffle who is in which arm.
+    pub fn assign(&self, user_did: &str) -> Option<usize> {
+        if self.values.is_empty() || self.traffic_pct == 0 {
+            return None;
+        }
+        let h = graze_common::hash_did(&format!("{}|{}", self.salt, user_did));
+        let v = u64::from_str_radix(&h, 16).unwrap_or(0);
+        if (v % 100) >= self.traffic_pct as u64 {
+            return None;
+        }
+        Some(self.values[((v / 100) % self.values.len() as u64) as usize])
+    }
 }
 
 /// Beta distribution parameters for a single arm.
@@ -220,6 +262,30 @@ pub struct ThompsonLearner {
     bandits: RwLock<HashMap<(i32, &'static str), ParameterBandit>>,
     /// Statistics tracking.
     stats: RwLock<ThompsonStats>,
+    /// Un-flushed evidence, as (alpha_delta, beta_delta) per arm.
+    ///
+    /// Bandit state was previously in-memory only, so every pod restart discarded all learning —
+    /// across three replicas, with frequent deploys, the search never converged. Worse, it made
+    /// arm selection correlate with *time*, which is what confounded the retrospective analysis of
+    /// `max_total_sources` (see THEORIES-personalization.md T19).
+    ///
+    /// Deltas rather than absolute alpha/beta so replicas merge instead of clobbering.
+    pending: RwLock<HashMap<ArmKey, ArmDelta>>,
+}
+
+/// Identifies one bandit arm: (algo_id, dimension name, parameter value).
+type ArmKey = (i32, &'static str, usize);
+/// Un-flushed (alpha_delta, beta_delta) for an arm.
+type ArmDelta = (f64, f64);
+
+/// Redis hash holding merged bandit evidence for one algorithm.
+fn arms_key(algo_id: i32) -> String {
+    format!("thompson:arms:{}", algo_id)
+}
+
+/// Field name for one arm's alpha or beta counter.
+fn arm_field(dimension: &str, value: usize, which: char) -> String {
+    format!("{}:{}:{}", dimension, value, which)
 }
 
 #[derive(Debug, Default)]
@@ -243,6 +309,7 @@ impl ThompsonLearner {
             config,
             bandits: RwLock::new(HashMap::new()),
             stats: RwLock::new(ThompsonStats::default()),
+            pending: RwLock::new(HashMap::new()),
         }
     }
 
@@ -377,6 +444,7 @@ impl ThompsonLearner {
                     is_holdout: true,
                     is_exploration: false,
                     is_treatment_override: false,
+                    is_hash_experiment: false,
                 }
             } else {
                 SelectedParams {
@@ -392,6 +460,7 @@ impl ThompsonLearner {
                     is_holdout: true,
                     is_exploration: false,
                     is_treatment_override: false,
+                    is_hash_experiment: false,
                 }
             };
         }
@@ -412,6 +481,7 @@ impl ThompsonLearner {
                 is_holdout: false,
                 is_exploration: false,
                 is_treatment_override: true,
+                is_hash_experiment: false,
             };
         }
 
@@ -474,6 +544,7 @@ impl ThompsonLearner {
             is_holdout: false,
             is_exploration,
             is_treatment_override: false,
+            is_hash_experiment: false,
         }
     }
 
@@ -513,13 +584,14 @@ impl ThompsonLearner {
             is_holdout: false,
             is_exploration: false,
             is_treatment_override: false,
+            is_hash_experiment: false,
         }
     }
 
     /// Record an observation (success/failure) for selected parameters.
     pub fn record_observation(&self, algo_id: i32, params: &SelectedParams, success: bool) {
-        if params.is_holdout || params.is_treatment_override {
-            return; // Don't learn from holdout or fixed treatment override
+        if params.is_holdout || params.is_treatment_override || params.is_hash_experiment {
+            return; // Don't learn from holdout, fixed treatment, or a forced experiment arm
         }
 
         let mut bandits = self.bandits.write();
@@ -543,6 +615,181 @@ impl ThompsonLearner {
                 bandit.update(value, success);
             }
         }
+
+        // Stage the same evidence for cross-replica persistence.
+        {
+            let mut pending = self.pending.write();
+            for (name, value) in param_values {
+                let e = pending.entry((algo_id, name, value)).or_insert((0.0, 0.0));
+                if success {
+                    e.0 += 1.0;
+                } else {
+                    e.1 += 1.0;
+                }
+            }
+        }
+    }
+
+    /// Push this replica's un-flushed evidence to Redis, then reload the merged totals.
+    ///
+    /// Deltas go out via `HINCRBYFLOAT` so replicas accumulate rather than overwrite; the reload
+    /// then gives every pod the benefit of the others' observations. Priors are re-added locally,
+    /// so Redis stores only *observed* counts and the prior is never double-counted.
+    ///
+    /// Failures are non-fatal: the pending map is only cleared once the write succeeds, so a Redis
+    /// blip defers evidence rather than losing it.
+    pub async fn flush_and_reload(
+        &self,
+        redis: &graze_common::RedisClient,
+    ) -> std::result::Result<(usize, usize), graze_common::GrazeError> {
+        // Snapshot and clear-on-success, grouped per algo.
+        let snapshot: Vec<(ArmKey, ArmDelta)> =
+            self.pending.read().iter().map(|(k, v)| (*k, *v)).collect();
+
+        let mut by_algo: HashMap<i32, Vec<(String, f64)>> = HashMap::new();
+        for ((algo_id, dim, value), (da, db)) in &snapshot {
+            let entry = by_algo.entry(*algo_id).or_default();
+            if *da != 0.0 {
+                entry.push((arm_field(dim, *value, 'a'), *da));
+            }
+            if *db != 0.0 {
+                entry.push((arm_field(dim, *value, 'b'), *db));
+            }
+        }
+
+        let mut flushed = 0usize;
+        for (algo_id, items) in &by_algo {
+            redis.hincrbyfloat_multi(&arms_key(*algo_id), items).await?;
+            flushed += items.len();
+        }
+
+        // Only drop what we actually wrote; anything recorded meanwhile survives.
+        if !snapshot.is_empty() {
+            let mut pending = self.pending.write();
+            for (k, (da, db)) in &snapshot {
+                if let Some(cur) = pending.get_mut(k) {
+                    cur.0 -= da;
+                    cur.1 -= db;
+                }
+            }
+            pending.retain(|_, v| v.0 != 0.0 || v.1 != 0.0);
+        }
+
+        // Reload merged state for every algo we know about locally, plus any we just wrote.
+        let mut algos: HashSet<i32> = self.bandits.read().keys().map(|(a, _)| *a).collect();
+        algos.extend(by_algo.keys().copied());
+
+        let mut loaded = 0usize;
+        for algo_id in algos {
+            let fields = redis.hgetall(&arms_key(algo_id)).await?;
+            if fields.is_empty() {
+                continue;
+            }
+            let mut merged: HashMap<(String, usize), (f64, f64)> = HashMap::new();
+            for (field, raw) in fields {
+                let mut parts = field.rsplitn(2, ':');
+                let which = parts.next().unwrap_or("");
+                let rest = parts.next().unwrap_or("");
+                let mut rp = rest.rsplitn(2, ':');
+                let value: usize = match rp.next().and_then(|v| v.parse().ok()) {
+                    Some(v) => v,
+                    None => continue,
+                };
+                let dim = match rp.next() {
+                    Some(d) => d.to_string(),
+                    None => continue,
+                };
+                let amount: f64 = raw.parse().unwrap_or(0.0);
+                let e = merged.entry((dim, value)).or_insert((0.0, 0.0));
+                match which {
+                    "a" => e.0 += amount,
+                    "b" => e.1 += amount,
+                    _ => {}
+                }
+            }
+
+            let mut bandits = self.bandits.write();
+            for ((dim, value), (a, b)) in merged {
+                if let Some(bandit) = bandits
+                    .iter_mut()
+                    .find(|((aid, name), _)| *aid == algo_id && *name == dim.as_str())
+                    .map(|(_, v)| v)
+                {
+                    for (v, arm) in bandit.arms.iter_mut() {
+                        if *v == value {
+                            arm.alpha = self.config.prior_alpha + a.max(0.0);
+                            arm.beta = self.config.prior_beta + b.max(0.0);
+                            loaded += 1;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok((flushed, loaded))
+    }
+
+    /// Force one dimension from a user-hash randomized experiment, if the user is enrolled.
+    ///
+    /// Returns the forced value so the caller can log it. The selected value also flows into the
+    /// `feedContext` provenance through the normal params path, so engagement analysis needs no
+    /// extra plumbing — but unlike a Thompson-chosen value, this one is randomized.
+    pub fn apply_hash_experiment(
+        &self,
+        params: &mut SelectedParams,
+        user_did: &str,
+        exp: &HashExperiment,
+    ) -> Option<usize> {
+        // Holdout is the existing control surface; leave it untouched so it stays interpretable.
+        if params.is_holdout || params.is_treatment_override {
+            return None;
+        }
+        let value = exp.assign(user_did)?;
+        let applied = match exp.dimension.as_str() {
+            "min_likes" => {
+                params.min_post_likes = value;
+                true
+            }
+            "max_likers" => {
+                params.max_likers_per_post = value;
+                true
+            }
+            "max_sources" => {
+                params.max_total_sources = value;
+                true
+            }
+            "max_checks" => {
+                params.max_algo_checks = value;
+                true
+            }
+            "min_colikes" => {
+                params.min_co_likes = value;
+                true
+            }
+            "max_user_likes" => {
+                params.max_user_likes = value;
+                true
+            }
+            "max_src_per_post" => {
+                params.max_sources_per_post = value;
+                true
+            }
+            "seed_pool" => {
+                params.seed_sample_pool = value;
+                true
+            }
+            "corater_decay" => {
+                params.corater_decay_pct = value;
+                true
+            }
+            _ => false,
+        };
+        if !applied {
+            return None;
+        }
+        params.is_hash_experiment = true;
+        Some(value)
     }
 
     /// Get statistics.
@@ -949,6 +1196,7 @@ mod tests {
             is_holdout: false,
             is_exploration: false,
             is_treatment_override: false,
+            is_hash_experiment: false,
         };
 
         assert_eq!(params.min_post_likes, 5);
@@ -956,5 +1204,130 @@ mod tests {
         assert_eq!(params.corater_decay_pct, 0);
         assert!(!params.is_holdout);
         assert!(!params.is_exploration);
+    }
+}
+
+#[cfg(test)]
+mod hash_experiment_tests {
+    use super::*;
+
+    fn exp(values: Vec<usize>, pct: u32) -> HashExperiment {
+        HashExperiment {
+            dimension: "max_sources".to_string(),
+            values,
+            traffic_pct: pct,
+            salt: "t".to_string(),
+        }
+    }
+
+    /// Assignment must be stable per user — otherwise a user flips arms between requests and the
+    /// experiment measures nothing.
+    #[test]
+    fn assignment_is_deterministic_per_user() {
+        let e = exp(vec![250, 10000], 100);
+        for did in ["did:plc:aaa", "did:plc:bbb", "did:plc:ccc"] {
+            let first = e.assign(did);
+            for _ in 0..20 {
+                assert_eq!(e.assign(did), first, "unstable assignment for {}", did);
+            }
+        }
+    }
+
+    /// Both arms must actually get traffic, roughly evenly.
+    #[test]
+    fn arms_are_balanced_across_many_users() {
+        let e = exp(vec![250, 10000], 100);
+        let mut a = 0;
+        let mut b = 0;
+        for i in 0..4000 {
+            match e.assign(&format!("did:plc:user{}", i)) {
+                Some(250) => a += 1,
+                Some(10000) => b += 1,
+                other => panic!("unexpected assignment {:?}", other),
+            }
+        }
+        let skew = (a as f64 - b as f64).abs() / 4000.0;
+        assert!(skew < 0.08, "arms too skewed: {} vs {}", a, b);
+    }
+
+    /// Traffic percentage must gate enrollment, and — critically — shrinking it must not reshuffle
+    /// which arm the still-enrolled users are in, or a ramp-up would invalidate earlier data.
+    #[test]
+    fn traffic_pct_gates_enrollment_without_reshuffling_arms() {
+        let full = exp(vec![250, 10000], 100);
+        let half = exp(vec![250, 10000], 50);
+        let mut enrolled_half = 0;
+        for i in 0..4000 {
+            let did = format!("did:plc:user{}", i);
+            if let Some(v) = half.assign(&did) {
+                enrolled_half += 1;
+                assert_eq!(
+                    v,
+                    full.assign(&did).unwrap(),
+                    "arm changed with traffic_pct"
+                );
+            }
+        }
+        let frac = enrolled_half as f64 / 4000.0;
+        assert!(
+            (0.42..0.58).contains(&frac),
+            "expected ~50% enrolled, got {:.2}",
+            frac
+        );
+    }
+
+    #[test]
+    fn disabled_or_empty_experiment_assigns_nobody() {
+        assert!(exp(vec![250, 10000], 0).assign("did:plc:x").is_none());
+        assert!(exp(vec![], 100).assign("did:plc:x").is_none());
+    }
+
+    /// A forced arm must be excluded from bandit learning — the bandit did not choose it, so
+    /// crediting it would corrupt the very arms we are trying to evaluate.
+    #[test]
+    fn forced_arms_are_excluded_from_learning() {
+        let learner = ThompsonLearner::new();
+        let mut p = learner.select_params(1);
+        p.is_holdout = false;
+        p.is_treatment_override = false;
+        let applied = learner.apply_hash_experiment(&mut p, "did:plc:zzz", &exp(vec![250], 100));
+        assert_eq!(applied, Some(250));
+        assert!(p.is_hash_experiment);
+        assert_eq!(p.max_total_sources, 250);
+
+        // record_observation must be a no-op for this request.
+        let before = learner.get_stats().get("observations_recorded").copied();
+        learner.record_observation(1, &p, true);
+        let after = learner.get_stats().get("observations_recorded").copied();
+        assert_eq!(before, after, "forced arm leaked into bandit learning");
+    }
+
+    /// Holdout is the pre-existing control surface; the experiment must leave it alone so it stays
+    /// interpretable as a baseline.
+    #[test]
+    fn holdout_requests_are_never_enrolled() {
+        let learner = ThompsonLearner::new();
+        let mut p = learner.select_params(1);
+        p.is_holdout = true;
+        let before = p.max_total_sources;
+        assert_eq!(
+            learner.apply_hash_experiment(&mut p, "did:plc:zzz", &exp(vec![250], 100)),
+            None
+        );
+        assert_eq!(p.max_total_sources, before);
+        assert!(!p.is_hash_experiment);
+    }
+
+    #[test]
+    fn unknown_dimension_is_a_no_op() {
+        let learner = ThompsonLearner::new();
+        let mut p = learner.select_params(1);
+        let mut e = exp(vec![250], 100);
+        e.dimension = "not_a_dimension".to_string();
+        assert_eq!(
+            learner.apply_hash_experiment(&mut p, "did:plc:zzz", &e),
+            None
+        );
+        assert!(!p.is_hash_experiment);
     }
 }

--- a/crates/graze-api/src/algorithm/walk.rs
+++ b/crates/graze-api/src/algorithm/walk.rs
@@ -1,0 +1,356 @@
+//! Pixie-style sampled random walk over the like graph.
+//!
+//! # Why sample at all
+//!
+//! Both traversals we have measured are *enumerative*, and both hit a wall:
+//!
+//! - **Post-first** (`Scorer::score`) truncates each candidate's liker list to the 30 most recent.
+//!   Measured: 72-100% of overlapping candidates have more than 30 likers, so the truncation is
+//!   biased toward whoever liked most recently rather than whoever is most informative.
+//! - **Co-liker-first** (`Scorer::score_inverted`) enumerates every co-liker's likes. It was
+//!   predicted 1.88x better coverage and 33-145x cheaper; measured **0.94x coverage at 5x latency**,
+//!   because real co-liker sets reach 5,157 while the harness that predicted the win capped at 128.
+//!
+//! Sampling escapes the dilemma rather than picking a side: cost is bounded by the walk budget
+//! instead of by graph degree, and visit *proportions* are unbiased estimates of the quantity the
+//! enumerative paths compute exactly but can only afford on a truncated subgraph.
+//!
+//! # The walk, and why it is two round trips rather than N
+//!
+//! A literal 3-step walk (post -> liker -> post) would need a Redis round trip per step, which at
+//! p99 latency is unaffordable. Instead the same walk is executed in two *batched* phases: sample
+//! (seed, liker) pairs from liker lists already fetched, then fetch the sampled likers' like lists in
+//! one pipeline. The distribution walked is the same; only the scheduling differs.
+//!
+//! # Scoring
+//!
+//! Visit counts, not weights. [`multi_hit_score`] is Pixie's booster: a candidate reached from many
+//! *different* seeds scores far above one reached repeatedly from a single seed. This is the
+//! principled form of the existing `paths_boost = overlap_count ^ num_paths_power`
+//! (`scorer.rs`), which is near-inert in production because measured `overlap_mean` is
+//! approximately 1.0 — the enumerative paths almost never find two paths to the same candidate,
+//! which is itself a symptom of their truncation.
+
+use rustc_hash::FxHashMap;
+
+/// A candidate's visit tally, kept per originating seed so the multi-hit booster can see breadth.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VisitTally {
+    /// Visits from each distinct seed that reached this candidate.
+    pub per_seed: Vec<u32>,
+}
+
+impl VisitTally {
+    /// Total visits, across all seeds.
+    pub fn total(&self) -> u32 {
+        self.per_seed.iter().sum()
+    }
+
+    /// Number of distinct seeds that reached this candidate.
+    pub fn breadth(&self) -> usize {
+        self.per_seed.len()
+    }
+}
+
+/// Pixie's multi-hit booster: `(Σ_s √V_s)²`.
+///
+/// Rewards *breadth* over depth. Two seeds contributing one visit each scores `(1+1)² = 4`, while one
+/// seed contributing two visits scores `(√2)² = 2` — so a candidate corroborated by independent parts
+/// of the user's taste outranks one that a single seed happened to hit twice.
+///
+/// This is the property the enumerative paths cannot exploit: with `overlap_mean ≈ 1.0` they
+/// effectively never observe breadth at all.
+pub fn multi_hit_score(tally: &VisitTally) -> f64 {
+    let sum_sqrt: f64 = tally.per_seed.iter().map(|v| (*v as f64).sqrt()).sum();
+    sum_sqrt * sum_sqrt
+}
+
+/// Discount a walk score by the candidate's global popularity.
+///
+/// A post everyone likes is reachable from everywhere, so raw visit counts favour it for reasons that
+/// have nothing to do with this user. `power = 0.0` disables the discount; `1.0` divides by the liker
+/// count outright. This plays the same role as LinkLonk's step-3 term `1/|items the source upvoted|`,
+/// which exists so prolific accounts cannot dominate — a fairness property we have deliberately kept
+/// elsewhere and should not quietly drop here.
+pub fn popularity_discounted(score: f64, liker_count: usize, power: f64) -> f64 {
+    if power <= 0.0 {
+        return score;
+    }
+    let denom = (liker_count.max(1) as f64).powf(power);
+    if denom <= 0.0 || !denom.is_finite() {
+        return score;
+    }
+    score / denom
+}
+
+/// Split a walk budget across seeds, favouring niche seeds over popular ones.
+///
+/// Weight is `1 / (1 + ln(1 + degree))`. A like on a post with six likers says far more about a user's
+/// taste than a like on a post with six thousand, which is the same reasoning behind LinkLonk's
+/// `1/|likers|` step-2 normalization; using a *logarithmic* rather than reciprocal discount keeps
+/// high-degree seeds contributing something instead of starving them entirely.
+///
+/// Every seed receives at least one walk when the budget allows, because a seed with zero walks is
+/// indistinguishable from a seed that was never in the set — and silently dropping seeds is how the
+/// enumerative paths acquired their bias.
+pub fn allocate_walks(seed_degrees: &[usize], total_budget: usize) -> Vec<usize> {
+    let n = seed_degrees.len();
+    if n == 0 || total_budget == 0 {
+        return vec![0; n];
+    }
+    if total_budget <= n {
+        // Not enough budget for everyone: give one walk each to the most informative seeds rather
+        // than spreading fractional budget that rounds to nothing.
+        let mut idx: Vec<usize> = (0..n).collect();
+        idx.sort_by_key(|&i| seed_degrees[i]);
+        let mut out = vec![0; n];
+        for &i in idx.iter().take(total_budget) {
+            out[i] = 1;
+        }
+        return out;
+    }
+
+    let weights: Vec<f64> = seed_degrees
+        .iter()
+        .map(|d| 1.0 / (1.0 + (1.0 + *d as f64).ln()))
+        .collect();
+    let sum: f64 = weights.iter().sum();
+    if sum <= 0.0 || !sum.is_finite() {
+        return vec![total_budget / n; n];
+    }
+
+    // One walk floor per seed, then distribute the remainder by weight.
+    let remainder = total_budget - n;
+    let mut out: Vec<usize> = weights
+        .iter()
+        .map(|w| 1 + (remainder as f64 * (w / sum)).floor() as usize)
+        .collect();
+
+    // Hand any rounding slack to the highest-weight seeds so the budget is spent exactly.
+    let spent: usize = out.iter().sum();
+    let mut slack = total_budget.saturating_sub(spent);
+    if slack > 0 {
+        let mut idx: Vec<usize> = (0..n).collect();
+        idx.sort_by(|&a, &b| {
+            weights[b]
+                .partial_cmp(&weights[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        for &i in idx.iter().cycle().take(slack.min(n * 4)) {
+            if slack == 0 {
+                break;
+            }
+            out[i] += 1;
+            slack -= 1;
+        }
+    }
+    out
+}
+
+/// Pixie's early-stopping rule: stop once `np` candidates have each been visited at least `nv` times.
+///
+/// The point is that a walk long enough to rank the top candidates confidently is much shorter than a
+/// walk long enough to visit everything — so most of the budget buys nothing. This is also the direct
+/// fix for the 3.8 s latency outliers observed during the inverted-lookup test, where cost scaled with
+/// the graph rather than with the answer.
+///
+/// `nv = 0` disables the rule (no candidate can fail a zero threshold, so stopping immediately would
+/// be wrong).
+pub fn early_stop_reached(tallies: &FxHashMap<String, VisitTally>, np: usize, nv: u32) -> bool {
+    if np == 0 || nv == 0 {
+        return false;
+    }
+    tallies.values().filter(|t| t.total() >= nv).count() >= np
+}
+
+/// Final ranking from walk tallies.
+///
+/// Returned as `(score, post_id)` to match what the rest of the scorer produces, sorted descending.
+pub fn rank_from_tallies(
+    tallies: &FxHashMap<String, VisitTally>,
+    liker_counts: &FxHashMap<String, usize>,
+    popularity_power: f64,
+    min_visits: u32,
+) -> Vec<(f64, String)> {
+    let mut out: Vec<(f64, String)> = tallies
+        .iter()
+        .filter(|(_, t)| t.total() >= min_visits)
+        .map(|(post_id, tally)| {
+            let base = multi_hit_score(tally);
+            let count = liker_counts.get(post_id).copied().unwrap_or(0);
+            (
+                popularity_discounted(base, count, popularity_power),
+                post_id.clone(),
+            )
+        })
+        .collect();
+    // Tie-break on post_id so the ranking is total and reproducible. Without this, equal-scoring
+    // candidates would order by hash-map iteration, which differs between two runs in one process and
+    // would reintroduce exactly the self-disagreement the interleaving self-check caught.
+    out.sort_by(|a, b| {
+        b.0.partial_cmp(&a.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.1.cmp(&b.1))
+    });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tally(per_seed: &[u32]) -> VisitTally {
+        VisitTally {
+            per_seed: per_seed.to_vec(),
+        }
+    }
+
+    #[test]
+    fn breadth_beats_depth() {
+        // The whole point of the booster: corroboration from independent seeds outranks repetition
+        // from one. Two seeds x one visit = 4; one seed x two visits = 2.
+        let broad = multi_hit_score(&tally(&[1, 1]));
+        let deep = multi_hit_score(&tally(&[2]));
+        assert!(broad > deep, "broad={broad} deep={deep}");
+        assert!((broad - 4.0).abs() < 1e-9);
+        assert!((deep - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn breadth_counts_distinct_seeds_not_visits() {
+        let t = tally(&[3, 1, 1]);
+        assert_eq!(t.breadth(), 3);
+        assert_eq!(t.total(), 5);
+    }
+
+    #[test]
+    fn a_single_visit_scores_one() {
+        assert!((multi_hit_score(&tally(&[1])) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn no_visits_scores_zero() {
+        assert_eq!(multi_hit_score(&tally(&[])), 0.0);
+    }
+
+    #[test]
+    fn popularity_discount_demotes_universally_liked_posts() {
+        let niche = popularity_discounted(4.0, 10, 0.5);
+        let viral = popularity_discounted(4.0, 10_000, 0.5);
+        assert!(niche > viral, "niche={niche} viral={viral}");
+    }
+
+    #[test]
+    fn popularity_discount_is_a_no_op_at_zero_power() {
+        assert_eq!(popularity_discounted(4.0, 10_000, 0.0), 4.0);
+    }
+
+    #[test]
+    fn popularity_discount_survives_a_zero_liker_count() {
+        // Pool posts always have at least one liker, but a missing `apc:` entry reads as 0 and must
+        // not produce a division by zero that poisons the ranking.
+        let scored = popularity_discounted(4.0, 0, 1.0);
+        assert!(scored.is_finite() && scored > 0.0);
+    }
+
+    #[test]
+    fn allocation_favours_niche_seeds() {
+        let alloc = allocate_walks(&[5, 5000], 100);
+        assert!(
+            alloc[0] > alloc[1],
+            "a 5-liker seed must get more walks than a 5000-liker seed: {alloc:?}"
+        );
+    }
+
+    #[test]
+    fn allocation_spends_the_whole_budget() {
+        for budget in [10usize, 37, 100, 1000] {
+            let alloc = allocate_walks(&[3, 30, 300, 3000, 30000], budget);
+            assert_eq!(alloc.iter().sum::<usize>(), budget, "budget={budget}");
+        }
+    }
+
+    #[test]
+    fn every_seed_gets_at_least_one_walk_when_budget_allows() {
+        let alloc = allocate_walks(&[1, 10, 100, 1000], 40);
+        assert!(
+            alloc.iter().all(|&w| w >= 1),
+            "a seed with zero walks is indistinguishable from one that was never there: {alloc:?}"
+        );
+    }
+
+    #[test]
+    fn tight_budget_prefers_the_most_informative_seeds() {
+        // Budget smaller than the seed count: the two lowest-degree seeds should win the walks.
+        let alloc = allocate_walks(&[9000, 5, 8000, 7], 2);
+        assert_eq!(alloc.iter().sum::<usize>(), 2);
+        assert_eq!(alloc[1], 1, "the 5-liker seed must be walked: {alloc:?}");
+        assert_eq!(alloc[3], 1, "the 7-liker seed must be walked: {alloc:?}");
+    }
+
+    #[test]
+    fn allocation_handles_degenerate_input() {
+        assert_eq!(allocate_walks(&[], 100), Vec::<usize>::new());
+        assert_eq!(allocate_walks(&[1, 2, 3], 0), vec![0, 0, 0]);
+    }
+
+    #[test]
+    fn early_stop_fires_once_enough_candidates_are_confident() {
+        let mut t = FxHashMap::default();
+        t.insert("a".to_string(), tally(&[2, 2]));
+        t.insert("b".to_string(), tally(&[4]));
+        t.insert("c".to_string(), tally(&[1]));
+        assert!(early_stop_reached(&t, 2, 4));
+        assert!(!early_stop_reached(&t, 3, 4));
+    }
+
+    #[test]
+    fn early_stop_is_disabled_rather_than_instant_at_zero() {
+        // A zero threshold must mean "no early stopping", never "stop before walking", which would
+        // silently disable personalization for everyone.
+        let mut t = FxHashMap::default();
+        t.insert("a".to_string(), tally(&[1]));
+        assert!(!early_stop_reached(&t, 0, 5));
+        assert!(!early_stop_reached(&t, 5, 0));
+    }
+
+    #[test]
+    fn ranking_is_total_and_reproducible_under_ties() {
+        // Equal scores must not order by hash-map iteration: two runs in one process would disagree,
+        // which is the exact defect the interleaving self-check caught in production.
+        let mut t = FxHashMap::default();
+        for id in ["zzz", "aaa", "mmm"] {
+            t.insert(id.to_string(), tally(&[1]));
+        }
+        let counts = FxHashMap::default();
+        let first = rank_from_tallies(&t, &counts, 0.0, 1);
+        let again = rank_from_tallies(&t, &counts, 0.0, 1);
+        assert_eq!(first, again);
+        assert_eq!(
+            first.iter().map(|(_, id)| id.as_str()).collect::<Vec<_>>(),
+            vec!["aaa", "mmm", "zzz"]
+        );
+    }
+
+    #[test]
+    fn ranking_drops_candidates_below_the_visit_floor() {
+        let mut t = FxHashMap::default();
+        t.insert("solid".to_string(), tally(&[3]));
+        t.insert("noise".to_string(), tally(&[1]));
+        let ranked = rank_from_tallies(&t, &FxHashMap::default(), 0.0, 2);
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].1, "solid");
+    }
+
+    #[test]
+    fn ranking_applies_the_popularity_discount() {
+        let mut t = FxHashMap::default();
+        t.insert("niche".to_string(), tally(&[1, 1]));
+        t.insert("viral".to_string(), tally(&[1, 1]));
+        let mut counts = FxHashMap::default();
+        counts.insert("niche".to_string(), 8usize);
+        counts.insert("viral".to_string(), 50_000usize);
+        let ranked = rank_from_tallies(&t, &counts, 0.5, 1);
+        assert_eq!(ranked[0].1, "niche", "{ranked:?}");
+    }
+}

--- a/crates/graze-api/src/api/admin.rs
+++ b/crates/graze-api/src/api/admin.rs
@@ -1189,11 +1189,7 @@ pub async fn get_candidates(
     };
 
     let limit = query.limit.unwrap_or(10_000).min(50_000);
-    let ids: Vec<i64> = id_strs
-        .iter()
-        .take(limit)
-        .filter_map(|s| s.parse().ok())
-        .collect();
+    let ids: Vec<String> = id_strs.iter().take(limit).cloned().collect();
 
     let id_to_uri = match state.interner.get_uris_batch(&ids).await {
         Ok(m) => m,
@@ -1210,8 +1206,8 @@ pub async fn get_candidates(
     };
 
     let uris: Vec<String> = ids
-        .into_iter()
-        .filter_map(|id| id_to_uri.get(&id).cloned())
+        .iter()
+        .filter_map(|id| id_to_uri.get(id).cloned())
         .collect();
 
     (
@@ -1253,7 +1249,12 @@ pub async fn add_candidates(
             .into_response();
     }
 
-    let uri_to_id = match state.interner.get_or_create_ids_batch(&body.uris).await {
+    let intern_date = graze_common::today_date();
+    let uri_to_id = match state
+        .interner
+        .get_or_create_ids_batch(&body.uris, &intern_date)
+        .await
+    {
         Ok(m) => m,
         Err(e) => {
             return (
@@ -1269,7 +1270,7 @@ pub async fn add_candidates(
 
     let posts_key = Keys::algo_posts(algo_id);
     let meta_key = Keys::algo_meta(algo_id);
-    let str_ids: Vec<String> = uri_to_id.values().map(|id| id.to_string()).collect();
+    let str_ids: Vec<String> = uri_to_id.values().cloned().collect();
 
     if let Err(e) = state.redis.sadd(&posts_key, &str_ids).await {
         return (
@@ -1337,7 +1338,7 @@ pub async fn remove_candidates(
         }
     };
 
-    let str_ids: Vec<String> = uri_to_id.values().map(|id| id.to_string()).collect();
+    let str_ids: Vec<String> = uri_to_id.values().cloned().collect();
     let posts_key = Keys::algo_posts(algo_id);
     let removed = match state.redis.srem(&posts_key, &str_ids).await {
         Ok(n) => n,

--- a/crates/graze-api/src/api/fallback.rs
+++ b/crates/graze-api/src/api/fallback.rs
@@ -85,22 +85,16 @@ async fn convert_ids_to_uris(
     exclude: &HashSet<String>,
     limit: usize,
 ) -> Result<Vec<String>> {
-    // Convert IDs to integers
-    let int_ids: Vec<i64> = post_ids
-        .iter()
-        .filter_map(|id| id.parse::<i64>().ok())
-        .collect();
-
-    if int_ids.is_empty() {
+    if post_ids.is_empty() {
         return Ok(Vec::new());
     }
 
     // Batch lookup URIs
-    let id_to_uri = interner.get_uris_batch(&int_ids).await?;
+    let id_to_uri = interner.get_uris_batch(post_ids).await?;
 
     // Filter out excluded posts and return up to limit
     let mut result = Vec::with_capacity(limit);
-    for id in &int_ids {
+    for id in post_ids {
         if let Some(uri) = id_to_uri.get(id) {
             if !exclude.contains(uri) {
                 result.push(uri.clone());
@@ -410,15 +404,13 @@ pub async fn get_blended_posts_with_stats(
             .await
         {
             Ok(result) => {
-                let scored_posts: Vec<(f64, i64)> = result
+                let scored_posts: Vec<(f64, String)> = result
                     .scored_posts
                     .iter()
                     .take(shortfall * 2)
-                    .filter_map(|(score, post_id)| {
-                        post_id.parse::<i64>().ok().map(|id| (*score, id))
-                    })
+                    .map(|(score, post_id)| (*score, post_id.clone()))
                     .collect();
-                let post_ids: Vec<i64> = scored_posts.iter().map(|(_, id)| *id).collect();
+                let post_ids: Vec<String> = scored_posts.iter().map(|(_, id)| id.clone()).collect();
                 let uri_map = interner.get_uris_batch(&post_ids).await.unwrap_or_default();
 
                 for (_, post_id) in scored_posts {
@@ -547,10 +539,7 @@ pub async fn load_user_liked_uris(
         return HashSet::new();
     }
 
-    let ids: Vec<i64> = liked_items
-        .into_iter()
-        .filter_map(|(id_str, _)| id_str.parse::<i64>().ok())
-        .collect();
+    let ids: Vec<String> = liked_items.into_iter().map(|(id_str, _)| id_str).collect();
 
     match interner.get_uris_batch(&ids).await {
         Ok(map) => map.into_values().collect(),

--- a/crates/graze-api/src/api/feed.rs
+++ b/crates/graze-api/src/api/feed.rs
@@ -31,7 +31,7 @@ use graze_common::models::{
     ProvenanceParams, SkeletonFeedPost, ThompsonSearchSpace,
 };
 use graze_common::services::special_posts::SpecialPostsResponse;
-use graze_common::{hash_did, Keys};
+use graze_common::{hash_did, is_excluded_post_uri, Keys};
 
 /// Placeholder posts for edge cases when feed cannot be served
 const PLACEHOLDER_ERROR: &str =
@@ -97,6 +97,16 @@ struct ResponseThompsonMeta {
     is_holdout: bool,
 }
 
+/// Build the randomized-experiment descriptor from config.
+fn graze_api_hash_experiment(config: &crate::config::Config) -> crate::algorithm::HashExperiment {
+    crate::algorithm::HashExperiment {
+        dimension: config.ab_experiment_dimension.clone(),
+        values: config.ab_experiment_values.clone(),
+        traffic_pct: config.ab_experiment_traffic_pct,
+        salt: config.ab_experiment_salt.clone(),
+    }
+}
+
 /// Build feedContext provenance for one item and encode to base64 string.
 /// feed_uri must always be provided—the client echoes this back with interactions
 /// and we rely on it for ClickHouse storage.
@@ -110,6 +120,8 @@ fn encode_feed_context(
     prov: &ItemProvenance,
     thompson_meta: Option<&ResponseThompsonMeta>,
     is_personalization_holdout: Option<bool>,
+    // Which ranker produced this item, when interleaving is active.
+    ranker: Option<String>,
 ) -> Option<String> {
     let (source, personalization_type, fallback_tranche, attribution, personalized) = match prov {
         ItemProvenance::Base(BlendedSource::PostLevelPersonalization) => (
@@ -177,6 +189,7 @@ fn encode_feed_context(
         response_time_ms,
         is_holdout,
         is_personalization_holdout,
+        ranker,
     };
     ctx.encode()
 }
@@ -241,6 +254,94 @@ fn compact_to_uri(compact: &str) -> String {
         format!("at://{}/app.bsky.feed.post/{}", did, rkey)
     } else {
         compact.to_string()
+    }
+}
+
+/// Encode a `BlendedSource` as a short tag for the `fsc:` cache.
+///
+/// The cache previously stored bare URIs, so every item read back from it was relabelled
+/// `PostLevelPersonalization` — meaning pages 2+ have always mis-attributed fallback and
+/// author-affinity items. Storing the source alongside the URI fixes that, and is a
+/// prerequisite for any per-item experiment attribution (which would otherwise be silently
+/// wrong on every page after the first).
+///
+/// Deliberately extensible: the tag is an opaque string, so an experiment arm can later be
+/// appended (e.g. `p/walk`) without another cache format change.
+fn source_to_tag(source: &BlendedSource) -> String {
+    match source {
+        BlendedSource::PostLevelPersonalization => "p".to_string(),
+        BlendedSource::AuthorAffinity => "a".to_string(),
+        BlendedSource::Fallback { tranche } => format!("f:{}", tranche),
+    }
+}
+
+/// Inverse of [`source_to_tag`].
+fn tag_to_source(tag: &str) -> BlendedSource {
+    match tag {
+        "a" => BlendedSource::AuthorAffinity,
+        t if t.starts_with("f:") => BlendedSource::Fallback {
+            tranche: t[2..].to_string(),
+        },
+        // "p", plus anything unrecognised (e.g. a tag written by a newer build).
+        _ => BlendedSource::PostLevelPersonalization,
+    }
+}
+
+/// Separator between the source tag and the compact URI. Cannot occur in a DID or an rkey,
+/// which is what makes the legacy (untagged) format unambiguously detectable.
+const CACHE_TAG_SEP: char = '|';
+
+/// Encode `(uri, source)` for the `fsc:` cache.
+/// Whether this user is in the personalization holdout.
+///
+/// Stable per user: the same DID always lands in the same arm for a given rate and salt, which is what
+/// makes a user-level readout meaningful. Changing the *rate* does move the boundary, so a rate change
+/// mid-experiment starts a new experiment — record a fresh `start` in the spec when you change it.
+fn is_personalization_holdout_user(user_did: &str, salt: &str, rate: f64) -> bool {
+    if rate <= 0.0 {
+        return false;
+    }
+    if rate >= 1.0 {
+        return true;
+    }
+    let h = graze_common::hash_did(&format!("{}|{}", salt, user_did));
+    // 16 hex chars of SHA-256. Take a wide slice and map to [0,1) so the comparison is against the
+    // configured rate directly rather than a coarse bucket count.
+    let v = u64::from_str_radix(&h[..15], 16).unwrap_or(0);
+    (v as f64 / 0xFFF_FFFF_FFFF_FFFF_u64 as f64) < rate
+}
+
+fn tagged_to_compact(uri: &str, source: &BlendedSource, ranker: Option<&str>) -> String {
+    let tag = match ranker {
+        Some(r) => format!("{}/{}", source_to_tag(source), r),
+        None => source_to_tag(source),
+    };
+    format!("{}{}{}", tag, CACHE_TAG_SEP, uri_to_compact(uri))
+}
+
+/// Decode a `fsc:` cache entry into `(uri, source)`.
+///
+/// Entries written before this format existed have no separator; they are treated as
+/// `PostLevelPersonalization`, which preserves the previous behaviour exactly rather than
+/// dropping in-flight caches on deploy.
+fn compact_to_tagged(entry: &str) -> (String, BlendedSource, Option<String>) {
+    // Split from the RIGHT: the compact URI half (DID + rkey, both base32) can never contain
+    // the separator, whereas a tranche name theoretically could. Splitting from the left would
+    // let a stray separator in the tag corrupt the URI.
+    match entry.rsplit_once(CACHE_TAG_SEP) {
+        Some((tag, compact)) => {
+            // A `/` in the tag separates the source from the interleaving ranker.
+            let (src_tag, ranker) = match tag.split_once('/') {
+                Some((s, r)) if !r.is_empty() => (s, Some(r.to_string())),
+                _ => (tag, None),
+            };
+            (compact_to_uri(compact), tag_to_source(src_tag), ranker)
+        }
+        None => (
+            compact_to_uri(entry),
+            BlendedSource::PostLevelPersonalization,
+            None,
+        ),
     }
 }
 
@@ -484,6 +585,7 @@ pub async fn get_feed_skeleton(
                         &prov,
                         None,
                         None,
+                        None,
                     );
                     SkeletonFeedPost {
                         post: uri,
@@ -544,6 +646,7 @@ pub async fn get_feed_skeleton(
             response_time_ms: None,
             is_holdout: None,
             is_personalization_holdout: None,
+            ranker: None,
         }
         .encode();
         let response = FeedSkeletonResponse {
@@ -558,23 +661,56 @@ pub async fn get_feed_skeleton(
     }
 
     let mut base_posts_tagged: Vec<(String, BlendedSource)> = Vec::new();
+    // URI -> ranker for interleaving attribution. Populated on a fresh compute, and recovered
+    // from the `fsc:` cache tag on paginated requests.
+    let mut ranker_by_uri: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
     let mut was_personalized = false;
     let mut fallback_reason: Option<&str> = None;
     let mut feed_cache_hit = false;
     let mut response_thompson_meta: Option<ResponseThompsonMeta> = None;
-    let mut is_personalization_holdout_for_provenance = false;
-    let is_fallback_only = feed_cursor.fallback_only;
+    // The arm is a pure function of the DID, so compute it once for EVERY request — first page or
+    // not, cursor or no cursor.
+    //
+    // Measured leak this replaces: 5 users appeared under both arms across three days. Their
+    // mislabelled rows were all at depth 3-6 (never page 1) and some carried `source: personalized`.
+    // Cause: the holdout branch was gated on `is_first_page`, so a paginated request whose cursor did
+    // not happen to carry `fallback_only` skipped the holdout entirely, read `fsc:`, and served
+    // personalized content *labelled as treated*. Two-way contamination — a holdout user both
+    // receiving treatment and being counted as treated.
+    //
+    // Deriving the arm from the DID on every request makes the invariant hold by construction rather
+    // than by every caller remembering to thread a flag: a holdout user can neither be served
+    // personalized content nor be labelled treated, on any page, with or without a cursor.
+    let holdout_user = user_did
+        .as_ref()
+        .map(|did| {
+            is_personalization_holdout_user(
+                did,
+                &state.config.personalization_holdout_salt,
+                state.config.personalization_holdout_rate,
+            )
+        })
+        .unwrap_or(false);
+    let mut is_personalization_holdout_for_provenance = holdout_user;
+    // Holdout users take the fallback-only path on every page. That path already handles pagination
+    // offsets and exclusions correctly, so routing through it removes the duplicate first-page-only
+    // branch rather than adding a second one to keep in sync.
+    let is_fallback_only = feed_cursor.fallback_only || holdout_user;
 
     // ═══════════════════════════════════════════════════════════════════
     // Handle fallback-only mode (personalization exhausted or holdout)
     // ═══════════════════════════════════════════════════════════════════
     if is_fallback_only {
-        fallback_reason = Some(if feed_cursor.is_personalization_holdout {
+        fallback_reason = Some(if holdout_user || feed_cursor.is_personalization_holdout {
             "personalization_holdout"
         } else {
             "personalization_exhausted"
         });
-        is_personalization_holdout_for_provenance = feed_cursor.is_personalization_holdout;
+        // `holdout_user` is authoritative; the cursor's copy is only a hint that can be absent on a
+        // fresh or truncated cursor, which is exactly how the old leak arose.
+        is_personalization_holdout_for_provenance =
+            holdout_user || feed_cursor.is_personalization_holdout;
         let exclude_set: HashSet<String> = feed_cursor.shown_fallback.clone();
 
         let fallback_raw = get_fallback_blend(
@@ -606,31 +742,10 @@ pub async fn get_feed_skeleton(
         let feed_cache_key = Keys::feed_cache(algo_id, &user_hash);
         let is_first_page = feed_cursor.is_first_page();
 
-        // Personalization holdout: 5% of first-page requests get non-personalized blend for A/B test
-        if is_first_page
-            && state.config.personalization_holdout_rate > 0.0
-            && rand::random::<f64>() < state.config.personalization_holdout_rate
-        {
-            fallback_reason = Some("personalization_holdout");
-            is_personalization_holdout_for_provenance = true;
-            let fallback_raw = get_fallback_blend(
-                &state.redis,
-                &state.interner,
-                &state.config,
-                algo_id,
-                limit * 2,
-                0,
-                &HashSet::new(),
-            )
-            .await
-            .unwrap_or_default();
-            for (uri, tranche) in fallback_raw {
-                if base_posts_tagged.len() >= limit {
-                    break;
-                }
-                base_posts_tagged.push((uri, BlendedSource::Fallback { tranche }));
-            }
-        } else if state.config.feed_cache_enabled {
+        // No holdout branch here: holdout users were routed to the fallback-only path above, before
+        // this block, so reaching here already implies the user is in the treated arm. Keeping a
+        // second first-page-only check would recreate the leak this removed.
+        if state.config.feed_cache_enabled {
             let cache_offset = feed_cursor.offset.max(0) as isize;
 
             // Check if cache exists by getting its length
@@ -651,9 +766,24 @@ pub async fn get_feed_skeleton(
                         feed_cache_hit = true;
                         base_posts_tagged = cached
                             .into_iter()
-                            .map(|c| (compact_to_uri(&c), BlendedSource::PostLevelPersonalization))
+                            .map(|c| {
+                                let (uri, src, ranker) = compact_to_tagged(&c);
+                                if let Some(r) = ranker {
+                                    ranker_by_uri.insert(uri.clone(), r);
+                                }
+                                (uri, src)
+                            })
                             .collect();
-                        was_personalized = true;
+                        // Only claim personalization if the cached page actually contains a
+                        // personalized item. Previously this was unconditionally true, which
+                        // inflated `was_personalized` on fallback-only cached pages.
+                        was_personalized = base_posts_tagged.iter().any(|(_, s)| {
+                            matches!(
+                                s,
+                                BlendedSource::PostLevelPersonalization
+                                    | BlendedSource::AuthorAffinity
+                            )
+                        });
                     } else if !is_first_page {
                         // Cache exists but offset is beyond cached posts - return EOF
                         // This means the user has scrolled past all cached content
@@ -678,22 +808,31 @@ pub async fn get_feed_skeleton(
         // If cache miss and NOT holdout, run personalization (only on first page when cache enabled)
         // When holdout, we already set base_posts_tagged from fallback above - do not overwrite.
         if !feed_cache_hit && !is_personalization_holdout_for_provenance {
-            // Check if user has any likes in date-based keys.
-            // Check today and yesterday so users who liked before UTC midnight still
-            // get the personalization path rather than falling to unfiltered fallback.
-            let now_secs = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs_f64();
-            let today = graze_common::today_date();
-            let yesterday = graze_common::date_from_timestamp(now_secs - 86400.0);
-            let user_likes_key_today = Keys::user_likes_date(&user_hash, &today);
-            let user_likes_key_yesterday = Keys::user_likes_date(&user_hash, &yesterday);
-            let (exists_today, exists_yesterday) = tokio::join!(
-                state.redis.exists(&user_likes_key_today),
-                state.redis.exists(&user_likes_key_yesterday),
-            );
-            let user_has_data = exists_today.unwrap_or(false) || exists_yesterday.unwrap_or(false);
+            // Check if the user has any like-seed the scorer could actually use.
+            //
+            // This previously checked only today and yesterday, to cover users who liked just
+            // before UTC midnight. But the scorer reads the FULL retention window
+            // (`user_likes_retention`, 6 days), so a 2-day gate turned away users whose seed
+            // the scorer would have found — reporting `no_user_data` and serving unfiltered
+            // fallback instead.
+            //
+            // Measured on 2,500 sampled daily-active users: the 2-day gate passed 49.2%, while
+            // 63.2% had seed somewhere in the 6-day window. **14.0% of all DAU — 22.1% of every
+            // seeded user — were being turned away despite usable seed.** That matched the
+            // observed `fallback_reason=no_user_data` rate of ~50% exactly.
+            //
+            // Their seed is thin (median 2 likes), so quality is modest, but the alternative
+            // for them is 100% fallback. Cost is one pipelined EXISTS batch — a single round
+            // trip regardless of window width — plus a scoring run for the newly admitted
+            // users. Window is configurable via USER_DATA_CHECK_DAYS to allow rollback without
+            // a rebuild.
+            let check_days = state.config.user_data_check_days;
+            let user_likes_keys = Keys::user_likes_retention(&user_hash, check_days);
+            let user_has_data = state
+                .redis
+                .exists_any(&user_likes_keys)
+                .await
+                .unwrap_or(false);
 
             if user_has_data {
                 // Load feed-specific Thompson config (holdout override, etc.)
@@ -731,13 +870,37 @@ pub async fn get_feed_skeleton(
                     .or(global_search_space.as_ref());
 
                 // Select Thompson Sampling parameters for this request
-                let thompson_params: SelectedParams =
+                let mut thompson_params: SelectedParams =
                     state.thompson.select_params_with_holdout_and_search_space(
                         algo_id,
                         holdout_override,
                         treatment_override,
                         search_space,
                     );
+
+                // Optionally override one dimension with a user-hash randomized assignment.
+                //
+                // Thompson picks adaptively, so its arms cannot be compared retrospectively:
+                // arm choice tracks bandit state, which tracks time, and engagement varies by
+                // time of day. Hash assignment is orthogonal to both and stable per user, giving
+                // a genuine randomized experiment. Enrolled requests are excluded from bandit
+                // learning (`is_hash_experiment`), and the forced value still flows into the
+                // feedContext provenance, so engagement analysis needs no extra plumbing.
+                if state.config.ab_experiment_enabled {
+                    let exp = graze_api_hash_experiment(&state.config);
+                    if let Some(v) = state.thompson.apply_hash_experiment(
+                        &mut thompson_params,
+                        user_did.as_deref().unwrap_or(""),
+                        &exp,
+                    ) {
+                        debug!(
+                            algo_id,
+                            dimension = %exp.dimension,
+                            value = v,
+                            "ab_experiment_assigned"
+                        );
+                    }
+                }
 
                 // Convert Thompson params to PersonalizationParams override
                 let params_override = PersonalizationParams {
@@ -778,11 +941,11 @@ pub async fn get_feed_skeleton(
                         let _scoring_time_ms = result.meta.scoring_time_ms.unwrap_or(0.0);
 
                         // Collect post IDs that need conversion to URIs
-                        let posts_to_convert: Vec<i64> = result
+                        let posts_to_convert: Vec<String> = result
                             .posts
                             .iter()
-                            .filter(|p| p.uri.is_empty())
-                            .filter_map(|p| p.post_id.parse::<i64>().ok())
+                            .filter(|p| p.uri.is_empty() && !p.post_id.is_empty())
+                            .map(|p| p.post_id.clone())
                             .collect();
 
                         // Batch lookup URIs from interner
@@ -799,16 +962,19 @@ pub async fn get_feed_skeleton(
                             .filter_map(|p| {
                                 let uri = if !p.uri.is_empty() {
                                     Some(p.uri.clone())
-                                } else if let Ok(id) = p.post_id.parse::<i64>() {
-                                    id_to_uri.get(&id).cloned()
                                 } else {
-                                    None
+                                    id_to_uri.get(&p.post_id).cloned()
                                 };
 
                                 // Track personalized posts in audit
                                 if let Some(ref uri) = uri {
                                     if let Some(ref mut a) = audit {
                                         a.add_personalized_post(&p.post_id, uri, p.score);
+                                    }
+                                    // Keep the interleaving attribution keyed by URI, which is
+                                    // what the rest of this handler works in.
+                                    if let Some(ref r) = p.ranker {
+                                        ranker_by_uri.insert(uri.clone(), r.clone());
                                     }
                                 }
 
@@ -839,10 +1005,17 @@ pub async fn get_feed_skeleton(
 
                         // Store full batch in feed cache for subsequent pages
                         if state.config.feed_cache_enabled && !blend_result.posts.is_empty() {
+                            // Store the per-item source so pagination can attribute correctly.
                             let compact_posts: Vec<String> = blend_result
-                                .posts
+                                .posts_with_source
                                 .iter()
-                                .map(|u| uri_to_compact(u))
+                                .map(|(u, src)| {
+                                    tagged_to_compact(
+                                        u,
+                                        src,
+                                        ranker_by_uri.get(u).map(|r| r.as_str()),
+                                    )
+                                })
                                 .collect();
                             let _ = state
                                 .redis
@@ -1039,12 +1212,17 @@ pub async fn get_feed_skeleton(
         .await
         .unwrap_or_else(|_| SpecialPostsResponse::empty(algo_id));
 
-    let (final_with_provenance, updated_cursor) = inject_special_posts(
+    let (mut final_with_provenance, updated_cursor) = inject_special_posts(
         base_posts_tagged.clone(),
         &special_posts,
         &feed_cursor,
         limit,
     );
+
+    if !state.config.exclusion_dids.is_empty() {
+        final_with_provenance
+            .retain(|(uri, _)| !is_excluded_post_uri(uri, state.config.exclusion_dids.as_ref()));
+    }
 
     // ═══════════════════════════════════════════════════════════════════
     // Build response cursor
@@ -1119,6 +1297,7 @@ pub async fn get_feed_skeleton(
                 } else {
                     None
                 },
+                ranker_by_uri.get(uri).cloned(),
             );
             SkeletonFeedPost {
                 post: uri.clone(),
@@ -1426,6 +1605,97 @@ pub async fn send_interactions(
 mod tests {
     use super::*;
 
+    /// The cache previously stored bare URIs, so every item read back was relabelled
+    /// `PostLevelPersonalization` — silently mis-attributing fallback and author-affinity
+    /// items on every page after the first.
+    #[test]
+    fn cache_tag_roundtrips_every_source() {
+        let uri = "at://did:plc:abc123/app.bsky.feed.post/3ldefgh456";
+        for src in [
+            BlendedSource::PostLevelPersonalization,
+            BlendedSource::AuthorAffinity,
+            BlendedSource::Fallback {
+                tranche: "trending".to_string(),
+            },
+            BlendedSource::Fallback {
+                tranche: "discovery".to_string(),
+            },
+        ] {
+            let encoded = tagged_to_compact(uri, &src, None);
+            let (got_uri, got_src, got_ranker) = compact_to_tagged(&encoded);
+            assert_eq!(got_ranker, None);
+            assert_eq!(got_uri, uri);
+            assert_eq!(source_to_tag(&got_src), source_to_tag(&src));
+        }
+    }
+
+    /// Entries written before the tagged format existed must still decode, so deploying does
+    /// not garble in-flight caches.
+    #[test]
+    fn legacy_untagged_cache_entries_still_decode() {
+        let legacy = uri_to_compact("at://did:plc:abc123/app.bsky.feed.post/3ldefgh456");
+        assert!(!legacy.contains(CACHE_TAG_SEP));
+        let (uri, src, ranker) = compact_to_tagged(&legacy);
+        assert_eq!(ranker, None);
+        assert_eq!(uri, "at://did:plc:abc123/app.bsky.feed.post/3ldefgh456");
+        assert!(matches!(src, BlendedSource::PostLevelPersonalization));
+    }
+
+    /// A tag written by a newer build must not panic or lose the URI.
+    #[test]
+    fn unknown_tag_degrades_to_personalized_without_losing_the_uri() {
+        let entry = format!(
+            "p/somefutureranker{}{}",
+            CACHE_TAG_SEP,
+            uri_to_compact("at://did:plc:abc123/app.bsky.feed.post/3ldefgh456")
+        );
+        let (uri, src, _) = compact_to_tagged(&entry);
+        assert_eq!(uri, "at://did:plc:abc123/app.bsky.feed.post/3ldefgh456");
+        assert!(matches!(src, BlendedSource::PostLevelPersonalization));
+    }
+
+    /// A fallback tranche containing the separator must not corrupt the URI half.
+    #[test]
+    fn tranche_with_separator_does_not_corrupt_the_uri() {
+        let uri = "at://did:plc:abc123/app.bsky.feed.post/3ldefgh456";
+        let src = BlendedSource::Fallback {
+            tranche: format!("odd{}name", CACHE_TAG_SEP),
+        };
+        let (got_uri, _, _) = compact_to_tagged(&tagged_to_compact(uri, &src, None));
+        assert_eq!(got_uri, uri, "uri must survive a separator in the tranche");
+    }
+
+    /// Interleaving attribution must survive pagination, which is served from the `fsc:` cache.
+    /// Without this the ranker credit silently vanishes after page 1 and the experiment reads as
+    /// having no effect.
+    #[test]
+    fn cache_tag_roundtrips_the_interleaving_ranker() {
+        let uri = "at://did:plc:abc123/app.bsky.feed.post/3ldefgh456";
+        let src = BlendedSource::PostLevelPersonalization;
+        let encoded = tagged_to_compact(uri, &src, Some("sampled_walk"));
+        let (got_uri, got_src, got_ranker) = compact_to_tagged(&encoded);
+        assert_eq!(got_uri, uri);
+        assert!(matches!(got_src, BlendedSource::PostLevelPersonalization));
+        assert_eq!(got_ranker.as_deref(), Some("sampled_walk"));
+    }
+
+    /// A fallback item can also be attributed, and the tranche must survive alongside the ranker.
+    #[test]
+    fn cache_tag_keeps_tranche_and_ranker_together() {
+        let uri = "at://did:plc:abc123/app.bsky.feed.post/3ldefgh456";
+        let src = BlendedSource::Fallback {
+            tranche: "trending".to_string(),
+        };
+        let (got_uri, got_src, got_ranker) =
+            compact_to_tagged(&tagged_to_compact(uri, &src, Some("item_item")));
+        assert_eq!(got_uri, uri);
+        match got_src {
+            BlendedSource::Fallback { tranche } => assert_eq!(tranche, "trending"),
+            other => panic!("expected fallback, got {:?}", other),
+        }
+        assert_eq!(got_ranker.as_deref(), Some("item_item"));
+    }
+
     #[test]
     fn test_uri_to_compact() {
         let uri = "at://did:plc:abc123/app.bsky.feed.post/3ldefgh456";
@@ -1445,5 +1715,145 @@ mod tests {
     fn test_uri_roundtrip() {
         let uri = "at://did:plc:xyz789/app.bsky.feed.post/abc123";
         assert_eq!(compact_to_uri(&uri_to_compact(uri)), uri);
+    }
+}
+
+#[cfg(test)]
+mod holdout_assignment_tests {
+    use super::*;
+
+    fn dids(n: usize) -> Vec<String> {
+        (0..n)
+            .map(|i| format!("did:plc:testuser{:06}", i))
+            .collect()
+    }
+
+    #[test]
+    fn assignment_is_stable_for_a_user_across_calls() {
+        // The property the whole readout rests on. A per-request coin flip put active users in BOTH
+        // arms simultaneously, which attenuates any real effect toward zero — the first readout's
+        // +5.4% (p=0.91) is what that looks like whether or not personalization works.
+        for did in dids(50) {
+            let first = is_personalization_holdout_user(&did, "pholdout-v1", 0.2);
+            for _ in 0..20 {
+                assert_eq!(
+                    is_personalization_holdout_user(&did, "pholdout-v1", 0.2),
+                    first,
+                    "assignment must not vary between requests for {did}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn observed_rate_tracks_the_configured_rate() {
+        for rate in [0.05_f64, 0.2, 0.5] {
+            let n = 4000;
+            let held = dids(n)
+                .iter()
+                .filter(|d| is_personalization_holdout_user(d, "pholdout-v1", rate))
+                .count();
+            let observed = held as f64 / n as f64;
+            assert!(
+                (observed - rate).abs() < 0.03,
+                "rate {rate} produced {observed:.4} over {n} users"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_rate_holds_nobody_and_full_rate_holds_everybody() {
+        for did in dids(200) {
+            assert!(!is_personalization_holdout_user(&did, "s", 0.0));
+            assert!(is_personalization_holdout_user(&did, "s", 1.0));
+        }
+    }
+
+    #[test]
+    fn holdout_arm_does_not_depend_on_page_or_cursor() {
+        // The leak this replaces: the arm was decided only on first pages, so a paginated request
+        // whose cursor lacked `fallback_only` skipped the holdout, read `fsc:`, and served
+        // personalized content *labelled treated*. Measured: 5 users under both arms over three days,
+        // all mislabelled rows at depth 3-6, some with `source: personalized`.
+        //
+        // The arm is now derived from the DID alone. This test states that contract directly: nothing
+        // about the request — page number, cursor contents, request ordering — may enter the decision.
+        for did in dids(200) {
+            let arm = is_personalization_holdout_user(&did, "pholdout-v1", 0.2);
+            // Whatever a caller does between requests, the same inputs must give the same arm.
+            for _ in 0..5 {
+                assert_eq!(
+                    is_personalization_holdout_user(&did, "pholdout-v1", 0.2),
+                    arm,
+                    "arm for {did} must be a function of the DID, salt and rate only"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn holdout_membership_is_monotone_in_the_rate() {
+        // Raising the rate must only ever ADD users to the holdout, never swap them out. Otherwise a
+        // rate change would reassign existing members and silently invalidate accrued data beyond the
+        // documented "a rate change starts a new experiment" caveat.
+        let users = dids(1000);
+        for did in &users {
+            if is_personalization_holdout_user(did, "pholdout-v1", 0.05) {
+                assert!(
+                    is_personalization_holdout_user(did, "pholdout-v1", 0.20),
+                    "{did} was held out at 5% but not at 20%; membership is not monotone"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn changing_the_salt_reshuffles_membership() {
+        // Documented consequence: a salt change starts a new experiment rather than continuing one.
+        let users = dids(500);
+        let moved = users
+            .iter()
+            .filter(|d| {
+                is_personalization_holdout_user(d, "pholdout-v1", 0.2)
+                    != is_personalization_holdout_user(d, "pholdout-v2", 0.2)
+            })
+            .count();
+        assert!(
+            moved > 50,
+            "only {moved} of 500 users moved; salt is not reshuffling"
+        );
+    }
+
+    #[test]
+    fn holdout_is_orthogonal_to_the_interleaving_and_thompson_salts() {
+        // Sharing a salt would correlate holdout membership with bandit arms, so a holdout readout
+        // would partly be measuring the bandit. Assert the assignments are near-independent.
+        let users = dids(2000);
+        let mut both = 0usize;
+        let mut held = 0usize;
+        let mut other = 0usize;
+        for d in &users {
+            let h = is_personalization_holdout_user(d, "pholdout-v1", 0.5);
+            // Same construction the interleaving/Thompson assignment uses, different salt.
+            let x = graze_common::hash_did(&format!("interleave-salt|{}", d));
+            let o = u64::from_str_radix(&x[..15], 16)
+                .unwrap_or(0)
+                .is_multiple_of(2);
+            if h {
+                held += 1;
+            }
+            if o {
+                other += 1;
+            }
+            if h && o {
+                both += 1;
+            }
+        }
+        let expected = held as f64 * other as f64 / users.len() as f64;
+        let ratio = both as f64 / expected.max(1.0);
+        assert!(
+            (0.85..1.15).contains(&ratio),
+            "holdout and interleaving assignments are correlated: joint/expected = {ratio:.3}"
+        );
     }
 }

--- a/crates/graze-api/src/api/feed.rs
+++ b/crates/graze-api/src/api/feed.rs
@@ -122,6 +122,9 @@ fn encode_feed_context(
     is_personalization_holdout: Option<bool>,
     // Which ranker produced this item, when interleaving is active.
     ranker: Option<String>,
+    // Why this response was not personalized, when it was not. Carried into provenance so coverage
+    // failures are decomposable in ClickHouse instead of only in log lines.
+    fallback_reason: Option<String>,
 ) -> Option<String> {
     let (source, personalization_type, fallback_tranche, attribution, personalized) = match prov {
         ItemProvenance::Base(BlendedSource::PostLevelPersonalization) => (
@@ -190,6 +193,7 @@ fn encode_feed_context(
         is_holdout,
         is_personalization_holdout,
         ranker,
+        fallback_reason,
     };
     ctx.encode()
 }
@@ -586,6 +590,9 @@ pub async fn get_feed_skeleton(
                         None,
                         None,
                         None,
+                        // This whole branch is the empty-candidate-pool path; `emit_skip_log`
+                        // above records the same reason.
+                        Some("no_algo_posts".to_string()),
                     );
                     SkeletonFeedPost {
                         post: uri,
@@ -647,6 +654,8 @@ pub async fn get_feed_skeleton(
             is_holdout: None,
             is_personalization_holdout: None,
             ranker: None,
+            // Same reason the debug! above records: no candidate pool and no fallback either.
+            fallback_reason: Some("no_algo_posts".to_string()),
         }
         .encode();
         let response = FeedSkeletonResponse {
@@ -1298,6 +1307,7 @@ pub async fn get_feed_skeleton(
                     None
                 },
                 ranker_by_uri.get(uri).cloned(),
+                fallback_reason.map(str::to_string),
             );
             SkeletonFeedPost {
                 post: uri.clone(),

--- a/crates/graze-api/src/api/personalize.rs
+++ b/crates/graze-api/src/api/personalize.rs
@@ -17,7 +17,43 @@ use crate::api::RequestId;
 use crate::audit::{emit_skip_log, should_audit, AuditCollector};
 use crate::AppState;
 use graze_common::hash_did;
-use graze_common::models::PersonalizeRequest;
+use graze_common::is_excluded_post_uri;
+use graze_common::models::{PersonalizeRequest, PersonalizeResponse};
+
+async fn filter_excluded_uris_from_personalize_response(
+    state: &AppState,
+    response: &mut PersonalizeResponse,
+) {
+    if state.config.exclusion_dids.is_empty() {
+        return;
+    }
+    let ids_needing_uri: Vec<String> = response
+        .posts
+        .iter()
+        .filter(|p| p.uri.is_empty() && !p.post_id.is_empty())
+        .map(|p| p.post_id.clone())
+        .collect();
+    let uri_by_id = if ids_needing_uri.is_empty() {
+        std::collections::HashMap::new()
+    } else {
+        state
+            .interner
+            .get_uris_batch(&ids_needing_uri)
+            .await
+            .unwrap_or_default()
+    };
+    response.posts.retain(|p| {
+        let uri_ref: Option<&str> = if !p.uri.is_empty() {
+            Some(p.uri.as_str())
+        } else {
+            uri_by_id.get(&p.post_id).map(|s| s.as_str())
+        };
+        match uri_ref {
+            Some(u) => !is_excluded_post_uri(u, state.config.exclusion_dids.as_ref()),
+            None => true,
+        }
+    });
+}
 
 /// POST /v1/personalize
 ///
@@ -81,7 +117,8 @@ pub async fn personalize(
         )
         .await
     {
-        Ok(response) => {
+        Ok(mut response) => {
+            filter_excluded_uris_from_personalize_response(&state, &mut response).await;
             // Emit audit log if enabled
             if let Some(mut a) = audit {
                 let response_time_ms = request_start.elapsed().as_millis() as f64;
@@ -290,17 +327,14 @@ pub async fn author_affinity_diagnostic(
     {
         Ok(result) => {
             // Collect post IDs and scores
-            let scored: Vec<(f64, String, i64)> = result
+            let scored: Vec<(f64, String)> = result
                 .scored_posts
                 .into_iter()
                 .take(request.limit)
-                .filter_map(|(score, post_id)| {
-                    post_id.parse::<i64>().ok().map(|id| (score, post_id, id))
-                })
                 .collect();
 
             // Batch fetch URIs
-            let post_ids: Vec<i64> = scored.iter().map(|(_, _, id)| *id).collect();
+            let post_ids: Vec<String> = scored.iter().map(|(_, id)| id.clone()).collect();
             let uri_map = state
                 .interner
                 .get_uris_batch(&post_ids)
@@ -310,11 +344,16 @@ pub async fn author_affinity_diagnostic(
             // Convert to response format
             let posts: Vec<AuthorAffinityPost> = scored
                 .into_iter()
-                .filter_map(|(score, post_id, id)| {
-                    uri_map.get(&id).map(|uri| AuthorAffinityPost {
-                        uri: uri.clone(),
-                        score,
-                        post_id,
+                .filter_map(|(score, post_id)| {
+                    uri_map.get(&post_id).and_then(|uri| {
+                        if is_excluded_post_uri(uri, state.config.exclusion_dids.as_ref()) {
+                            return None;
+                        }
+                        Some(AuthorAffinityPost {
+                            uri: uri.clone(),
+                            score,
+                            post_id,
+                        })
                     })
                 })
                 .collect();

--- a/crates/graze-api/src/api/special_posts.rs
+++ b/crates/graze-api/src/api/special_posts.rs
@@ -44,7 +44,7 @@ pub fn inject_special_posts(
     base_posts: Vec<(String, BlendedSource)>,
     special_posts: &SpecialPostsResponse,
     feed_cursor: &FeedCursor,
-    _limit: usize,
+    limit: usize,
 ) -> (Vec<(String, ItemProvenance)>, FeedCursor) {
     // Make a copy of the cursor to update
     let mut new_cursor = FeedCursor {
@@ -225,6 +225,14 @@ pub fn inject_special_posts(
         }
     }
 
+    // Honour the caller's limit. This argument was previously ignored and nothing truncated
+    // afterwards, so responses could exceed the requested `limit` by the number of injected
+    // special posts — which also made tail positions (and therefore positional attribution)
+    // unstable. Specials are injected at low positions, so truncating the tail keeps them.
+    if limit > 0 && final_posts.len() > limit {
+        final_posts.truncate(limit);
+    }
+
     (final_posts, new_cursor)
 }
 
@@ -389,5 +397,43 @@ mod tests {
         assert_eq!(pinned, 2);
         assert_eq!(rotating, 1);
         assert_eq!(sponsored, 3);
+    }
+
+    /// `limit` was previously ignored and nothing truncated afterwards, so responses could
+    /// exceed the client's requested size by the number of injected specials — which also made
+    /// tail positions unstable, and positional attribution depends on them.
+    #[test]
+    fn injection_honours_the_requested_limit() {
+        let base: Vec<(String, BlendedSource)> = (0..10)
+            .map(|i| {
+                (
+                    format!("at://did:plc:base{}/app.bsky.feed.post/{}", i, i),
+                    BlendedSource::PostLevelPersonalization,
+                )
+            })
+            .collect();
+        let specials = SpecialPostsResponse {
+            algorithm_id: 1,
+            sponsorship_saturation_rate: 20,
+            pinned: vec![make_special_post(
+                "pin1",
+                "at://did:plc:pin/app.bsky.feed.post/1",
+            )],
+            sticky: vec![make_special_post(
+                "st1",
+                "at://did:plc:st/app.bsky.feed.post/1",
+            )],
+            sponsored: vec![],
+        };
+        let cursor = FeedCursor::new();
+        let (out, _) = inject_special_posts(base.clone(), &specials, &cursor, 10);
+        assert!(
+            out.len() <= 10,
+            "returned {} items for limit 10 (specials must not inflate the response)",
+            out.len()
+        );
+        // limit = 0 means "no limit" and must not truncate to nothing.
+        let (unbounded, _) = inject_special_posts(base, &specials, &cursor, 0);
+        assert!(unbounded.len() >= 10);
     }
 }

--- a/crates/graze-api/src/config.rs
+++ b/crates/graze-api/src/config.rs
@@ -2,7 +2,10 @@
 //!
 //! All configuration is loaded from environment variables.
 
-use graze_common::RedisConfig;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use graze_common::{exclusion_set_from_env_opt, RedisConfig};
 
 /// Application settings loaded from environment variables.
 #[derive(Debug, Clone)]
@@ -25,7 +28,204 @@ pub struct Config {
     pub inverted_min_post_likes: usize,
     pub inverted_max_likers_per_post: usize,
     pub inverted_max_posts_to_score: usize,
+    /// Skip personalization entirely when the feed's candidate pool
+    /// (`SCARD ap:{algo_id}`) is below this size. 0 disables the gate.
+    ///
+    /// Rationale (measured in prod, 25-min window, 359 scorer runs): candidate
+    /// pool size is the dominant predictor of how many posts get personalized —
+    /// r=0.604 (0.777 log-log) vs r=0.141 for co-liker source count. Requests
+    /// against a pool under 500 posts returned a MEDIAN OF ZERO scored posts
+    /// with a 74% zero rate, and accounted for 41% of all personalization
+    /// attempts. Those runs still paid for co-liker computation (27-106ms),
+    /// author-affinity supplementation (~106ms), a full SMEMBERS of the pool and
+    /// an HMGET of every liker count — to produce nothing. The 500-2k band, by
+    /// contrast, returned a median of 18, so the useful cut is at ~500, not
+    /// higher.
+    pub min_candidate_pool_for_personalization: usize,
     pub min_overlapping_colikers: usize,
+
+    /// How many days of like history the "does this user have seed?" gate looks back.
+    ///
+    /// Must match what the scorer actually reads (`DEFAULT_RETENTION_DAYS`), or users get
+    /// turned away with `fallback_reason=no_user_data` despite having seed the scorer would
+    /// have used. This was previously hardcoded to 2 days (today + yesterday) while the
+    /// scorer read 6, which measured as **14.0% of all daily-active users — 22.1% of every
+    /// seeded user — losing personalization for no reason.**
+    ///
+    /// Lower it to 2 to restore the old behaviour without a rebuild.
+    pub user_data_check_days: u32,
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Randomized parameter experiment + Thompson persistence — see THEORIES T19
+    // ═══════════════════════════════════════════════════════════════════════════════
+    /// Force one Thompson dimension to a randomized value chosen by hashing the user DID.
+    ///
+    /// Exists because Thompson assignment is adaptive, which makes retrospective arm comparisons
+    /// confounded — the `max_total_sources` signal appeared just as strongly on fallback posts the
+    /// parameter cannot affect. Hash assignment is orthogonal to time and bandit state.
+    pub ab_experiment_enabled: bool,
+    /// Bandit dimension to randomize: `min_likes`, `max_likers`, `max_sources`, `max_checks`,
+    /// `min_colikes`, `max_user_likes`, `max_src_per_post`, `seed_pool`, `corater_decay`.
+    pub ab_experiment_dimension: String,
+    /// Comma-separated values to randomize between, e.g. `250,10000`.
+    pub ab_experiment_values: Vec<usize>,
+    /// Percentage of users enrolled. Enrolled users are excluded from bandit learning.
+    pub ab_experiment_traffic_pct: u32,
+    /// Bump to re-randomize assignment.
+    pub ab_experiment_salt: String,
+
+    /// Persist Thompson bandit evidence to Redis and merge across replicas.
+    ///
+    /// Without this, arms are in-memory per pod and every deploy discards all learning across
+    /// three replicas — which is both why the search never converged and why arm selection
+    /// correlates with time.
+    pub thompson_persist_enabled: bool,
+    /// Seconds between flush-and-reload cycles.
+    pub thompson_persist_interval_seconds: u64,
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Inverted (co-liker-first) lookup — see THEORIES-personalization.md T7
+    // ═══════════════════════════════════════════════════════════════════════════════
+    /// Compute the co-liker-first arm alongside the post-first arm, log the comparison, and
+    /// **serve the post-first result**. Safe to leave on; it cannot change a response.
+    pub inverted_lookup_shadow_mode: bool,
+
+    /// Serve from the co-liker-first arm. Keep false until shadow mode confirms the coverage
+    /// and latency numbers on live traffic.
+    pub inverted_lookup_enabled: bool,
+
+    /// How many days of each co-liker's likes to read.
+    ///
+    /// Pool posts are capped at `SYNC_PREFERRED_MAX_AGE_HOURS` (72h), so a like on a pool post
+    /// cannot be older than that plus a margin; older shards only return posts that fail the
+    /// pool-membership test. 4 keeps a day of headroom over the 3-day pool.
+    pub inverted_coliker_like_days: u32,
+
+    /// Max recent likes to read per co-liker.
+    ///
+    /// This is where truncation moves to, and it is a much weaker bias than the post-first
+    /// `max_likers_per_post`: one cap per person rather than per post, the median seeded user
+    /// has only ~16 likes in the window, and a single ZREVRANGEBYSCORE returns 500 members as
+    /// cheaply as 30 — so raising it costs essentially nothing.
+    pub inverted_coliker_like_limit: usize,
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Sampled random walk (`SampledWalk` ranker) — see algorithm/walk.rs
+    // ═══════════════════════════════════════════════════════════════════════════════
+    /// Total walks to distribute across the user's seed posts.
+    ///
+    /// This is the *entire* cost knob: unlike both enumerative paths, work here is bounded by the
+    /// budget rather than by graph degree, which is what makes the 5,157-co-liker case affordable.
+    /// Salt for the per-user personalization-holdout assignment.
+    ///
+    /// Deliberately distinct from the Thompson and interleaving salts: sharing one would correlate
+    /// holdout membership with bandit arms, so a holdout readout would partly measure the bandit.
+    /// Changing this reshuffles who is held out, which starts a new experiment.
+    pub personalization_holdout_salt: String,
+
+    /// Minimum share of a feed's candidate pool that must clear `min_post_likes` before the engine
+    /// will spend a co-liker walk on that feed. `0.0` disables the gate.
+    ///
+    /// Measured across 64 live pools: 22 feeds have >=20% scoreable candidates, 27 are 5-20%, and 15
+    /// are below 5%. The distribution is not driven by pool size — algo 8352 has 596 posts and 22%
+    /// scoreable while algo 5395's 1,000 posts are 2% — so the existing
+    /// `min_candidate_pool_for_personalization` gate cannot separate them. Density can.
+    ///
+    /// This matters because algo 5395 is ~83% of all scoring traffic at 2% scoreable, so most of the
+    /// engine's compute currently goes to a feed that structurally cannot produce a ranking.
+    pub min_pool_scoreable_share: f64,
+
+    pub walk_count: usize,
+
+    /// Distinct co-likers whose like lists may be fetched in the second phase.
+    ///
+    /// Bounds the one pipelined fetch that dominates latency. The inverted path failed precisely
+    /// because it had no such bound.
+    pub walk_max_users: usize,
+
+    /// Likes to read per sampled co-liker.
+    pub walk_user_like_limit: usize,
+
+    /// Early stop once this many candidates have been visited `walk_early_stop_nv` times.
+    pub walk_early_stop_np: usize,
+
+    /// Visit threshold for [`Config::walk_early_stop_np`]. Zero disables early stopping.
+    pub walk_early_stop_nv: u32,
+
+    /// Exponent on the popularity discount. Zero disables it.
+    pub walk_popularity_power: f64,
+
+    /// Minimum visits before a candidate is ranked at all — the noise floor of a sampled estimate.
+    pub walk_min_visits: u32,
+
+    /// Below this many seed posts, fall back to exhaustive scoring.
+    ///
+    /// Sampling variance is worst exactly where the graph is smallest, and enumeration is cheap
+    /// there, so there is nothing to buy and accuracy to lose.
+    pub walk_min_seed_for_sampling: usize,
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Durable Co-liker Profiles (`ucl:`) — see DESIGN-durable-coliker-profiles.md
+    // ═══════════════════════════════════════════════════════════════════════════════
+    /// Phase B: compute a durable-profile arm alongside the live one, log the comparison,
+    /// and **serve nothing** from it. Safe to leave on — it cannot change any response.
+    ///
+    /// Costs one `GET` plus one extra scoring pass, and only for requests that would
+    /// otherwise early-exit with zero co-likers.
+    pub durable_profile_shadow_mode: bool,
+
+    /// Phase C: actually serve from the durable profile when the live path finds no
+    /// co-likers. Keep false until shadow mode shows the `overlap_count` distribution is
+    /// sane — `overlap_count` feeds a nonlinear `paths_boost`, so a ~128-member profile can
+    /// distort ranking rather than merely rescale it.
+    pub durable_profile_enabled: bool,
+
+    /// `min_post_likes` used **only** when scoring against a durable profile.
+    ///
+    /// Measured on algo 396 (10,703 candidates) with the global
+    /// `INVERTED_MIN_POST_LIKES=10`: 1,866 candidates had no likers, **5,048 (47%) were
+    /// dropped by this filter**, and of the ~3,789 survivors ~3,777 had no overlap with the
+    /// 128-member profile — leaving 12 scored. The filter is the single largest loss in the
+    /// funnel, and 10 is already stricter than the modal 5 seen in `feedContext`.
+    ///
+    /// Kept separate from `inverted_min_post_likes` so relaxing it cannot change what the
+    /// live arm serves: users the live path can already personalize never reach the durable
+    /// arm at all.
+    pub durable_profile_min_post_likes: usize,
+
+    /// `max_likers_per_post` used **only** when scoring against a durable profile.
+    ///
+    /// This is the dominant constraint on durable-profile reach, not `min_post_likes`. The
+    /// scorer fetches the N *most recent* likers per candidate, so a co-liker who liked
+    /// early is invisible — detection probability is `min(1, N/L)` for a post with L likers.
+    /// Measured on algo 396: **72–100% of a lurker's eligible overlapping candidates have
+    /// more than 30 likers**, and modelling `min(1, 30/L)` reproduced production almost
+    /// exactly (predicted 16/589/1/21 vs observed 12/500/2/24).
+    ///
+    /// Expected scoreable candidates by N for four sampled lurkers:
+    ///
+    /// | N | 30 | 100 | 200 | 500 | ∞ |
+    /// |---|---|---|---|---|---|
+    /// | A | 18 | 25 | 29 | 33 | 41 |
+    /// | B | 679 | 979 | 1064 | 1112 | 1141 |
+    /// | C | 1 | 2 | 2 | 4 | 7 |
+    /// | D | 21 | 37 | 43 | 52 | 67 |
+    ///
+    /// 100 captures most of the available gain (+39% to +100%) before returns flatten.
+    ///
+    /// Raising this for the durable arm **requires a separate liker cache** — the scorer
+    /// writes fetched liker lists back into its cache, so sharing one would leak longer
+    /// lists into the live arm and silently change what it scores.
+    pub durable_profile_max_likers_per_post: usize,
+
+    /// Target for the largest weight derived from a durable profile.
+    ///
+    /// Stored profile scores are `Σ 1/L_j` (order 1e-3..1e2), while live co-liker weights
+    /// are ~2e-7 and `max_coliker_weight` clamps at 1e-6. Weights are rescaled
+    /// rank-preservingly so the top entry lands here; absolute scale is load-bearing only
+    /// at that clamp and at `score > 0.0`, so this keeps the profile arm inside the same
+    /// regime as the live arm.
+    pub durable_profile_weight_target: f64,
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // Liker Cache Configuration
@@ -181,6 +381,41 @@ pub struct Config {
     pub max_posts_per_author: usize,
     pub author_diminishing_factor: f64,
     pub diversity_mmr_lambda: f64,
+    /// Keep ranking order through diversity instead of re-sorting by adjusted score.
+    ///
+    /// Needed by interleaving, whose team-draft order carries the ranker assignment. Off by
+    /// default; the per-author cap still applies when on.
+    pub diversity_preserve_order: bool,
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Interleaving (see experiment/interleave.rs, RESEARCH-personalization-directions.md)
+    // ═══════════════════════════════════════════════════════════════════════════════
+    /// Blend two rankers into one response and attribute engagement per item.
+    ///
+    /// This is the measurement unlock: within-user clustering inflates A/B variance 6.2x, so a
+    /// 20% effect needs ~48 days. Interleaving makes each user their own control — reported at
+    /// 50-100x sensitivity (Airbnb: same conclusion on 0.5% of the duration, 4% of traffic).
+    ///
+    /// Unlike the shadow modes, this changes what users see: both rankers really contribute.
+    pub interleave_enabled: bool,
+    /// Control ranker name (see `Ranker::parse`). Invalid names disable the experiment rather
+    /// than silently measuring the control against itself.
+    pub interleave_control: String,
+    /// Treatment ranker name.
+    pub interleave_treatment: String,
+    /// Percentage of eligible users enrolled.
+    pub interleave_traffic_pct: u32,
+    /// Bump to re-randomize both enrolment and the per-user draft coin flip.
+    pub interleave_salt: String,
+
+    /// Allow control and treatment to be the SAME ranker.
+    ///
+    /// Normally rejected as pointless, but it is the one production exposure that is provably
+    /// feed-neutral: two identical lists produce all-shared, all-untagged items in the original
+    /// order, so no user's feed changes while the full path (enrolment, draft, cache write/read,
+    /// provenance) is exercised. Use it to validate the harness before pointing it at a real
+    /// treatment.
+    pub interleave_self_check: bool,
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // HTTP Server Configuration
@@ -237,6 +472,11 @@ pub struct Config {
     pub clickhouse_password: String,
     pub clickhouse_database: String,
     pub clickhouse_secure: bool,
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Privacy / opt-out (EXCLUSION_LIST)
+    // ═══════════════════════════════════════════════════════════════════════════════
+    pub exclusion_dids: Arc<HashSet<String>>,
 }
 
 impl Config {
@@ -261,7 +501,56 @@ impl Config {
             inverted_min_post_likes: parse_usize_env("INVERTED_MIN_POST_LIKES", 10),
             inverted_max_likers_per_post: parse_usize_env("INVERTED_MAX_LIKERS_PER_POST", 30),
             inverted_max_posts_to_score: parse_usize_env("INVERTED_MAX_POSTS_TO_SCORE", 0),
+            // Defaults to 0 (gate disabled) so merging cannot silently change what
+            // users are served. Recommended rollout value: 500.
+            min_candidate_pool_for_personalization: parse_usize_env(
+                "MIN_CANDIDATE_POOL_FOR_PERSONALIZATION",
+                0,
+            ),
             min_overlapping_colikers: parse_usize_env("MIN_OVERLAPPING_COLIKERS", 1),
+            user_data_check_days: parse_u32_env(
+                "USER_DATA_CHECK_DAYS",
+                graze_common::DEFAULT_RETENTION_DAYS,
+            ),
+            ab_experiment_enabled: parse_bool_env("AB_EXPERIMENT_ENABLED", false),
+            ab_experiment_dimension: default_env("AB_EXPERIMENT_DIMENSION", "max_sources"),
+            ab_experiment_values: default_env("AB_EXPERIMENT_VALUES", "250,10000")
+                .split(',')
+                .filter_map(|v| v.trim().parse::<usize>().ok())
+                .collect(),
+            ab_experiment_traffic_pct: parse_u32_env("AB_EXPERIMENT_TRAFFIC_PCT", 100).min(100),
+            ab_experiment_salt: default_env("AB_EXPERIMENT_SALT", "v1"),
+            thompson_persist_enabled: parse_bool_env("THOMPSON_PERSIST_ENABLED", false),
+            thompson_persist_interval_seconds: parse_u64_env(
+                "THOMPSON_PERSIST_INTERVAL_SECONDS",
+                60,
+            ),
+            inverted_lookup_shadow_mode: parse_bool_env("INVERTED_LOOKUP_SHADOW_MODE", false),
+            inverted_lookup_enabled: parse_bool_env("INVERTED_LOOKUP_ENABLED", false),
+            inverted_coliker_like_days: parse_u32_env("INVERTED_COLIKER_LIKE_DAYS", 4),
+            inverted_coliker_like_limit: parse_usize_env("INVERTED_COLIKER_LIKE_LIMIT", 500),
+            min_pool_scoreable_share: parse_f64_env("MIN_POOL_SCOREABLE_SHARE", 0.0),
+            personalization_holdout_salt: std::env::var("PERSONALIZATION_HOLDOUT_SALT")
+                .unwrap_or_else(|_| "pholdout-v1".to_string()),
+            walk_count: parse_usize_env("WALK_COUNT", 2000),
+            walk_max_users: parse_usize_env("WALK_MAX_USERS", 256),
+            walk_user_like_limit: parse_usize_env("WALK_USER_LIKE_LIMIT", 200),
+            walk_early_stop_np: parse_usize_env("WALK_EARLY_STOP_NP", 200),
+            walk_early_stop_nv: parse_u32_env("WALK_EARLY_STOP_NV", 3),
+            walk_popularity_power: parse_f64_env("WALK_POPULARITY_POWER", 0.5),
+            walk_min_visits: parse_u32_env("WALK_MIN_VISITS", 1),
+            walk_min_seed_for_sampling: parse_usize_env("WALK_MIN_SEED_FOR_SAMPLING", 5),
+            durable_profile_shadow_mode: parse_bool_env("DURABLE_PROFILE_SHADOW_MODE", false),
+            durable_profile_enabled: parse_bool_env("DURABLE_PROFILE_ENABLED", false),
+            durable_profile_min_post_likes: parse_usize_env("DURABLE_PROFILE_MIN_POST_LIKES", 5),
+            durable_profile_max_likers_per_post: parse_usize_env(
+                "DURABLE_PROFILE_MAX_LIKERS_PER_POST",
+                100,
+            ),
+            durable_profile_weight_target: parse_f64_env(
+                "DURABLE_PROFILE_WEIGHT_TARGET",
+                0.0000002,
+            ),
 
             // Liker Cache
             liker_cache_enabled: parse_bool_env("LIKER_CACHE_ENABLED", true),
@@ -397,7 +686,7 @@ impl Config {
             default_max_user_likes: parse_usize_env("DEFAULT_MAX_USER_LIKES", 750),
             default_max_sources_per_post: parse_usize_env("DEFAULT_MAX_SOURCES_PER_POST", 100),
             default_min_co_likes: parse_usize_env("DEFAULT_MIN_CO_LIKES", 1),
-            default_time_window_hours: parse_f64_env("DEFAULT_TIME_WINDOW_HOURS", 168.0),
+            default_time_window_hours: parse_f64_env("DEFAULT_TIME_WINDOW_HOURS", 144.0),
             default_recency_half_life_hours: parse_f64_env("DEFAULT_RECENCY_HALF_LIFE_HOURS", 24.0),
             default_specificity_power: parse_f64_env("DEFAULT_SPECIFICITY_POWER", 1.0),
             default_popularity_power: parse_f64_env("DEFAULT_POPULARITY_POWER", 0.6),
@@ -410,6 +699,13 @@ impl Config {
             max_posts_per_author: parse_usize_env("MAX_POSTS_PER_AUTHOR", 3),
             author_diminishing_factor: parse_f64_env("AUTHOR_DIMINISHING_FACTOR", 0.5),
             diversity_mmr_lambda: parse_f64_env("DIVERSITY_MMR_LAMBDA", 0.3),
+            diversity_preserve_order: parse_bool_env("DIVERSITY_PRESERVE_ORDER", false),
+            interleave_enabled: parse_bool_env("INTERLEAVE_ENABLED", false),
+            interleave_control: default_env("INTERLEAVE_CONTROL", "post_first"),
+            interleave_treatment: default_env("INTERLEAVE_TREATMENT", "post_first"),
+            interleave_traffic_pct: parse_u32_env("INTERLEAVE_TRAFFIC_PCT", 100).min(100),
+            interleave_salt: default_env("INTERLEAVE_SALT", "v1"),
+            interleave_self_check: parse_bool_env("INTERLEAVE_SELF_CHECK", false),
 
             // HTTP Server
             http_host: default_env("HTTP_HOST", "0.0.0.0"),
@@ -437,7 +733,10 @@ impl Config {
             }),
 
             // Personalization Holdout (A/B test)
-            personalization_holdout_rate: parse_f64_env("PERSONALIZATION_HOLDOUT_RATE", 0.5),
+            // Cut from 0.5: half of authenticated first-page requests were skipping
+            // personalization entirely, which halved the traffic any experiment could learn
+            // from. 0.05 keeps a control group for absolute-lift measurement.
+            personalization_holdout_rate: parse_f64_env("PERSONALIZATION_HOLDOUT_RATE", 0.05),
 
             // Audit
             audit_enabled: parse_bool_env("AUDIT_ENABLED", false),
@@ -453,6 +752,8 @@ impl Config {
             clickhouse_password: default_env("CLICKHOUSE_PASSWORD", ""),
             clickhouse_database: default_env("CLICKHOUSE_DATABASE", "default"),
             clickhouse_secure: parse_bool_env("CLICKHOUSE_SECURE", false),
+
+            exclusion_dids: exclusion_set_from_env_opt(std::env::var("EXCLUSION_LIST").ok()),
         }
     }
 
@@ -512,5 +813,254 @@ fn parse_bool_env(name: &str, default: bool) -> bool {
     match std::env::var(name) {
         Ok(v) => matches!(v.to_lowercase().as_str(), "true" | "1" | "yes"),
         Err(_) => default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deploying the Phase B image must not change behaviour on its own. Both durable
+    /// profile flags have to be opt-in, so shipping the binary is inert until someone
+    /// sets the env var.
+    #[test]
+    fn durable_profile_flags_are_off_unless_set() {
+        // Guard against a stray value in the ambient environment invalidating the check.
+        if std::env::var("DURABLE_PROFILE_SHADOW_MODE").is_ok()
+            || std::env::var("DURABLE_PROFILE_ENABLED").is_ok()
+        {
+            return;
+        }
+        let c = Config::from_env();
+        assert!(
+            !c.durable_profile_shadow_mode,
+            "shadow mode must default off"
+        );
+        assert!(!c.durable_profile_enabled, "serving must default off");
+    }
+
+    /// The rescale target has to sit strictly below `max_coliker_weight`, or the scorer's
+    /// `weight.min(cap)` clamps every profile entry to the same value and ranking collapses
+    /// into arbitrary tie order.
+    #[test]
+    fn weight_target_stays_under_the_coliker_weight_cap() {
+        if std::env::var("DURABLE_PROFILE_WEIGHT_TARGET").is_ok()
+            || std::env::var("MAX_COLIKER_WEIGHT").is_ok()
+        {
+            return;
+        }
+        let c = Config::from_env();
+        assert!(
+            c.durable_profile_weight_target > 0.0
+                && c.durable_profile_weight_target < c.max_coliker_weight,
+            "target {} must be in (0, {})",
+            c.durable_profile_weight_target,
+            c.max_coliker_weight
+        );
+    }
+}
+
+#[cfg(test)]
+mod durable_arm_tests {
+    use super::*;
+
+    /// The durable arm must not be able to change what the live arm serves. The only
+    /// intended difference is `min_post_likes`; if a future edit accidentally points the
+    /// live scorer at the relaxed value, this catches it.
+    #[test]
+    fn profile_min_post_likes_is_independent_of_the_live_filter() {
+        if std::env::var("DURABLE_PROFILE_MIN_POST_LIKES").is_ok()
+            || std::env::var("INVERTED_MIN_POST_LIKES").is_ok()
+        {
+            return;
+        }
+        let c = Config::from_env();
+        assert_eq!(c.inverted_min_post_likes, 10, "live arm default unchanged");
+        assert_eq!(c.durable_profile_min_post_likes, 5, "durable arm relaxed");
+        assert!(
+            c.durable_profile_min_post_likes <= c.inverted_min_post_likes,
+            "relaxing the durable arm is the whole point; {} > {}",
+            c.durable_profile_min_post_likes,
+            c.inverted_min_post_likes
+        );
+    }
+
+    /// `max_likers_per_post` is the dominant reach constraint: detection probability for a
+    /// co-liker on a post with L likers is `min(1, N/L)`, and 72-100% of eligible candidates
+    /// have L > 30. The durable arm must relax it, and the live arm must not move.
+    #[test]
+    fn profile_max_likers_is_relaxed_without_touching_the_live_arm() {
+        if std::env::var("DURABLE_PROFILE_MAX_LIKERS_PER_POST").is_ok()
+            || std::env::var("INVERTED_MAX_LIKERS_PER_POST").is_ok()
+        {
+            return;
+        }
+        let c = Config::from_env();
+        assert_eq!(c.inverted_max_likers_per_post, 30, "live arm unchanged");
+        assert_eq!(c.durable_profile_max_likers_per_post, 100);
+        assert!(c.durable_profile_max_likers_per_post > c.inverted_max_likers_per_post);
+    }
+}
+
+#[cfg(test)]
+mod seed_gate_tests {
+    use super::*;
+
+    /// The seed gate must look back at least as far as the scorer reads, or users are turned
+    /// away with `no_user_data` despite having seed the scorer would have used. Measured: a
+    /// 2-day gate against a 6-day scorer lost 14.0% of all DAU (22.1% of seeded users).
+    #[test]
+    fn seed_gate_window_matches_what_the_scorer_reads() {
+        if std::env::var("USER_DATA_CHECK_DAYS").is_ok() {
+            return;
+        }
+        let c = Config::from_env();
+        assert_eq!(
+            c.user_data_check_days,
+            graze_common::DEFAULT_RETENTION_DAYS,
+            "gate window must equal the scorer's retention window"
+        );
+        assert!(
+            c.user_data_check_days >= 2,
+            "must not regress below the old 2-day behaviour"
+        );
+    }
+}
+
+#[cfg(test)]
+mod inverted_lookup_tests {
+    use super::*;
+
+    /// Deploying must not change behaviour on its own: both arms opt-in.
+    #[test]
+    fn inverted_lookup_flags_default_off() {
+        if std::env::var("INVERTED_LOOKUP_SHADOW_MODE").is_ok()
+            || std::env::var("INVERTED_LOOKUP_ENABLED").is_ok()
+        {
+            return;
+        }
+        let c = Config::from_env();
+        assert!(!c.inverted_lookup_shadow_mode);
+        assert!(!c.inverted_lookup_enabled);
+    }
+
+    /// The co-liker like window must cover the pool's age span, or the inverted arm cannot see
+    /// likes on the oldest pool posts. Pool age is capped at SYNC_PREFERRED_MAX_AGE_HOURS (72h
+    /// = 3 days), so 4 days leaves a day of headroom.
+    #[test]
+    fn coliker_like_window_covers_the_pool_age_span() {
+        if std::env::var("INVERTED_COLIKER_LIKE_DAYS").is_ok() {
+            return;
+        }
+        let c = Config::from_env();
+        assert!(
+            c.inverted_coliker_like_days >= 4,
+            "must cover the 3-day pool span plus headroom, got {}",
+            c.inverted_coliker_like_days
+        );
+        assert!(
+            c.inverted_coliker_like_days <= graze_common::DEFAULT_RETENTION_DAYS,
+            "reading beyond retention wastes ops on keys that cannot exist"
+        );
+    }
+
+    /// Truncation moves to the co-liker side, so the per-co-liker cap must be far more generous
+    /// than the per-post cap it replaces — that is the whole point of the inversion.
+    #[test]
+    fn coliker_like_limit_is_generous_relative_to_the_per_post_cap() {
+        if std::env::var("INVERTED_COLIKER_LIKE_LIMIT").is_ok() {
+            return;
+        }
+        let c = Config::from_env();
+        assert!(
+            c.inverted_coliker_like_limit >= 10 * c.inverted_max_likers_per_post,
+            "per-co-liker cap {} should dwarf the per-post cap {}",
+            c.inverted_coliker_like_limit,
+            c.inverted_max_likers_per_post
+        );
+    }
+}
+
+#[cfg(test)]
+mod interleave_config_tests {
+    use super::*;
+
+    /// Deploying the image must not change any feed on its own.
+    #[test]
+    fn interleaving_defaults_off_and_neutral() {
+        for k in [
+            "INTERLEAVE_ENABLED",
+            "INTERLEAVE_SELF_CHECK",
+            "DIVERSITY_PRESERVE_ORDER",
+            "INTERLEAVE_TREATMENT",
+        ] {
+            if std::env::var(k).is_ok() {
+                return;
+            }
+        }
+        let c = Config::from_env();
+        assert!(!c.interleave_enabled);
+        assert!(!c.interleave_self_check);
+        assert!(!c.diversity_preserve_order);
+        // Control == treatment by default, so even a stray INTERLEAVE_ENABLED=1 is a no-op
+        // rather than an accidental live comparison against an unspecified ranker.
+        assert_eq!(c.interleave_control, c.interleave_treatment);
+    }
+
+    /// The holdout cut is what makes interleaving worth running; guard it against regression.
+    #[test]
+    fn personalization_holdout_is_no_longer_half_the_traffic() {
+        if std::env::var("PERSONALIZATION_HOLDOUT_RATE").is_ok() {
+            return;
+        }
+        let c = Config::from_env();
+        assert!(
+            c.personalization_holdout_rate <= 0.1,
+            "holdout {} would halve experiment throughput",
+            c.personalization_holdout_rate
+        );
+        assert!(
+            c.personalization_holdout_rate > 0.0,
+            "keep a control group for absolute-lift measurement"
+        );
+    }
+}
+
+#[cfg(test)]
+mod density_gate_guards {
+    use super::*;
+
+    #[test]
+    fn density_gate_defaults_to_disabled() {
+        // Must ship inert. Enabling it by default would silently stop personalizing feeds before we
+        // have measured what the gate actually skips.
+        let c = Config::from_env();
+        assert_eq!(
+            c.min_pool_scoreable_share, 0.0,
+            "MIN_POOL_SCOREABLE_SHARE must default to 0.0 (disabled)"
+        );
+    }
+
+    #[test]
+    fn density_gate_would_separate_the_feeds_we_measured() {
+        // Real measured shares at min_post_likes=10. A gate at 0.05 must keep the viable feeds and
+        // skip the dead ones — including the pair that pool SIZE cannot separate (8352 is smaller
+        // than 5395 but far denser).
+        let measured: [(i32, f64, bool); 6] = [
+            (1988, 0.29, true),
+            (396, 0.36, true),
+            (8352, 0.22, true),  // 596 posts  — small but dense
+            (5395, 0.02, false), // 1,000 posts — larger but sparse
+            (4051, 0.01, false),
+            (30237, 0.003, false),
+        ];
+        let gate = 0.05;
+        for (algo, share, expect_personalize) in measured {
+            assert_eq!(
+                share >= gate,
+                expect_personalize,
+                "algo {algo} at share {share} classified wrongly by gate {gate}"
+            );
+        }
     }
 }

--- a/crates/graze-api/src/experiment/interleave.rs
+++ b/crates/graze-api/src/experiment/interleave.rs
@@ -1,0 +1,388 @@
+//! Team-draft interleaving for ranker comparison.
+//!
+//! # Why interleaving
+//!
+//! An A/B test splits users between two rankers, so the estimate carries between-user variance.
+//! Measured here: within-user clustering inflates variance **6.2×** (naive pooled z=3.59 vs
+//! cluster-correct permutation z=1.44), which at ~3,600 usable impressions/day means **48 days to
+//! detect a 20% effect** — about 4–8 well-powered experiments per year.
+//!
+//! Interleaving blends both rankers into a single response, so each user is their own control and
+//! the between-user variance disappears. Netflix reports up to **100×** sensitivity; Airbnb reached
+//! the same conclusion as the corresponding A/B using **0.5% of the running time and 4% of the
+//! traffic**, agreeing directionally 82% of the time.
+//!
+//! # Design: team draft with competitive pairs
+//!
+//! Following Airbnb: a single coin flip, derived from the user's DID so it is stable across
+//! requests and pages, decides which ranker drafts first. Then we repeatedly take the next
+//! not-yet-placed item from each ranker:
+//!
+//! - if the two items **differ**, they form a **competitive pair** and both are added, each tagged
+//!   with the ranker that contributed it;
+//! - if they are the **same** item, it is added once and left **untagged** — neither ranker earns
+//!   credit for something both would have shown anyway.
+//!
+//! The per-user statistic is `τᵢ = wins(treatment) − wins(control)` over that user's competitive
+//! pairs, aggregated as a proportion test across users.
+//!
+//! # Known limitations (respect these)
+//!
+//! Interleaving is **not valid** for set-level objectives such as diversity, for results reused by
+//! other surfaces, or for continuous metrics. Anything that changes diversity behaviour still needs
+//! a full A/B. Airbnb also observed a treatment looking *worse* under interleaving than in the
+//! following A/B, caused by comparative advantage when control had a higher base rate.
+
+use std::collections::HashSet;
+
+use graze_common::hash_did;
+
+/// A ranking strategy that can take part in an interleaving experiment.
+///
+/// Every later ranking approach plugs in here rather than forking the serving path, so each is
+/// measured the same way against the same control.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Ranker {
+    /// Current production path: iterate candidates, fetch `pl:{post}` per candidate.
+    PostFirst,
+    /// Co-liker-first traversal. Measured at 0.94× coverage and 5× latency; kept behind a flag
+    /// because it becomes competitive if co-liker sets shrink.
+    Inverted,
+    /// Seed restricted to the user's likes relevant to *this* feed (LinkLonk facets at Step 1).
+    PerFeedSeeded,
+    /// Offline author-author similarity.
+    ItemItem,
+    /// Pixie-style sampled random walk.
+    SampledWalk,
+    /// Learned two-tower embeddings.
+    TwoTower,
+}
+
+impl Ranker {
+    /// Stable wire name, used in the `feedContext` provenance and in config.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Ranker::PostFirst => "post_first",
+            Ranker::Inverted => "inverted",
+            Ranker::PerFeedSeeded => "per_feed_seeded",
+            Ranker::ItemItem => "item_item",
+            Ranker::SampledWalk => "sampled_walk",
+            Ranker::TwoTower => "two_tower",
+        }
+    }
+
+    /// Parse from config. Unknown names are **rejected** rather than defaulted, so a typo in an
+    /// experiment definition fails loudly instead of quietly measuring the control against itself.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim() {
+            "post_first" => Some(Ranker::PostFirst),
+            "inverted" => Some(Ranker::Inverted),
+            "per_feed_seeded" => Some(Ranker::PerFeedSeeded),
+            "item_item" => Some(Ranker::ItemItem),
+            "sampled_walk" => Some(Ranker::SampledWalk),
+            "two_tower" => Some(Ranker::TwoTower),
+            _ => None,
+        }
+    }
+}
+
+/// One item in an interleaved result.
+#[derive(Debug, Clone)]
+pub struct DraftedItem {
+    pub score: f64,
+    pub post_id: String,
+    /// Which ranker contributed this item. `None` when both rankers offered it, or when one list
+    /// was exhausted and the remainder came from the other — in both cases attribution would be
+    /// misleading, so the item is excluded from the preference statistic.
+    pub ranker: Option<Ranker>,
+}
+
+/// The result of a team draft.
+#[derive(Debug, Clone, Default)]
+pub struct Draft {
+    pub items: Vec<DraftedItem>,
+    /// Number of competitive pairs formed — the unit the preference statistic is computed over.
+    pub competitive_pairs: usize,
+    /// Items both rankers offered, added untagged.
+    pub shared_items: usize,
+    /// True when the control ranker drafted first for this user.
+    pub control_first: bool,
+}
+
+/// Decide deterministically, from the user, which ranker drafts first.
+///
+/// Stable per user so a feed does not reshuffle between requests or pages, and derived from a
+/// different hash input than experiment enrolment so the two are independent.
+pub fn control_drafts_first(user_did: &str, salt: &str) -> bool {
+    let h = hash_did(&format!("{}|draft|{}", salt, user_did));
+    u64::from_str_radix(&h, 16).unwrap_or(0).is_multiple_of(2)
+}
+
+/// Advance `idx` to the next item not already placed, returning it.
+fn next_unused<'a>(
+    list: &'a [(f64, String)],
+    idx: &mut usize,
+    placed: &HashSet<String>,
+) -> Option<&'a (f64, String)> {
+    while *idx < list.len() {
+        if !placed.contains(&list[*idx].1) {
+            return Some(&list[*idx]);
+        }
+        *idx += 1;
+    }
+    None
+}
+
+/// Interleave two ranked lists using team draft with competitive pairs.
+///
+/// `control` and `treatment` are `(score, post_id)` ranked best-first.
+///
+/// **The draft order *is* the ranking.** Each item keeps the score its contributing ranker gave it,
+/// and those scores are not comparable across rankers, so anything downstream that re-sorts by
+/// score destroys the assignment. The caller must therefore run diversity in `preserve_order` mode
+/// (`DIVERSITY_PRESERVE_ORDER`).
+pub fn team_draft(
+    control: &[(f64, String)],
+    treatment: &[(f64, String)],
+    control_ranker: Ranker,
+    treatment_ranker: Ranker,
+    control_first: bool,
+    limit: usize,
+) -> Draft {
+    let mut items: Vec<DraftedItem> = Vec::new();
+    let mut placed: HashSet<String> = HashSet::new();
+    let mut competitive_pairs = 0usize;
+    let mut shared_items = 0usize;
+    let (mut ci, mut ti) = (0usize, 0usize);
+
+    while items.len() < limit {
+        let c = next_unused(control, &mut ci, &placed).cloned();
+        let t = next_unused(treatment, &mut ti, &placed).cloned();
+
+        match (c, t) {
+            (None, None) => break,
+
+            // One list is exhausted. Keep filling from the other so the feed stays full, but do
+            // not tag: an unopposed item is not evidence of preference.
+            (Some(item), None) | (None, Some(item)) => {
+                placed.insert(item.1.clone());
+                items.push(DraftedItem {
+                    score: item.0,
+                    post_id: item.1,
+                    ranker: None,
+                });
+            }
+
+            (Some(c), Some(t)) if c.1 == t.1 => {
+                // Both rankers want the same post — add once, credit neither.
+                placed.insert(c.1.clone());
+                items.push(DraftedItem {
+                    score: c.0,
+                    post_id: c.1,
+                    ranker: None,
+                });
+                shared_items += 1;
+            }
+
+            (Some(c), Some(t)) => {
+                // A competitive pair. The per-user coin flip decides which side leads, so
+                // position bias does not systematically favour one ranker.
+                competitive_pairs += 1;
+                let mut pair = [
+                    DraftedItem {
+                        score: c.0,
+                        post_id: c.1,
+                        ranker: Some(control_ranker),
+                    },
+                    DraftedItem {
+                        score: t.0,
+                        post_id: t.1,
+                        ranker: Some(treatment_ranker),
+                    },
+                ];
+                if !control_first {
+                    pair.swap(0, 1);
+                }
+                for item in pair {
+                    if items.len() >= limit {
+                        break;
+                    }
+                    placed.insert(item.post_id.clone());
+                    items.push(item);
+                }
+            }
+        }
+    }
+
+    Draft {
+        items,
+        competitive_pairs,
+        shared_items,
+        control_first,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn list(ids: &[&str]) -> Vec<(f64, String)> {
+        ids.iter()
+            .enumerate()
+            .map(|(i, id)| (1.0 - i as f64 * 0.01, id.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn disjoint_lists_alternate_and_both_are_credited() {
+        let c = list(&["c1", "c2", "c3"]);
+        let t = list(&["t1", "t2", "t3"]);
+        let d = team_draft(&c, &t, Ranker::PostFirst, Ranker::SampledWalk, true, 6);
+        let ids: Vec<&str> = d.items.iter().map(|i| i.post_id.as_str()).collect();
+        assert_eq!(ids, vec!["c1", "t1", "c2", "t2", "c3", "t3"]);
+        assert_eq!(d.competitive_pairs, 3);
+        assert_eq!(d.shared_items, 0);
+        // Each side credited equally — the harness must not bias the count.
+        let control_count = d
+            .items
+            .iter()
+            .filter(|i| i.ranker == Some(Ranker::PostFirst))
+            .count();
+        assert_eq!(control_count, 3);
+    }
+
+    #[test]
+    fn coin_flip_controls_which_side_leads() {
+        let c = list(&["c1"]);
+        let t = list(&["t1"]);
+        let first = team_draft(&c, &t, Ranker::PostFirst, Ranker::SampledWalk, true, 2);
+        let second = team_draft(&c, &t, Ranker::PostFirst, Ranker::SampledWalk, false, 2);
+        assert_eq!(first.items[0].post_id, "c1");
+        assert_eq!(second.items[0].post_id, "t1");
+    }
+
+    /// Items both rankers would show carry no preference information, so neither may be credited.
+    /// Getting this wrong inflates whichever ranker happens to draft first.
+    #[test]
+    fn identical_items_are_added_once_and_untagged() {
+        let c = list(&["same1", "c2", "same2"]);
+        let t = list(&["same1", "t2", "same2"]);
+        let d = team_draft(&c, &t, Ranker::PostFirst, Ranker::SampledWalk, true, 10);
+        let ids: Vec<&str> = d.items.iter().map(|i| i.post_id.as_str()).collect();
+        assert_eq!(ids.iter().filter(|id| **id == "same1").count(), 1);
+        assert_eq!(ids.iter().filter(|id| **id == "same2").count(), 1);
+        assert_eq!(d.shared_items, 2);
+        assert_eq!(d.competitive_pairs, 1, "only c2/t2 compete");
+        for item in &d.items {
+            if item.post_id.starts_with("same") {
+                assert!(item.ranker.is_none(), "shared item must be untagged");
+            }
+        }
+    }
+
+    /// No post may appear twice in one feed, even if the two rankers order it differently.
+    #[test]
+    fn no_duplicates_across_the_whole_draft() {
+        let c = list(&["a", "b", "c", "d"]);
+        let t = list(&["d", "c", "b", "a"]);
+        let d = team_draft(&c, &t, Ranker::PostFirst, Ranker::SampledWalk, true, 10);
+        let ids: Vec<&str> = d.items.iter().map(|i| i.post_id.as_str()).collect();
+        let unique: HashSet<&&str> = ids.iter().collect();
+        assert_eq!(ids.len(), unique.len(), "duplicate in draft: {:?}", ids);
+    }
+
+    #[test]
+    fn respects_the_limit_including_mid_pair() {
+        let c = list(&["c1", "c2", "c3"]);
+        let t = list(&["t1", "t2", "t3"]);
+        for limit in 0..7 {
+            let d = team_draft(&c, &t, Ranker::PostFirst, Ranker::SampledWalk, true, limit);
+            assert!(d.items.len() <= limit, "limit {} exceeded", limit);
+        }
+        // An odd limit must be allowed to split a pair rather than overshoot.
+        let d = team_draft(&c, &t, Ranker::PostFirst, Ranker::SampledWalk, true, 3);
+        assert_eq!(d.items.len(), 3);
+    }
+
+    #[test]
+    fn exhausted_list_keeps_filling_but_stops_crediting() {
+        let c = list(&["c1", "c2", "c3", "c4"]);
+        let t = list(&["t1"]);
+        let d = team_draft(&c, &t, Ranker::PostFirst, Ranker::SampledWalk, true, 6);
+        assert_eq!(d.competitive_pairs, 1);
+        // Everything after the single pair is unopposed and therefore untagged.
+        let tagged = d.items.iter().filter(|i| i.ranker.is_some()).count();
+        assert_eq!(tagged, 2, "only the one pair is credited");
+        assert_eq!(d.items.len(), 5);
+    }
+
+    #[test]
+    fn empty_inputs_are_handled() {
+        let empty: Vec<(f64, String)> = vec![];
+        let d = team_draft(
+            &empty,
+            &empty,
+            Ranker::PostFirst,
+            Ranker::SampledWalk,
+            true,
+            10,
+        );
+        assert!(d.items.is_empty());
+        assert_eq!(d.competitive_pairs, 0);
+
+        let c = list(&["c1"]);
+        let d = team_draft(&c, &empty, Ranker::PostFirst, Ranker::SampledWalk, true, 10);
+        assert_eq!(d.items.len(), 1);
+        assert!(d.items[0].ranker.is_none());
+    }
+
+    /// **The harness's own negative control.** Interleaving a ranker against itself must produce no
+    /// competitive pairs at all — every item is shared. If this ever fails, any measured preference
+    /// is an artifact of the harness rather than of the rankers.
+    #[test]
+    fn self_interleaving_yields_no_competitive_pairs() {
+        let c = list(&["a", "b", "c", "d", "e"]);
+        let d = team_draft(&c, &c, Ranker::PostFirst, Ranker::PostFirst, true, 10);
+        assert_eq!(
+            d.competitive_pairs, 0,
+            "a ranker cannot compete with itself"
+        );
+        assert_eq!(d.shared_items, 5);
+        assert!(d.items.iter().all(|i| i.ranker.is_none()));
+        let ids: Vec<&str> = d.items.iter().map(|i| i.post_id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b", "c", "d", "e"], "order preserved");
+    }
+
+    #[test]
+    fn draft_order_is_stable_per_user_and_split_evenly() {
+        let mut firsts = 0;
+        for i in 0..2000 {
+            let did = format!("did:plc:user{}", i);
+            let a = control_drafts_first(&did, "v1");
+            // Stability: repeated calls agree.
+            assert_eq!(a, control_drafts_first(&did, "v1"));
+            if a {
+                firsts += 1;
+            }
+        }
+        let frac = firsts as f64 / 2000.0;
+        assert!((0.45..0.55).contains(&frac), "coin flip skewed: {}", frac);
+    }
+
+    #[test]
+    fn ranker_names_roundtrip_and_reject_typos() {
+        for r in [
+            Ranker::PostFirst,
+            Ranker::Inverted,
+            Ranker::PerFeedSeeded,
+            Ranker::ItemItem,
+            Ranker::SampledWalk,
+            Ranker::TwoTower,
+        ] {
+            assert_eq!(Ranker::parse(r.as_str()), Some(r));
+        }
+        assert_eq!(Ranker::parse("post-first"), None);
+        assert_eq!(Ranker::parse(""), None);
+        assert_eq!(Ranker::parse("PostFirst"), None);
+    }
+}

--- a/crates/graze-api/src/experiment/mod.rs
+++ b/crates/graze-api/src/experiment/mod.rs
@@ -1,0 +1,9 @@
+//! Experiment harnesses for comparing ranking approaches.
+//!
+//! Measurement, not ranking, is the binding constraint on this system: within-user clustering
+//! inflates variance 6.2×, which at current traffic means ~48 days to detect a 20% effect. These
+//! harnesses exist to shrink that.
+
+pub mod interleave;
+
+pub use interleave::{control_drafts_first, team_draft, Draft, DraftedItem, Ranker};

--- a/crates/graze-api/src/lib.rs
+++ b/crates/graze-api/src/lib.rs
@@ -8,6 +8,7 @@ pub mod api;
 pub mod audit;
 pub mod config;
 pub mod error;
+pub mod experiment;
 pub mod interaction_queue;
 pub mod metrics;
 

--- a/crates/graze-api/src/main.rs
+++ b/crates/graze-api/src/main.rs
@@ -35,6 +35,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Load configuration
     let config = Config::from_env();
+    info!(
+        exclusion_did_count = config.exclusion_dids.len(),
+        "api_exclusion_config"
+    );
     let bind_addr = format!("{}:{}", config.http_host, config.http_port);
 
     // Capture metrics port before wrapping config in Arc
@@ -105,6 +109,46 @@ async fn main() -> anyhow::Result<()> {
 
     // Create Thompson learner for adaptive parameter optimization
     let thompson = Arc::new(ThompsonLearner::new());
+
+    // Persist and merge Thompson bandit evidence across replicas.
+    //
+    // Arms were in-memory only, so every pod restart discarded all learning across three
+    // replicas — the search never converged, and arm selection ended up correlated with time
+    // (which is what confounded the retrospective analysis in THEORIES-personalization.md T19).
+    // Evidence is pushed as HINCRBYFLOAT deltas and re-read merged, so replicas accumulate
+    // instead of overwriting each other.
+    if config.thompson_persist_enabled {
+        let t = thompson.clone();
+        let r = redis.clone();
+        let interval = config.thompson_persist_interval_seconds.max(5);
+        tokio::spawn(async move {
+            // Load once before serving so a fresh pod starts from accumulated evidence.
+            match t.flush_and_reload(&r).await {
+                Ok((_, loaded)) => {
+                    tracing::info!(arms_loaded = loaded, "thompson_persist_initial_load")
+                }
+                Err(e) => tracing::warn!(error = %e, "thompson_persist_initial_load_failed"),
+            }
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                match t.flush_and_reload(&r).await {
+                    Ok((flushed, loaded)) => {
+                        if flushed > 0 || loaded > 0 {
+                            tracing::debug!(
+                                fields_flushed = flushed,
+                                arms_loaded = loaded,
+                                "thompson_persist_cycle"
+                            );
+                        }
+                    }
+                    Err(e) => tracing::warn!(error = %e, "thompson_persist_cycle_failed"),
+                }
+            }
+        });
+        tracing::info!(interval_seconds = interval, "thompson_persistence_enabled");
+    }
     info!(
         holdout_rate = 0.10,
         exploration_prob = 0.05,
@@ -139,6 +183,7 @@ async fn main() -> anyhow::Result<()> {
         interactions_config,
         redis.clone(),
         interaction_writer,
+        config.exclusion_dids.clone(),
     ));
     info!(
         interactions_logging_enabled = config.interactions_logging_enabled,

--- a/crates/graze-candidate-sync/src/bin/build_coliker_profiles.rs
+++ b/crates/graze-candidate-sync/src/bin/build_coliker_profiles.rs
@@ -1,0 +1,94 @@
+//! Build durable co-liker taste profiles (`ucl:{hash}`) from long-range like history.
+//!
+//! Phase A of `DESIGN-durable-coliker-profiles.md`: this writes `ucl:` keys and nothing
+//! else. No read path is wired up, so it cannot change what any user is served.
+//!
+//! Usage:
+//!   cargo run --release --bin graze-build-coliker-profiles
+//!
+//! Start with a dry run to see profile counts and sizes without writing:
+//!   PROFILE_DRY_RUN=1 PROFILE_ONLY_BUCKET=0 cargo run --release --bin graze-build-coliker-profiles
+//!
+//! Environment variables:
+//!   REDIS_URL                     Redis connection URL (required)
+//!   CLICKHOUSE_HOST/_PORT/...     ClickHouse connection (see graze-candidate-sync config)
+//!   PROFILE_DRY_RUN               Compute and report, write nothing (default: false)
+//!   PROFILE_ONLY_BUCKET           Build a single bucket instead of all (default: all)
+//!   PROFILE_CHUNK_COUNT           cityHash64 buckets to split the job into (default: 8)
+//!   PROFILE_MAX_COLIKERS          Profile size cap (default: 128)
+//!   PROFILE_MIN_SIZE              Skip profiles smaller than this (default: 10)
+//!   PROFILE_HISTORY_DAYS          Like history window for the seed (default: 365)
+//!   PROFILE_REQUESTER_WINDOW_DAYS Only profile users who requested a feed since (default: 30)
+//!   PROFILE_MIN_HISTORY_LIKES     Minimum lifetime likes (default: 20)
+//!   PROFILE_MAX_HISTORY_LIKES     Hyper-liker exclusion (default: 5000)
+//!   PROFILE_MAX_SEED_POSTS        Recent liked posts used as seed (default: 128)
+//!   PROFILE_MAX_SEED_POST_LIKERS  Drop seed posts above this liker count (default: 500)
+//!   PROFILE_TTL_DAYS              TTL on ucl: keys (default: 7)
+//!   PROFILE_WRITE_BATCH           Redis writes per pipeline (default: 500)
+//!   PROFILE_QUERY_TIMEOUT_SECS    Per-chunk ClickHouse timeout (default: 1800)
+
+use std::sync::Arc;
+
+use tracing::{info, Level};
+use tracing_subscriber::EnvFilter;
+
+use graze_candidate_sync::coliker_profiles::{ProfileBuilder, ProfileBuilderConfig};
+use graze_candidate_sync::config::Config;
+use graze_common::clickhouse::ClickHouseConfig;
+use graze_common::RedisClient;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(Level::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let config = Config::from_env();
+    let builder_config = ProfileBuilderConfig::from_env();
+
+    let clickhouse = Arc::new(ClickHouseConfig {
+        host: config.clickhouse_host.clone(),
+        port: config.clickhouse_port,
+        database: config.clickhouse_database.clone(),
+        user: config.clickhouse_user.clone(),
+        password: config.clickhouse_password.clone(),
+        secure: config.clickhouse_secure,
+    });
+
+    let redis = Arc::new(RedisClient::new(&config.redis_config()).await?);
+    info!(
+        clickhouse_host = %clickhouse.host,
+        database = %clickhouse.database,
+        "connected"
+    );
+
+    let stats = ProfileBuilder::new(clickhouse, redis, builder_config)
+        .run()
+        .await?;
+
+    // Phase A verification numbers: compare against the design's 118 MB / ~124-mean
+    // projections before wiring up any read path.
+    info!(
+        profiles_written = stats.profiles_written,
+        skipped_too_small = stats.skipped_too_small,
+        mean_profile_size = stats.mean_profile_size(),
+        bytes_written = stats.bytes_written,
+        megabytes_written = stats.bytes_written as f64 / 1_048_576.0,
+        chunks_failed = stats.chunks_failed,
+        "phase_a_summary"
+    );
+
+    if stats.chunks_failed > 0 {
+        anyhow::bail!(
+            "{} of {} chunks failed",
+            stats.chunks_failed,
+            stats.chunks_failed + stats.chunks_run
+        );
+    }
+
+    Ok(())
+}

--- a/crates/graze-candidate-sync/src/coliker_profiles.rs
+++ b/crates/graze-candidate-sync/src/coliker_profiles.rs
@@ -1,0 +1,545 @@
+//! Offline builder for durable co-liker taste profiles (`ucl:{hash}`).
+//!
+//! # What this solves
+//!
+//! The live co-liker derivation seeds from `ul:`, which retains 6 days. A user who liked
+//! 200 posts last month and nothing this week therefore derives **zero** co-likers and
+//! gets 100% fallback. Measured on production: of 138,745 feed requesters in 3 days,
+//! 13,196 have zero likes in the 6-day window but ≥20 in history, against 21,597 who are
+//! currently personalizable — a 61% larger addressable population.
+//!
+//! Long-range history lives in ClickHouse `user_action_logs` (`action_type =
+//! 'app.bsky.feed.like'`: ~141M likes across ~986k users, years deep). This job walks
+//! that history, derives each user's top-K co-likers, and stores them as a durable
+//! profile. Only the *seed* and *co-liker discovery* need history — the candidates being
+//! ranked still come from the live `pl:`/`ap:` graph — so a stored co-liker set is all
+//! that is required.
+//!
+//! For one sampled lurker this took scoreable candidates from **0 to 4,736 of algo 396's
+//! 10,473-post pool**, versus ~1,700–1,860 for a typical active user.
+//!
+//! # Why offline
+//!
+//! The co-liker self-join full-scans ~141M rows — impossible per request. It also does
+//! not fit in one query: a naive single-shot OOMed at 18 GiB with 2,000 users. Two bounds
+//! fix that and *improve* the signal, since both discard low-specificity mass:
+//!
+//! - seed capped to the most recent `max_seed_posts` liked posts per user;
+//! - seed posts with more than `max_seed_post_likers` likers dropped — a 5,000-liker post
+//!   contributes `1/5000` to `Σ 1/L_j` while dragging 5,000 rows into the join.
+//!
+//! Measured after those bounds: 2,000 users in 3m50s and 8,000 users in 4m50s (4× the
+//! users for 1.26× the time — the scan is a fixed cost, so prefer large chunks), with
+//! profiles still averaging ~124 of a 128 cap.
+//!
+//! # Phase A scope
+//!
+//! This writes `ucl:` keys and nothing else. No read path, no serving change. See
+//! `DESIGN-durable-coliker-profiles.md`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+
+use graze_common::clickhouse::ClickHouseConfig;
+use graze_common::{encode_profile_from_dids, hash_did, Keys, RedisClient};
+
+/// Tuning for the profile builder. Defaults match the measured design points.
+#[derive(Debug, Clone)]
+pub struct ProfileBuilderConfig {
+    /// How far back to read like history for the seed.
+    pub history_days: u32,
+    /// Only build profiles for users who requested a feed within this window.
+    pub requester_window_days: u32,
+    /// Minimum lifetime likes to bother building a profile.
+    pub min_history_likes: u32,
+    /// Upper bound excluding hyper-likers. `bot:filtered` holds only 13 users because
+    /// `BOT_LIKE_THRESHOLD=5000`/6d ≈ 833/day, so it cannot be relied on; sampling found
+    /// real accounts at 216,073 likes/year. 959 users sit above this bound.
+    pub max_history_likes: u32,
+    /// Most recent liked posts used as seed, per user.
+    pub max_seed_posts: u32,
+    /// Drop seed posts with more likers than this (viral-post filter).
+    pub max_seed_post_likers: u32,
+    /// Profile size cap. 128 keeps a ZSET listpack-encoded and the packed form at 1,536
+    /// bytes; measured coverage at 128 already exceeds what active users get.
+    pub max_colikers: u32,
+    /// Skip writing profiles smaller than this — a 1-member profile yields near-zero
+    /// coverage and gives `overlap_count` nothing to discriminate on.
+    pub min_profile_size: usize,
+    /// Number of `cityHash64(user_did) % n` buckets to split the job into.
+    pub chunk_count: u32,
+    /// Only build this single bucket, if set. Otherwise all buckets run in sequence.
+    pub only_bucket: Option<u32>,
+    /// TTL on `ucl:` keys — long enough to survive several failed nightly runs.
+    pub profile_ttl_days: u32,
+    /// Redis writes per pipeline.
+    pub write_batch: usize,
+    /// Per-chunk ClickHouse timeout.
+    pub query_timeout_secs: u64,
+    /// Compute and report, but write nothing.
+    pub dry_run: bool,
+}
+
+impl Default for ProfileBuilderConfig {
+    fn default() -> Self {
+        Self {
+            history_days: 365,
+            requester_window_days: 30,
+            min_history_likes: 20,
+            max_history_likes: 5_000,
+            max_seed_posts: 128,
+            max_seed_post_likers: 500,
+            max_colikers: 128,
+            min_profile_size: 10,
+            chunk_count: 8,
+            only_bucket: None,
+            profile_ttl_days: 7,
+            write_batch: 500,
+            query_timeout_secs: 1_800,
+            dry_run: false,
+        }
+    }
+}
+
+impl ProfileBuilderConfig {
+    /// Read overrides from the environment, falling back to [`Default`].
+    pub fn from_env() -> Self {
+        let d = Self::default();
+        Self {
+            history_days: env_u32("PROFILE_HISTORY_DAYS", d.history_days),
+            requester_window_days: env_u32(
+                "PROFILE_REQUESTER_WINDOW_DAYS",
+                d.requester_window_days,
+            ),
+            min_history_likes: env_u32("PROFILE_MIN_HISTORY_LIKES", d.min_history_likes),
+            max_history_likes: env_u32("PROFILE_MAX_HISTORY_LIKES", d.max_history_likes),
+            max_seed_posts: env_u32("PROFILE_MAX_SEED_POSTS", d.max_seed_posts),
+            max_seed_post_likers: env_u32("PROFILE_MAX_SEED_POST_LIKERS", d.max_seed_post_likers),
+            max_colikers: env_u32("PROFILE_MAX_COLIKERS", d.max_colikers),
+            min_profile_size: env_u32("PROFILE_MIN_SIZE", d.min_profile_size as u32) as usize,
+            chunk_count: env_u32("PROFILE_CHUNK_COUNT", d.chunk_count).max(1),
+            only_bucket: std::env::var("PROFILE_ONLY_BUCKET")
+                .ok()
+                .and_then(|s| s.parse().ok()),
+            profile_ttl_days: env_u32("PROFILE_TTL_DAYS", d.profile_ttl_days),
+            write_batch: env_u32("PROFILE_WRITE_BATCH", d.write_batch as u32) as usize,
+            query_timeout_secs: env_u32("PROFILE_QUERY_TIMEOUT_SECS", d.query_timeout_secs as u32)
+                as u64,
+            dry_run: std::env::var("PROFILE_DRY_RUN")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(d.dry_run),
+        }
+    }
+}
+
+fn env_u32(name: &str, default: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Totals across every chunk.
+#[derive(Debug, Default, Clone)]
+pub struct BuildStats {
+    pub chunks_run: u32,
+    pub chunks_failed: u32,
+    pub users_returned: usize,
+    pub profiles_written: usize,
+    pub skipped_too_small: usize,
+    pub entries_written: usize,
+    pub bytes_written: usize,
+}
+
+impl BuildStats {
+    fn merge(&mut self, other: &ChunkStats) {
+        self.users_returned += other.users_returned;
+        self.profiles_written += other.profiles_written;
+        self.skipped_too_small += other.skipped_too_small;
+        self.entries_written += other.entries_written;
+        self.bytes_written += other.bytes_written;
+    }
+
+    /// Mean profile size across everything written.
+    pub fn mean_profile_size(&self) -> f64 {
+        if self.profiles_written == 0 {
+            0.0
+        } else {
+            self.entries_written as f64 / self.profiles_written as f64
+        }
+    }
+}
+
+/// Per-chunk counters.
+#[derive(Debug, Default, Clone)]
+pub struct ChunkStats {
+    pub users_returned: usize,
+    pub profiles_written: usize,
+    pub skipped_too_small: usize,
+    pub entries_written: usize,
+    pub bytes_written: usize,
+}
+
+/// One row of the profile query: user DID, co-liker DIDs, and their scores.
+type ProfileRow = (String, Vec<String>, Vec<f64>);
+
+#[derive(Deserialize)]
+struct ChResponse {
+    data: Vec<ProfileRow>,
+}
+
+pub struct ProfileBuilder {
+    http: Client,
+    clickhouse: Arc<ClickHouseConfig>,
+    redis: Arc<RedisClient>,
+    config: ProfileBuilderConfig,
+}
+
+impl ProfileBuilder {
+    pub fn new(
+        clickhouse: Arc<ClickHouseConfig>,
+        redis: Arc<RedisClient>,
+        config: ProfileBuilderConfig,
+    ) -> Self {
+        let http = Client::builder()
+            .timeout(Duration::from_secs(config.query_timeout_secs))
+            .build()
+            .expect("HTTP client");
+        Self {
+            http,
+            clickhouse,
+            redis,
+            config,
+        }
+    }
+
+    /// Build every configured bucket in sequence.
+    ///
+    /// Buckets are independent and stable across runs (`cityHash64(user_did) % n`), so a
+    /// failed bucket can be retried on its own via `PROFILE_ONLY_BUCKET` without redoing
+    /// the rest. A bucket failure is logged and skipped rather than aborting the run.
+    pub async fn run(&self) -> anyhow::Result<BuildStats> {
+        let started = Instant::now();
+        let mut stats = BuildStats::default();
+
+        let buckets: Vec<u32> = match self.config.only_bucket {
+            Some(b) => vec![b],
+            None => (0..self.config.chunk_count).collect(),
+        };
+
+        info!(
+            buckets = buckets.len(),
+            chunk_count = self.config.chunk_count,
+            history_days = self.config.history_days,
+            max_colikers = self.config.max_colikers,
+            min_profile_size = self.config.min_profile_size,
+            dry_run = self.config.dry_run,
+            "coliker_profile_build_starting"
+        );
+
+        for bucket in buckets {
+            let t0 = Instant::now();
+            match self.run_chunk(bucket).await {
+                Ok(chunk) => {
+                    stats.chunks_run += 1;
+                    stats.merge(&chunk);
+                    info!(
+                        bucket,
+                        users_returned = chunk.users_returned,
+                        profiles_written = chunk.profiles_written,
+                        skipped_too_small = chunk.skipped_too_small,
+                        entries_written = chunk.entries_written,
+                        bytes_written = chunk.bytes_written,
+                        elapsed_secs = t0.elapsed().as_secs(),
+                        "coliker_profile_chunk_complete"
+                    );
+                }
+                Err(e) => {
+                    stats.chunks_failed += 1;
+                    warn!(
+                        bucket,
+                        elapsed_secs = t0.elapsed().as_secs(),
+                        error = %e,
+                        "coliker_profile_chunk_failed"
+                    );
+                }
+            }
+        }
+
+        info!(
+            chunks_run = stats.chunks_run,
+            chunks_failed = stats.chunks_failed,
+            users_returned = stats.users_returned,
+            profiles_written = stats.profiles_written,
+            skipped_too_small = stats.skipped_too_small,
+            mean_profile_size = stats.mean_profile_size(),
+            bytes_written = stats.bytes_written,
+            elapsed_secs = started.elapsed().as_secs(),
+            "coliker_profile_build_complete"
+        );
+
+        Ok(stats)
+    }
+
+    async fn run_chunk(&self, bucket: u32) -> anyhow::Result<ChunkStats> {
+        let rows = self.fetch_chunk(bucket).await?;
+        let mut stats = ChunkStats {
+            users_returned: rows.len(),
+            ..Default::default()
+        };
+
+        let ttl_secs = self.config.profile_ttl_days as u64 * 24 * 60 * 60;
+        let mut pending: Vec<(String, Vec<u8>)> = Vec::with_capacity(self.config.write_batch);
+
+        for (user_did, coliker_dids, scores) in rows {
+            // Zip and sort descending here rather than trusting groupArray() to preserve
+            // the subquery's ORDER BY under parallel execution.
+            let mut entries: Vec<(String, f64)> = coliker_dids
+                .into_iter()
+                .zip(scores)
+                .filter(|(did, score)| !did.is_empty() && score.is_finite() && *score > 0.0)
+                .collect();
+            entries.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
+            entries.truncate(self.config.max_colikers as usize);
+
+            if entries.len() < self.config.min_profile_size {
+                stats.skipped_too_small += 1;
+                continue;
+            }
+
+            let packed = encode_profile_from_dids(&entries);
+            if packed.is_empty() {
+                stats.skipped_too_small += 1;
+                continue;
+            }
+
+            stats.profiles_written += 1;
+            stats.entries_written += entries.len();
+            stats.bytes_written += packed.len();
+
+            if !self.config.dry_run {
+                pending.push((Keys::user_colikers(&hash_did(&user_did)), packed));
+                if pending.len() >= self.config.write_batch {
+                    self.redis.set_ex_bytes_multi(&pending, ttl_secs).await?;
+                    pending.clear();
+                }
+            }
+        }
+
+        if !pending.is_empty() {
+            self.redis.set_ex_bytes_multi(&pending, ttl_secs).await?;
+        }
+
+        Ok(stats)
+    }
+
+    async fn fetch_chunk(&self, bucket: u32) -> anyhow::Result<Vec<ProfileRow>> {
+        // Bound both windows client-side. `user_action_logs.action_time` for
+        // `app.bsky.feed.like` spans 2017→2038 (bad TIDs and clock skew), so every window
+        // needs an upper bound as well as a lower one.
+        let now = Utc::now();
+        let history_from = (now - chrono::Duration::days(self.config.history_days as i64))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        let requester_from = (now
+            - chrono::Duration::days(self.config.requester_window_days as i64))
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string();
+        let now_str = now.format("%Y-%m-%d %H:%M:%S").to_string();
+
+        debug!(
+            bucket,
+            history_from = %history_from,
+            requester_from = %requester_from,
+            "coliker_profile_query_starting"
+        );
+
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .query(&[
+                ("enable_http_compression", "1"),
+                (
+                    "max_execution_time",
+                    &self.config.query_timeout_secs.to_string(),
+                ),
+                ("join_algorithm", "parallel_hash"),
+                ("param_database", self.clickhouse.database.as_str()),
+                ("param_history_from", &history_from),
+                ("param_requester_from", &requester_from),
+                ("param_now", &now_str),
+                ("param_chunk_count", &self.config.chunk_count.to_string()),
+                ("param_bucket", &bucket.to_string()),
+                (
+                    "param_min_history",
+                    &self.config.min_history_likes.to_string(),
+                ),
+                (
+                    "param_max_history",
+                    &self.config.max_history_likes.to_string(),
+                ),
+                ("param_max_seed", &self.config.max_seed_posts.to_string()),
+                (
+                    "param_max_post_likers",
+                    &self.config.max_seed_post_likers.to_string(),
+                ),
+                ("param_max_colikers", &self.config.max_colikers.to_string()),
+            ])
+            .body(PROFILE_QUERY)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "ClickHouse profile query failed ({}): {}",
+                status,
+                &body[..body.len().min(600)]
+            );
+        }
+
+        let parsed: ChResponse = response.json().await?;
+        Ok(parsed.data)
+    }
+}
+
+/// The profile query.
+///
+/// Shape and bounds are the ones validated against production — see the module docs for
+/// the OOM this structure avoids. `LIMIT n BY u` does top-K per user server-side so
+/// nothing oversized is ever materialised client-side, and folding `lj` into `seed`
+/// (rather than joining it again in the outer query) removes one of the two chained joins
+/// that caused the original blow-up.
+const PROFILE_QUERY: &str = r#"
+WITH targets AS (
+    SELECT user_did
+    FROM (
+        SELECT user_did, count() AS c
+        FROM {database:Identifier}.user_action_logs
+        WHERE action_type = 'app.bsky.feed.like'
+          AND action_time >= {history_from:DateTime}
+          AND action_time <= {now:DateTime}
+          AND cityHash64(user_did) % {chunk_count:UInt32} = {bucket:UInt32}
+        GROUP BY user_did
+        HAVING c >= {min_history:UInt32} AND c <= {max_history:UInt32}
+    )
+    WHERE user_did IN (
+        SELECT DISTINCT user_did
+        FROM {database:Identifier}.user_action_logs
+        WHERE action_type = 'app.bsky.feed.defs#interactionSeen'
+          AND action_time >= {requester_from:DateTime}
+          AND action_time <= {now:DateTime}
+    )
+),
+seed0 AS (
+    SELECT user_did AS u, action_identifier AS post, min(action_time) AS t
+    FROM {database:Identifier}.user_action_logs
+    WHERE action_type = 'app.bsky.feed.like'
+      AND action_time >= {history_from:DateTime}
+      AND action_time <= {now:DateTime}
+      AND user_did IN (SELECT user_did FROM targets)
+    GROUP BY u, post
+    ORDER BY u, t DESC
+    LIMIT {max_seed:UInt32} BY u
+),
+lj AS (
+    SELECT action_identifier AS post, count() AS l
+    FROM {database:Identifier}.user_action_logs
+    WHERE action_type = 'app.bsky.feed.like'
+      AND action_identifier IN (SELECT DISTINCT post FROM seed0)
+    GROUP BY post
+    HAVING l <= {max_post_likers:UInt32}
+),
+seed AS (
+    SELECT s.u AS u, s.post AS post, s.t AS t, j.l AS l
+    FROM seed0 s
+    INNER JOIN lj j ON j.post = s.post
+)
+SELECT u, groupArray(cl) AS cls, groupArray(sc) AS scs
+FROM (
+    SELECT s.u AS u, o.user_did AS cl, sum(1.0 / s.l) AS sc
+    FROM {database:Identifier}.user_action_logs o
+    INNER JOIN seed s ON o.action_identifier = s.post
+    WHERE o.action_type = 'app.bsky.feed.like'
+      AND o.user_did != s.u
+      AND o.action_time < s.t
+    GROUP BY u, cl
+    ORDER BY u, sc DESC
+    LIMIT {max_colikers:UInt32} BY u
+)
+GROUP BY u
+FORMAT JSONCompact
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_the_measured_design_points() {
+        let c = ProfileBuilderConfig::default();
+        // 128 is the ZSET listpack boundary and the validated coverage point.
+        assert_eq!(c.max_colikers, 128);
+        assert_eq!(c.max_seed_posts, 128);
+        // The viral-post filter is what keeps the join inside the memory limit.
+        assert_eq!(c.max_seed_post_likers, 500);
+        // Excludes the 959 hyper-likers that the inert bot filter misses.
+        assert_eq!(c.max_history_likes, 5_000);
+    }
+
+    #[test]
+    fn ttl_outlives_several_failed_nightly_runs() {
+        let c = ProfileBuilderConfig::default();
+        assert!(c.profile_ttl_days >= 3, "ttl too tight for a nightly job");
+    }
+
+    #[test]
+    fn query_bounds_every_time_window_on_both_sides() {
+        // action_time spans 2017..2038 in production; an unbounded upper edge would pull
+        // in garbage timestamps.
+        assert_eq!(PROFILE_QUERY.matches("{now:DateTime}").count(), 3);
+        assert!(PROFILE_QUERY.contains("{history_from:DateTime}"));
+        assert!(PROFILE_QUERY.contains("{requester_from:DateTime}"));
+    }
+
+    #[test]
+    fn query_applies_both_cost_bounds() {
+        assert!(PROFILE_QUERY.contains("LIMIT {max_seed:UInt32} BY u"));
+        assert!(PROFILE_QUERY.contains("HAVING l <= {max_post_likers:UInt32}"));
+        assert!(PROFILE_QUERY.contains("LIMIT {max_colikers:UInt32} BY u"));
+    }
+
+    #[test]
+    fn query_excludes_self_and_respects_liked_before_me() {
+        assert!(PROFILE_QUERY.contains("o.user_did != s.u"));
+        assert!(PROFILE_QUERY.contains("o.action_time < s.t"));
+    }
+
+    #[test]
+    fn stats_mean_is_zero_without_writes() {
+        let s = BuildStats::default();
+        assert_eq!(s.mean_profile_size(), 0.0);
+    }
+
+    #[test]
+    fn stats_mean_tracks_entries_per_profile() {
+        let mut s = BuildStats::default();
+        s.merge(&ChunkStats {
+            users_returned: 10,
+            profiles_written: 4,
+            skipped_too_small: 6,
+            entries_written: 496,
+            bytes_written: 5_952,
+        });
+        assert_eq!(s.mean_profile_size(), 124.0);
+        assert_eq!(s.users_returned, 10);
+    }
+}

--- a/crates/graze-candidate-sync/src/config.rs
+++ b/crates/graze-candidate-sync/src/config.rs
@@ -2,7 +2,10 @@
 //!
 //! All configuration is loaded from environment variables.
 
-use graze_common::RedisConfig;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use graze_common::{exclusion_set_from_env_opt, RedisConfig};
 
 /// Application settings loaded from environment variables.
 #[derive(Debug, Clone)]
@@ -96,6 +99,11 @@ pub struct Config {
     // Metrics Configuration
     // ═══════════════════════════════════════════════════════════════════════════════
     pub metrics_port: u16,
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Privacy / opt-out (EXCLUSION_LIST)
+    // ═══════════════════════════════════════════════════════════════════════════════
+    pub exclusion_dids: Arc<HashSet<String>>,
 }
 
 impl Config {
@@ -180,6 +188,8 @@ impl Config {
 
             // Metrics
             metrics_port: parse_u16_env("METRICS_PORT", 0),
+
+            exclusion_dids: exclusion_set_from_env_opt(std::env::var("EXCLUSION_LIST").ok()),
         }
     }
 

--- a/crates/graze-candidate-sync/src/lib.rs
+++ b/crates/graze-candidate-sync/src/lib.rs
@@ -4,10 +4,12 @@
 //! candidates from ClickHouse to Redis, along with fallback tranches for trending,
 //! popular, velocity, and discovery posts.
 
+pub mod coliker_profiles;
 pub mod config;
 pub mod metrics;
 pub mod sync;
 
+pub use coliker_profiles::{BuildStats, ProfileBuilder, ProfileBuilderConfig};
 pub use config::Config;
 pub use metrics::SyncMetrics;
 pub use sync::CandidateSync;

--- a/crates/graze-candidate-sync/src/main.rs
+++ b/crates/graze-candidate-sync/src/main.rs
@@ -30,6 +30,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Load configuration
     let config = Config::from_env();
+    info!(
+        exclusion_did_count = config.exclusion_dids.len(),
+        "candidate_sync_exclusion_config"
+    );
 
     // Capture metrics port before wrapping config
     let metrics_port = config.metrics_port;

--- a/crates/graze-candidate-sync/src/sync.rs
+++ b/crates/graze-candidate-sync/src/sync.rs
@@ -18,7 +18,10 @@ use deadpool_redis::redis;
 
 use crate::config::Config;
 use graze_common::services::UriInterner;
-use graze_common::{CandidateSource, Keys, RedisClient, Result, DEFAULT_RETENTION_DAYS};
+use graze_common::{
+    hash_did, is_excluded_post_uri, CandidateSource, Keys, RedisClient, Result,
+    DEFAULT_RETENTION_DAYS,
+};
 
 /// Syncs algorithm candidates from a configurable source to Redis.
 pub struct CandidateSync {
@@ -257,7 +260,7 @@ impl CandidateSync {
         info!(algo_id = algo_id, "Sync starting");
 
         // Fetch candidates from configured source (ClickHouse, HTTP, or admin-only)
-        let posts = match self.source.fetch_candidates(algo_id).await {
+        let mut posts = match self.source.fetch_candidates(algo_id).await {
             Ok(p) => p,
             Err(e) => {
                 error!(algo_id = algo_id, error = %e, "Sync failed");
@@ -265,16 +268,24 @@ impl CandidateSync {
             }
         };
 
+        if !self.config.exclusion_dids.is_empty() {
+            posts.retain(|uri| !is_excluded_post_uri(uri, self.config.exclusion_dids.as_ref()));
+        }
+
         if posts.is_empty() {
             warn!(algo_id = algo_id, "No posts found");
             return Ok(());
         }
 
-        // Intern all URIs
-        let uri_to_id = self.interner.get_or_create_ids_batch(&posts).await?;
+        // Intern all URIs (shard = today; candidate-sync refreshes ap from URIs each run)
+        let intern_date = graze_common::today_date();
+        let uri_to_id = self
+            .interner
+            .get_or_create_ids_batch(&posts, &intern_date)
+            .await?;
 
         // Store posts in Redis (atomic swap)
-        let post_ids: Vec<i64> = uri_to_id.values().copied().collect();
+        let post_ids: Vec<String> = uri_to_id.values().cloned().collect();
         self.store_posts(algo_id, &post_ids).await?;
 
         let duration = start_time.elapsed();
@@ -303,7 +314,7 @@ impl CandidateSync {
     ///
     /// Also fetches and stores liker counts for each post to avoid
     /// ZCARD calls during scoring (major performance optimization).
-    async fn store_posts(&self, algo_id: i32, post_ids: &[i64]) -> Result<()> {
+    async fn store_posts(&self, algo_id: i32, post_ids: &[String]) -> Result<()> {
         let posts_key = Keys::algo_posts(algo_id);
         let counts_key = Keys::algo_posts_counts(algo_id);
         let meta_key = Keys::algo_meta(algo_id);
@@ -314,21 +325,17 @@ impl CandidateSync {
             return Ok(());
         }
 
-        // Convert IDs to strings for Redis
-        let str_ids: Vec<String> = post_ids.iter().map(|id| id.to_string()).collect();
-
         // Fetch liker counts using pipelined ZCARD across date-based keys
-        let post_liker_key_groups: Vec<Vec<String>> = str_ids
+        let post_liker_key_groups: Vec<Vec<String>> = post_ids
             .iter()
-            .map(|id| Keys::post_likers_retention(id, DEFAULT_RETENTION_DAYS))
+            .map(|id| Keys::post_likers_retention_bounded(id, DEFAULT_RETENTION_DAYS))
             .collect();
         let counts = self
             .redis
             .zcard_summed_multi(&post_liker_key_groups)
             .await?;
 
-        let liker_counts: HashMap<String, usize> =
-            str_ids.iter().cloned().zip(counts.into_iter()).collect();
+        let liker_counts: HashMap<String, usize> = post_ids.iter().cloned().zip(counts).collect();
 
         let ttl_seconds = self.config.algo_posts_ttl_hours as i64 * 60 * 60;
         let now = std::time::SystemTime::now()
@@ -345,7 +352,7 @@ impl CandidateSync {
         pipe.del(&temp_counts_key);
 
         // Store posts in temp key (SADD)
-        pipe.cmd("SADD").arg(&temp_key).arg(&str_ids);
+        pipe.cmd("SADD").arg(&temp_key).arg(post_ids);
 
         // Store liker counts in temp hash (HSET)
         if !liker_counts.is_empty() {
@@ -363,10 +370,33 @@ impl CandidateSync {
         pipe.cmd("RENAME").arg(&temp_counts_key).arg(&counts_key);
         pipe.expire(&counts_key, ttl_seconds);
 
+        // Like-density histogram for the pool, written alongside the pool itself.
+        //
+        // The serving path needs to know whether a feed can be personalized *at all* before spending
+        // the co-liker walk on it. Measured: algo 5395 is ~83% of all scoring traffic and only 2% of
+        // its candidates clear `min_post_likes = 10`, so nearly all the engine's compute goes to a feed
+        // that cannot produce a ranking. Pool *size* does not predict this — algo 8352 has 596 posts
+        // and 22% scoreable, while 5395's 1,000 posts are 2% — so density is the measure to publish.
+        //
+        // Free to compute: `liker_counts` is already in hand for every post. Stored as counts at
+        // several thresholds rather than one share, so the serving side can change its threshold
+        // without waiting on a candidate-sync redeploy.
+        let mut scoreable: Vec<(u32, usize)> = Vec::with_capacity(5);
+        for threshold in [1u32, 2, 3, 5, 10] {
+            let n = liker_counts
+                .values()
+                .filter(|c| **c >= threshold as usize)
+                .count();
+            scoreable.push((threshold, n));
+        }
+
         // Update metadata
-        pipe.cmd("HSET")
-            .arg(&meta_key)
-            .arg("last_sync")
+        let hset = pipe.cmd("HSET").arg(&meta_key);
+        for (threshold, n) in &scoreable {
+            hset.arg(format!("scoreable_{}", threshold))
+                .arg(n.to_string());
+        }
+        hset.arg("last_sync")
             .arg(now.to_string())
             .arg("post_count")
             .arg(post_ids.len().to_string());
@@ -441,7 +471,7 @@ impl CandidateSync {
             // Build date-based key groups for this batch
             let pl_key_groups: Vec<Vec<String>> = batch
                 .iter()
-                .map(|id| Keys::post_likers_retention(id, DEFAULT_RETENTION_DAYS))
+                .map(|id| Keys::post_likers_retention_bounded(id, DEFAULT_RETENTION_DAYS))
                 .collect();
 
             // Pipelined ZCARD summed across date-based keys
@@ -545,7 +575,7 @@ impl CandidateSync {
             // Build date-based key groups for this batch
             let pl_key_groups: Vec<Vec<String>> = batch
                 .iter()
-                .map(|id| Keys::post_likers_retention(id, DEFAULT_RETENTION_DAYS))
+                .map(|id| Keys::post_likers_retention_bounded(id, DEFAULT_RETENTION_DAYS))
                 .collect();
 
             // Pipelined ZCARD summed across date-based keys
@@ -647,7 +677,7 @@ impl CandidateSync {
             // Build date-based key groups for ZCOUNT (sum across all dates)
             let pl_key_groups: Vec<Vec<String>> = batch
                 .iter()
-                .map(|id| Keys::post_likers_retention(id, DEFAULT_RETENTION_DAYS))
+                .map(|id| Keys::post_likers_retention_bounded(id, DEFAULT_RETENTION_DAYS))
                 .collect();
 
             // Flatten keys for ZCOUNT
@@ -733,6 +763,46 @@ impl CandidateSync {
         Ok(())
     }
 
+    /// Store the set of author DID hashes present in an algorithm's candidate pool.
+    ///
+    /// Written to a temp key and renamed, matching `store_posts`, so readers never observe a
+    /// partially-built set — a half-written author set would silently shrink every seed derived from
+    /// it, which is exactly the kind of quiet degradation that is hard to attribute later.
+    async fn store_pool_authors(
+        &self,
+        algo_id: i32,
+        author_posts: &HashMap<String, Vec<(String, usize, i64)>>,
+    ) -> Result<()> {
+        let key = Keys::algo_pool_authors(algo_id);
+        if author_posts.is_empty() {
+            // Leave any existing set alone rather than replacing it with an empty one: an empty
+            // `apa:` key is indistinguishable at read time from "this feed has no authors", which
+            // would filter every seed to nothing.
+            return Ok(());
+        }
+
+        let hashes: Vec<String> = author_posts.keys().map(|did| hash_did(did)).collect();
+        let temp_key = format!("{}:temp", key);
+        let ttl_seconds = self.config.algo_posts_ttl_hours as i64 * 60 * 60;
+
+        let mut conn = self.redis.get().await?;
+        let mut pipe = redis::pipe();
+        pipe.del(&temp_key);
+        for chunk in hashes.chunks(1000) {
+            pipe.cmd("SADD").arg(&temp_key).arg(chunk);
+        }
+        pipe.cmd("RENAME").arg(&temp_key).arg(&key);
+        pipe.expire(&key, ttl_seconds);
+        let _: Vec<redis::Value> = pipe.query_async(&mut conn).await?;
+
+        debug!(
+            algo_id = algo_id,
+            author_count = hashes.len(),
+            "Pool author set stored"
+        );
+        Ok(())
+    }
+
     /// Sync author success scores and discovery posts.
     ///
     /// 1. Calculate author success = avg engagement across their posts in feed
@@ -755,8 +825,7 @@ impl CandidateSync {
         }
 
         // Get URIs for all posts to extract author DIDs
-        let int_ids: Vec<i64> = post_ids.iter().filter_map(|id| id.parse().ok()).collect();
-        let uri_mapping = self.interner.get_uris_batch(&int_ids).await?;
+        let uri_mapping = self.interner.get_uris_batch(&post_ids).await?;
 
         // Collect post data: {post_id: (like_count, post_time, author_did)}
         let mut post_data: HashMap<String, (usize, i64, Option<String>)> = HashMap::new();
@@ -768,7 +837,7 @@ impl CandidateSync {
             // Build date-based key groups for this batch
             let pl_key_groups: Vec<Vec<String>> = batch
                 .iter()
-                .map(|id| Keys::post_likers_retention(id, DEFAULT_RETENTION_DAYS))
+                .map(|id| Keys::post_likers_retention_bounded(id, DEFAULT_RETENTION_DAYS))
                 .collect();
 
             // Pipelined ZCARD summed across date-based keys
@@ -800,15 +869,9 @@ impl CandidateSync {
                     .unwrap_or(now);
 
                 // Extract author DID from URI
-                let author_did = if let Ok(id) = post_id.parse::<i64>() {
-                    if let Some(uri) = uri_mapping.get(&id) {
-                        extract_author_did(uri)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
+                let author_did = uri_mapping
+                    .get(post_id)
+                    .and_then(|uri| extract_author_did(uri));
 
                 post_data.insert(post_id.clone(), (*like_count, post_time, author_did));
             }
@@ -826,6 +889,26 @@ impl CandidateSync {
                     *post_time,
                 ));
             }
+        }
+
+        // Publish the pool's author set (`apa:{algo}`) while the author map is already in hand.
+        //
+        // This piggybacks deliberately rather than living in `store_posts`: that function has only
+        // post IDs, so building this there would mean a second interner round trip over the whole
+        // pool. Here `author_posts` is already keyed by author over the same `ap:{algo}` membership,
+        // so the set costs one pipeline.
+        //
+        // Note this includes *every* author with a post in the pool, not only "successful" ones —
+        // the set answers "does this feed carry this author at all", which is a membership question
+        // and must not inherit the `min_posts` threshold applied to success scoring below.
+        if let Err(e) = self.store_pool_authors(algo_id, &author_posts).await {
+            // Non-fatal: a missing `apa:` key makes per-feed seeding fall back to the unfaceted
+            // seed, which is the current behaviour. Failing the whole sync would be worse.
+            warn!(
+                algo_id = algo_id,
+                error = %e,
+                "Failed to store pool authors; per-feed seeding will fall back to the global seed"
+            );
         }
 
         // Calculate author success scores
@@ -963,7 +1046,7 @@ impl CandidateSync {
             // Build date-based key groups for this batch
             let key_groups: Vec<Vec<String>> = batch
                 .iter()
-                .map(|post_id| Keys::post_likers_retention(post_id, DEFAULT_RETENTION_DAYS))
+                .map(|post_id| Keys::post_likers_retention_bounded(post_id, DEFAULT_RETENTION_DAYS))
                 .collect();
 
             // Flatten all keys and fetch in parallel

--- a/crates/graze-common/src/coliker_profile.rs
+++ b/crates/graze-common/src/coliker_profile.rs
@@ -1,0 +1,192 @@
+//! Packed binary codec for durable co-liker profiles (`ucl:{hash}` keys).
+//!
+//! # Wire format
+//!
+//! A flat array of fixed-width entries, no header:
+//!
+//! ```text
+//! [ 8-byte raw DID hash | 4-byte big-endian f32 score ] × K
+//! ```
+//!
+//! # Why a packed string rather than a ZSET
+//!
+//! Profiles are rebuilt wholesale by a nightly batch job and always read in full, so
+//! none of a ZSET's incremental machinery (`ZADD`, `ZINCRBY`, `ZREMRANGEBYRANK`) or
+//! range-access capability is ever used. Measured on the production instance at K=128:
+//!
+//! | representation                | bytes/user |
+//! |-------------------------------|-----------:|
+//! | ZSET (16-hex member + score)  |      3,632 |
+//! | packed string (this format)   |  **1,840** |
+//!
+//! A single `GET` of 1,840 bytes also beats a 128-member `ZREVRANGE` on both round-trip
+//! payload and allocations.
+//!
+//! Note K=128 is not arbitrary: a ZSET crosses the listpack→skiplist boundary at 128
+//! members, where per-member cost jumps from 28.4 to 85.0 bytes. Keeping profiles at or
+//! below 128 keeps every representation cheap.
+//!
+//! # Why f32 for the score
+//!
+//! Scores are `Σ 1/L_j` over overlapping posts — in practice ~1e-3 to ~1e2. f32 carries
+//! ~7 significant decimal digits, far more than needed to order 128 neighbours, and saves
+//! 4 bytes per entry (25% of the payload) against f64.
+
+use crate::redis::hash_did;
+
+/// Raw bytes of a DID hash (`hash_did` returns this as 16 hex chars).
+pub const HASH_BYTES: usize = 8;
+
+/// Hex-encoded length of a DID hash.
+pub const HASH_HEX_LEN: usize = HASH_BYTES * 2;
+
+/// Bytes per profile entry: 8-byte hash + 4-byte f32 score.
+pub const PROFILE_ENTRY_BYTES: usize = HASH_BYTES + 4;
+
+/// Encode `(coliker_hash_hex, score)` pairs into the packed wire format.
+///
+/// Entries whose hash is not exactly [`HASH_HEX_LEN`] valid hex characters are skipped —
+/// a malformed row from an upstream query should not poison an entire profile. Input
+/// order is preserved, so callers should pass entries already sorted by descending score.
+pub fn encode_profile(entries: &[(String, f64)]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(entries.len() * PROFILE_ENTRY_BYTES);
+    for (hash_hex, score) in entries {
+        if hash_hex.len() != HASH_HEX_LEN {
+            continue;
+        }
+        let mut raw = [0u8; HASH_BYTES];
+        if hex::decode_to_slice(hash_hex.as_bytes(), &mut raw).is_err() {
+            continue;
+        }
+        out.extend_from_slice(&raw);
+        out.extend_from_slice(&(*score as f32).to_be_bytes());
+    }
+    out
+}
+
+/// Decode packed bytes back into `(coliker_hash_hex, score)` pairs.
+///
+/// A trailing partial entry is ignored rather than treated as an error, so a truncated
+/// value degrades to a shorter profile instead of failing the request.
+pub fn decode_profile(bytes: &[u8]) -> Vec<(String, f64)> {
+    let n = bytes.len() / PROFILE_ENTRY_BYTES;
+    let mut out = Vec::with_capacity(n);
+    for chunk in bytes.chunks_exact(PROFILE_ENTRY_BYTES) {
+        let hash_hex = hex::encode(&chunk[..HASH_BYTES]);
+        let score = f32::from_be_bytes([
+            chunk[HASH_BYTES],
+            chunk[HASH_BYTES + 1],
+            chunk[HASH_BYTES + 2],
+            chunk[HASH_BYTES + 3],
+        ]);
+        out.push((hash_hex, score as f64));
+    }
+    out
+}
+
+/// Number of entries a packed profile holds, without decoding it.
+#[inline]
+pub fn profile_len(bytes: &[u8]) -> usize {
+    bytes.len() / PROFILE_ENTRY_BYTES
+}
+
+/// Encode `(coliker_did, score)` pairs, hashing each DID first.
+///
+/// Convenience for the batch builder, which reads raw DIDs out of ClickHouse.
+pub fn encode_profile_from_dids(entries: &[(String, f64)]) -> Vec<u8> {
+    let hashed: Vec<(String, f64)> = entries
+        .iter()
+        .map(|(did, score)| (hash_did(did), *score))
+        .collect();
+    encode_profile(&hashed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_preserves_order_and_hashes() {
+        let entries = vec![
+            ("0123456789abcdef".to_string(), 12.5_f64),
+            ("fedcba9876543210".to_string(), 3.25_f64),
+            ("00000000000000ff".to_string(), 0.125_f64),
+        ];
+        let packed = encode_profile(&entries);
+        assert_eq!(packed.len(), 3 * PROFILE_ENTRY_BYTES);
+        assert_eq!(profile_len(&packed), 3);
+
+        let decoded = decode_profile(&packed);
+        assert_eq!(decoded.len(), 3);
+        for (i, (hash, score)) in decoded.iter().enumerate() {
+            assert_eq!(*hash, entries[i].0);
+            // 12.5 / 3.25 / 0.125 are all exactly representable in f32.
+            assert_eq!(*score, entries[i].1);
+        }
+    }
+
+    #[test]
+    fn packed_size_matches_design_budget() {
+        // 128 entries must be 1,536 bytes on the wire; the production measurement of
+        // 1,840 bytes of Valkey memory is this plus per-key overhead.
+        let entries: Vec<(String, f64)> = (0..128)
+            .map(|i| (format!("{:016x}", i), 1.0 / (i + 1) as f64))
+            .collect();
+        assert_eq!(encode_profile(&entries).len(), 1_536);
+    }
+
+    #[test]
+    fn skips_malformed_hashes_without_dropping_the_profile() {
+        let entries = vec![
+            ("0123456789abcdef".to_string(), 1.0),
+            ("tooshort".to_string(), 2.0),         // wrong length
+            ("zzzzzzzzzzzzzzzz".to_string(), 3.0), // not hex
+            ("fedcba9876543210".to_string(), 4.0),
+        ];
+        let decoded = decode_profile(&encode_profile(&entries));
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0].0, "0123456789abcdef");
+        assert_eq!(decoded[1].0, "fedcba9876543210");
+    }
+
+    #[test]
+    fn truncated_value_degrades_to_shorter_profile() {
+        let entries = vec![
+            ("0123456789abcdef".to_string(), 1.0),
+            ("fedcba9876543210".to_string(), 2.0),
+        ];
+        let mut packed = encode_profile(&entries);
+        packed.truncate(PROFILE_ENTRY_BYTES + 5); // one whole entry + a partial
+        let decoded = decode_profile(&packed);
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].0, "0123456789abcdef");
+    }
+
+    #[test]
+    fn empty_input_encodes_to_empty() {
+        assert!(encode_profile(&[]).is_empty());
+        assert!(decode_profile(&[]).is_empty());
+        assert_eq!(profile_len(&[]), 0);
+    }
+
+    #[test]
+    fn dids_are_hashed_to_16_hex_chars() {
+        let entries = vec![("did:plc:65lxax66ewvlshze4ytsdohk".to_string(), 1.5)];
+        let decoded = decode_profile(&encode_profile_from_dids(&entries));
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].0.len(), HASH_HEX_LEN);
+        assert_eq!(decoded[0].0, hash_did("did:plc:65lxax66ewvlshze4ytsdohk"));
+    }
+
+    #[test]
+    fn score_ordering_survives_f32_narrowing() {
+        // Ranking is what matters; confirm a realistic Sum(1/L_j) spread stays ordered.
+        let entries: Vec<(String, f64)> = (0..128)
+            .map(|i| (format!("{:016x}", i), 10.0 / (i + 1) as f64))
+            .collect();
+        let decoded = decode_profile(&encode_profile(&entries));
+        for w in decoded.windows(2) {
+            assert!(w[0].1 > w[1].1, "order broken at {:?}", w);
+        }
+    }
+}

--- a/crates/graze-common/src/exclusion.rs
+++ b/crates/graze-common/src/exclusion.rs
@@ -1,0 +1,199 @@
+//! DID exclusion list parsing for privacy opt-outs (`EXCLUSION_LIST` env).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Extract author DID from an AT-URI (`at://did:plc:xxx/app.bsky.feed.post/rkey`).
+pub fn author_did_from_at_uri(uri: &str) -> Option<&str> {
+    if !uri.starts_with("at://") {
+        return None;
+    }
+    let path = &uri[5..];
+    let end = path.find('/')?;
+    let did = &path[..end];
+    if did.starts_with("did:") {
+        Some(did)
+    } else {
+        None
+    }
+}
+
+/// Parse `EXCLUSION_LIST` content: comma- and newline-separated DIDs, trimmed, empties dropped.
+pub fn parse_exclusion_list(raw: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for part in raw.split([',', '\n', '\r']) {
+        let did = part.trim();
+        if !did.is_empty() {
+            out.insert(did.to_string());
+        }
+    }
+    out
+}
+
+/// Load exclusion set from optional env value (caller passes `std::env::var("EXCLUSION_LIST").ok()`).
+pub fn exclusion_set_from_env_opt(raw: Option<String>) -> Arc<HashSet<String>> {
+    match raw {
+        Some(s) if !s.trim().is_empty() => Arc::new(parse_exclusion_list(&s)),
+        _ => Arc::new(HashSet::new()),
+    }
+}
+
+#[inline]
+pub fn is_excluded_did(did: &str, excluded: &HashSet<String>) -> bool {
+    excluded.contains(did)
+}
+
+/// True if the post URI's author is in the exclusion set.
+pub fn is_excluded_post_uri(uri: &str, excluded: &HashSet<String>) -> bool {
+    author_did_from_at_uri(uri).is_some_and(|author| is_excluded_did(author, excluded))
+}
+
+/// Whether a like event from Jetstream should update the Redis graph (liker and post author must not be excluded).
+pub fn should_process_like_event(
+    liker_did: &str,
+    post_uri: &str,
+    excluded: &HashSet<String>,
+) -> bool {
+    if excluded.is_empty() {
+        return true;
+    }
+    if is_excluded_did(liker_did, excluded) {
+        return false;
+    }
+    if is_excluded_post_uri(post_uri, excluded) {
+        return false;
+    }
+    true
+}
+
+/// Whether an interaction may be written to analytics (viewer and post author must not be excluded).
+pub fn should_log_interaction(
+    viewer_did: &str,
+    interaction_item: &str,
+    excluded: &HashSet<String>,
+) -> bool {
+    if excluded.is_empty() {
+        return true;
+    }
+    if is_excluded_did(viewer_did, excluded) {
+        return false;
+    }
+    if is_excluded_post_uri(interaction_item, excluded) {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn author_did_from_at_uri_valid() {
+        assert_eq!(
+            author_did_from_at_uri("at://did:plc:abc/app.bsky.feed.post/3xyz"),
+            Some("did:plc:abc")
+        );
+    }
+
+    #[test]
+    fn author_did_from_at_uri_non_did_rejected() {
+        assert_eq!(author_did_from_at_uri("at://handle.example/post/1"), None);
+    }
+
+    #[test]
+    fn author_did_from_at_uri_not_at_uri() {
+        assert_eq!(author_did_from_at_uri("https://x"), None);
+    }
+
+    #[test]
+    fn parse_exclusion_list_commas_and_whitespace() {
+        let s = " did:plc:a , did:plc:b  ";
+        let set = parse_exclusion_list(s);
+        assert_eq!(set.len(), 2);
+        assert!(set.contains("did:plc:a"));
+        assert!(set.contains("did:plc:b"));
+    }
+
+    #[test]
+    fn parse_exclusion_list_newlines() {
+        let s = "did:plc:x\n\r\ndid:plc:y,";
+        let set = parse_exclusion_list(s);
+        assert_eq!(set.len(), 2);
+        assert!(set.contains("did:plc:x"));
+        assert!(set.contains("did:plc:y"));
+    }
+
+    #[test]
+    fn parse_exclusion_list_empty_tokens_ignored() {
+        assert!(parse_exclusion_list(",  ,\n").is_empty());
+    }
+
+    #[test]
+    fn excluded_post_uri_detects_author() {
+        let mut set = HashSet::new();
+        set.insert("did:plc:ex".to_string());
+        assert!(super::is_excluded_post_uri(
+            "at://did:plc:ex/app.bsky.feed.post/3a",
+            &set
+        ));
+        assert!(!super::is_excluded_post_uri(
+            "at://did:plc:ok/app.bsky.feed.post/3a",
+            &set
+        ));
+    }
+
+    #[test]
+    fn should_log_interaction_viewer_excluded() {
+        let mut set = HashSet::new();
+        set.insert("did:plc:viewer".to_string());
+        assert!(!should_log_interaction(
+            "did:plc:viewer",
+            "at://did:plc:other/app.bsky.feed.post/1",
+            &set
+        ));
+    }
+
+    #[test]
+    fn should_log_interaction_post_author_excluded() {
+        let mut set = HashSet::new();
+        set.insert("did:plc:author".to_string());
+        assert!(!should_log_interaction(
+            "did:plc:viewer",
+            "at://did:plc:author/app.bsky.feed.post/1",
+            &set
+        ));
+    }
+
+    #[test]
+    fn should_log_interaction_empty_set_accepts() {
+        let set = HashSet::new();
+        assert!(should_log_interaction(
+            "did:plc:any",
+            "at://did:plc:x/app.bsky.feed.post/1",
+            &set
+        ));
+    }
+
+    #[test]
+    fn should_process_like_event_liker_excluded() {
+        let mut set = HashSet::new();
+        set.insert("did:plc:liker".to_string());
+        assert!(!should_process_like_event(
+            "did:plc:liker",
+            "at://did:plc:author/app.bsky.feed.post/1",
+            &set
+        ));
+    }
+
+    #[test]
+    fn should_process_like_event_post_author_excluded() {
+        let mut set = HashSet::new();
+        set.insert("did:plc:author".to_string());
+        assert!(!should_process_like_event(
+            "did:plc:liker",
+            "at://did:plc:author/app.bsky.feed.post/1",
+            &set
+        ));
+    }
+}

--- a/crates/graze-common/src/lib.rs
+++ b/crates/graze-common/src/lib.rs
@@ -7,9 +7,12 @@
 //! - Shared models
 
 pub mod clickhouse;
+pub mod coliker_profile;
 pub mod error;
+pub mod exclusion;
 pub mod metrics_server;
 pub mod models;
+pub mod post_id;
 pub mod redis;
 pub mod services;
 
@@ -18,7 +21,17 @@ pub use clickhouse::{
     ClickHouseConfig, ClickHouseInteractionWriter, HttpCandidateSource, InteractionWriter,
     NoOpInteractionWriter,
 };
+pub use coliker_profile::{
+    decode_profile, encode_profile, encode_profile_from_dids, profile_len, PROFILE_ENTRY_BYTES,
+};
 pub use error::{GrazeError, Result};
+pub use exclusion::{
+    author_did_from_at_uri, exclusion_set_from_env_opt, is_excluded_did, is_excluded_post_uri,
+    parse_exclusion_list, should_log_interaction, should_process_like_event,
+};
+pub use post_id::{
+    format_post_id, intern_date_from_post_id, is_dated, is_legacy_numeric, DATED_ID_LEN,
+};
 pub use redis::{
     // New date-based functions
     date_from_timestamp,

--- a/crates/graze-common/src/models/feed_context.rs
+++ b/crates/graze-common/src/models/feed_context.rs
@@ -72,6 +72,19 @@ pub struct FeedContextProvenance {
         skip_serializing_if = "Option::is_none"
     )]
     pub is_personalization_holdout: Option<bool>,
+
+    /// Which ranker produced this item, when an interleaving experiment is running.
+    ///
+    /// Set only for interleaved items; `None` otherwise. Required for per-item attribution in
+    /// team-draft interleaving, where the whole point is that both rankers contribute to one
+    /// response and engagement must be credited to the right one.
+    ///
+    /// Safe to add without a ClickHouse migration: the blob is stored verbatim in
+    /// `interaction_feed_context String`, `decode` uses plain `serde_json::from_str` (which
+    /// ignores unknown keys), and the lenient consumer decoder reads only two fields.
+    #[serde(rename = "ranker", skip_serializing_if = "Option::is_none")]
+    pub ranker: Option<String>,
+
 }
 
 /// Compact personalization params for provenance.
@@ -172,6 +185,7 @@ mod tests {
             response_time_ms: Some(150.0),
             is_holdout: Some(false),
             is_personalization_holdout: None,
+            ranker: None,
         };
         let encoded = ctx.encode().expect("encode");
         let decoded = FeedContextProvenance::decode(&encoded).expect("decode");
@@ -194,4 +208,50 @@ mod tests {
     fn test_decode_feed_context_invalid_base64() {
         assert!(FeedContextProvenance::decode("!!!invalid!!!").is_none());
     }
+
+    /// The `ranker` field must be invisible when unset, so existing consumers and stored blobs
+    /// are unaffected, and must survive a round-trip when set.
+    #[test]
+    fn ranker_is_omitted_when_unset_and_roundtrips_when_set() {
+        let mut ctx = FeedContextProvenance {
+            feed_uri: "at://did:plc:abc/app.bsky.feed.generator/feed".to_string(),
+            algo_id: 1,
+            depth: 0,
+            personalized: true,
+            source: "personalized".to_string(),
+            personalization_type: None,
+            fallback_tranche: None,
+            total: 10,
+            personalized_count: 5,
+            attribution: None,
+            params: None,
+            response_time_ms: None,
+            is_holdout: None,
+            is_personalization_holdout: None,
+            ranker: None,
+        };
+        let json_absent = serde_json::to_string(&ctx).expect("serialize");
+        assert!(
+            !json_absent.contains("ranker"),
+            "unset ranker must not appear on the wire: {}",
+            json_absent
+        );
+
+        ctx.ranker = Some("sampled_walk".to_string());
+        let decoded =
+            FeedContextProvenance::decode(&ctx.encode().expect("encode")).expect("decode");
+        assert_eq!(decoded.ranker.as_deref(), Some("sampled_walk"));
+    }
+
+    /// A blob produced by an older build (no `ranker` key) must still decode — this is what
+    /// makes the field safe to add without a ClickHouse migration.
+    #[test]
+    fn blob_without_ranker_key_still_decodes() {
+        let legacy = r#"{"feed_uri":"at://x","algo_id":1,"depth":0,"personalized":false,"source":"fallback","total":1,"personalized_count":0}"#;
+        let ctx: FeedContextProvenance = serde_json::from_str(legacy).expect("legacy decode");
+        assert_eq!(ctx.ranker, None);
+        assert_eq!(ctx.source, "fallback");
+    }
+
+
 }

--- a/crates/graze-common/src/models/feed_context.rs
+++ b/crates/graze-common/src/models/feed_context.rs
@@ -85,6 +85,24 @@ pub struct FeedContextProvenance {
     #[serde(rename = "ranker", skip_serializing_if = "Option::is_none")]
     pub ranker: Option<String>,
 
+    /// Why this response was not personalized, when it was not.
+    ///
+    /// `no_user_data` (no seed in the like window) | `no_auth` (unauthenticated request) |
+    /// `no_algo_posts` (the feed's candidate pool is empty) | `personalization_holdout` |
+    /// `personalization_error`. `None` when the response *was* personalized.
+    ///
+    /// Exists because this reason was previously only ever written to a log line, so coverage
+    /// failures could not be decomposed in ClickHouse and every experiment silently mixed users
+    /// the engine served with users it could not serve. Measured 2026-08-25: 52% of the holdout
+    /// experiment's treatment arm received zero personalized impressions, which is the dominant
+    /// reason the readout will not converge.
+    ///
+    /// Safe to add without a ClickHouse migration, for the same reason `ranker` was: the blob is
+    /// stored verbatim in `interaction_feed_context String`, `decode` uses plain
+    /// `serde_json::from_str` (which ignores unknown keys), and the lenient consumer decoder reads
+    /// only two fields.
+    #[serde(rename = "fallback_reason", skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
 }
 
 /// Compact personalization params for provenance.
@@ -186,6 +204,7 @@ mod tests {
             is_holdout: Some(false),
             is_personalization_holdout: None,
             ranker: None,
+            fallback_reason: None,
         };
         let encoded = ctx.encode().expect("encode");
         let decoded = FeedContextProvenance::decode(&encoded).expect("decode");
@@ -229,6 +248,7 @@ mod tests {
             is_holdout: None,
             is_personalization_holdout: None,
             ranker: None,
+            fallback_reason: None,
         };
         let json_absent = serde_json::to_string(&ctx).expect("serialize");
         assert!(
@@ -253,5 +273,52 @@ mod tests {
         assert_eq!(ctx.source, "fallback");
     }
 
+    /// `fallback_reason` is what makes coverage failures decomposable in ClickHouse rather than
+    /// only in log lines. Two properties matter and both are asserted here: it must be absent from
+    /// the wire when the response *was* personalized (so personalized rows stay compact and are
+    /// distinguishable by the key's absence), and it must round-trip when set.
+    #[test]
+    fn fallback_reason_is_omitted_when_personalized_and_round_trips_when_set() {
+        let mut ctx = FeedContextProvenance {
+            feed_uri: "at://did:plc:abc/app.bsky.feed.generator/feed".to_string(),
+            algo_id: 1,
+            depth: 0,
+            personalized: true,
+            source: "personalized".to_string(),
+            personalization_type: None,
+            fallback_tranche: None,
+            total: 10,
+            personalized_count: 5,
+            attribution: None,
+            params: None,
+            response_time_ms: None,
+            is_holdout: None,
+            is_personalization_holdout: None,
+            ranker: None,
+            fallback_reason: None,
+        };
+        let json_absent = serde_json::to_string(&ctx).expect("serialize");
+        assert!(
+            !json_absent.contains("fallback_reason"),
+            "a personalized response must not carry fallback_reason: {}",
+            json_absent
+        );
 
+        ctx.personalized = false;
+        ctx.source = "fallback".to_string();
+        ctx.fallback_reason = Some("no_user_data".to_string());
+        let decoded =
+            FeedContextProvenance::decode(&ctx.encode().expect("encode")).expect("decode");
+        assert_eq!(decoded.fallback_reason.as_deref(), Some("no_user_data"));
+    }
+
+    /// The migration-free guarantee, stated for the new field: blobs written by every build before
+    /// this one carry no `fallback_reason` key, and must still decode rather than erroring.
+    #[test]
+    fn blob_without_fallback_reason_key_still_decodes() {
+        let legacy = r#"{"feed_uri":"at://x","algo_id":1,"depth":0,"personalized":false,"source":"fallback","total":1,"personalized_count":0}"#;
+        let ctx: FeedContextProvenance = serde_json::from_str(legacy).expect("legacy decode");
+        assert_eq!(ctx.fallback_reason, None);
+        assert_eq!(ctx.source, "fallback");
+    }
 }

--- a/crates/graze-common/src/models/responses.rs
+++ b/crates/graze-common/src/models/responses.rs
@@ -19,6 +19,13 @@ pub struct ScoredPost {
     /// Reasons why this post was recommended.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub reasons: Vec<String>,
+
+    /// Which ranker contributed this post, when an interleaving experiment is running.
+    ///
+    /// `None` outside experiments, and also for items both rankers offered (which carry no
+    /// preference information and must not be credited to either side).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ranker: Option<String>,
 }
 
 impl ScoredPost {
@@ -29,6 +36,7 @@ impl ScoredPost {
             post_id,
             score,
             reasons: Vec::new(),
+            ranker: None,
         }
     }
 
@@ -39,6 +47,7 @@ impl ScoredPost {
             post_id: String::new(),
             score,
             reasons: Vec::new(),
+            ranker: None,
         }
     }
 }

--- a/crates/graze-common/src/post_id.rs
+++ b/crates/graze-common/src/post_id.rs
@@ -1,0 +1,73 @@
+//! Date-sharded post identifiers for URI interning.
+//!
+//! New IDs are `{YYYYMMDD}{seq:010}` (18 ASCII digits, no separators) so they are
+//! safe inside Redis keys like `pl:{post_id}:{YYYYMMDD}`.
+
+/// Length of the date prefix (`YYYYMMDD`).
+pub const DATE_LEN: usize = 8;
+/// Length of the daily sequence suffix.
+pub const SEQ_LEN: usize = 10;
+/// Total length of a dated post ID.
+pub const DATED_ID_LEN: usize = DATE_LEN + SEQ_LEN;
+
+/// Build a dated post ID from intern date and daily sequence.
+#[inline]
+pub fn format_post_id(date: &str, seq: u64) -> String {
+    format!("{}{:0width$}", date, seq, width = SEQ_LEN)
+}
+
+/// True if `id` is a dated post ID (`YYYYMMDD` + 10-digit seq).
+#[inline]
+pub fn is_dated(id: &str) -> bool {
+    if id.len() != DATED_ID_LEN {
+        return false;
+    }
+    id.chars().all(|c| c.is_ascii_digit()) && parse_date_prefix(id).is_some()
+}
+
+/// True if `id` is a legacy global monotonic integer string.
+#[inline]
+pub fn is_legacy_numeric(id: &str) -> bool {
+    !id.is_empty() && id.len() < DATED_ID_LEN && id.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Extract `YYYYMMDD` from a dated post ID.
+#[inline]
+pub fn intern_date_from_post_id(id: &str) -> Option<&str> {
+    if !is_dated(id) {
+        return None;
+    }
+    Some(&id[..DATE_LEN])
+}
+
+fn parse_date_prefix(id: &str) -> Option<()> {
+    if id.len() < DATE_LEN {
+        return None;
+    }
+    let y: u32 = id[0..4].parse().ok()?;
+    let m: u32 = id[4..6].parse().ok()?;
+    let d: u32 = id[6..8].parse().ok()?;
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) || y < 1970 {
+        return None;
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_and_parse_dated_id() {
+        let id = format_post_id("20260513", 42);
+        assert_eq!(id, "202605130000000042");
+        assert!(is_dated(&id));
+        assert_eq!(intern_date_from_post_id(&id), Some("20260513"));
+    }
+
+    #[test]
+    fn legacy_numeric() {
+        assert!(is_legacy_numeric("184729301"));
+        assert!(!is_legacy_numeric("202605130000000042"));
+    }
+}

--- a/crates/graze-common/src/redis/client.rs
+++ b/crates/graze-common/src/redis/client.rs
@@ -118,6 +118,23 @@ impl RedisClient {
         Ok(exists)
     }
 
+    /// Return true if **any** of the given keys exists, in a single pipeline.
+    ///
+    /// Used to decide whether a user has usable like-seed anywhere in the retention window.
+    /// One round trip regardless of window size, so widening the window is nearly free.
+    pub async fn exists_any(&self, keys: &[String]) -> Result<bool> {
+        if keys.is_empty() {
+            return Ok(false);
+        }
+        let mut conn = self.get().await?;
+        let mut pipe = redis::pipe();
+        for key in keys {
+            pipe.exists(key.as_str());
+        }
+        let flags: Vec<bool> = pipe.query_async(&mut conn).await?;
+        Ok(flags.into_iter().any(|f| f))
+    }
+
     /// Delete a key.
     pub async fn del(&self, key: &str) -> Result<()> {
         let mut conn = self.get().await?;
@@ -144,6 +161,55 @@ impl RedisClient {
         let mut conn = self.get().await?;
         let _: () = conn.set_ex(key, value, seconds).await?;
         Ok(())
+    }
+
+    /// Set multiple keys to binary values with a TTL, in a single pipeline.
+    ///
+    /// Used for durable co-liker profiles (`ucl:`), whose packed wire format is not valid
+    /// UTF-8 and so cannot go through [`Self::set_ex`].
+    pub async fn set_ex_bytes_multi(
+        &self,
+        items: &[(String, Vec<u8>)],
+        seconds: u64,
+    ) -> Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.get().await?;
+        let mut pipe = redis::pipe();
+        for (key, value) in items {
+            pipe.set_ex(key.as_str(), value.as_slice(), seconds);
+        }
+        let _: Vec<()> = pipe.query_async(&mut conn).await?;
+        Ok(())
+    }
+
+    /// Apply float increments to hash fields in one pipeline.
+    ///
+    /// Used to merge Thompson bandit evidence across replicas: each pod pushes only its own
+    /// *deltas*, so concurrent writers accumulate instead of clobbering each other the way a
+    /// read-modify-write of absolute alpha/beta would.
+    pub async fn hincrbyfloat_multi(&self, key: &str, items: &[(String, f64)]) -> Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.get().await?;
+        let mut pipe = redis::pipe();
+        for (field, delta) in items {
+            pipe.cmd("HINCRBYFLOAT")
+                .arg(key)
+                .arg(field.as_str())
+                .arg(*delta);
+        }
+        let _: Vec<f64> = pipe.query_async(&mut conn).await?;
+        Ok(())
+    }
+
+    /// Get a binary value.
+    pub async fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        let mut conn = self.get().await?;
+        let value: Option<Vec<u8>> = conn.get(key).await?;
+        Ok(value)
     }
 
     /// Get a string value.
@@ -642,6 +708,29 @@ impl RedisClient {
         let mut conn = self.get().await?;
         let is_member: bool = conn.sismember(key, member).await?;
         Ok(is_member)
+    }
+
+    /// Check many members of one set in a single round trip.
+    ///
+    /// Uses `SMISMEMBER` (Redis 6.2+, and Valkey throughout), which answers the whole batch in one
+    /// command. The alternative — one `SISMEMBER` per member — would put a round trip on the serving
+    /// path for every seed post, which is precisely the cost that made the inverted-lookup
+    /// experiment 5x slower than the path it replaced.
+    ///
+    /// Returns a vector parallel to `members`. An empty `members` yields an empty vector without
+    /// touching Redis.
+    pub async fn sismember_multi(&self, key: &str, members: &[String]) -> Result<Vec<bool>> {
+        if members.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut conn = self.get().await?;
+        let mut cmd = redis::cmd("SMISMEMBER");
+        cmd.arg(key);
+        for m in members {
+            cmd.arg(m);
+        }
+        let flags: Vec<i64> = cmd.query_async(&mut conn).await?;
+        Ok(flags.into_iter().map(|f| f == 1).collect())
     }
 
     /// Get all members of a set.

--- a/crates/graze-common/src/redis/keys.rs
+++ b/crates/graze-common/src/redis/keys.rs
@@ -10,7 +10,7 @@
 pub struct Keys;
 
 /// Default number of days to retain like data.
-pub const DEFAULT_RETENTION_DAYS: u32 = 8;
+pub const DEFAULT_RETENTION_DAYS: u32 = 6;
 
 /// Convert a unix timestamp to a YYYYMMDD date string (UTC).
 #[inline]
@@ -64,7 +64,7 @@ pub fn retention_dates(retention_days: u32) -> Vec<String> {
 
 /// Calculate TTL for a key based on when it should expire.
 /// Keys should expire at the end of the retention window.
-/// For example, if retention is 8 days, a key for today should expire in 8 days.
+/// For example, if retention is 6 days, a key for today should expire in 6 days.
 #[inline]
 pub fn ttl_for_date(date: &str, retention_days: u32) -> i64 {
     // Parse the date to get the timestamp at start of that day (UTC)
@@ -178,6 +178,60 @@ impl Keys {
             .collect()
     }
 
+    /// Like [`Self::post_likers_retention`], but skips date shards that **cannot** contain a
+    /// like for this post.
+    ///
+    /// Post IDs are `{YYYYMMDD}{seq:010}` where the prefix is the **intern** date. A like is
+    /// only ever recorded under the date it happened, and a post cannot be liked before it has
+    /// an ID — so every shard older than the post's intern date is guaranteed empty.
+    ///
+    /// This matters because the pool is capped at `SYNC_PREFERRED_MAX_AGE_HOURS=72`, so
+    /// candidates are at most ~3 days old while retention is 6 days. Measured on live pools
+    /// (400 posts × 4 feeds): shards d3–d5 held **zero** likes in every case, and probing them
+    /// is pure waste. Sampling 3,000 members from each of 5 live pools:
+    ///
+    /// | algo | shards now | shards needed | reduction |
+    /// |---|---|---|---|
+    /// | 2323 | 18,000 | 5,641 | 69% |
+    /// | 396 | 18,000 | 5,411 | 70% |
+    /// | 3153 | 18,000 | 5,756 | 68% |
+    /// | 1988 | 18,000 | 5,815 | 68% |
+    /// | 33516 | 18,000 | 3,000 | 83% |
+    ///
+    /// **72% overall** — on both the scorer's per-candidate liker fetch and candidate-sync's
+    /// `zcard_summed_multi` (which is 26.6% of all Valkey commands).
+    ///
+    /// Legacy non-dated IDs carry no date information, so they fall back to the full window.
+    /// Always returns at least one key so callers never see an empty group.
+    #[inline]
+    pub fn post_likers_retention_bounded(post_id: &str, retention_days: u32) -> Vec<String> {
+        let dates = retention_dates(retention_days);
+        let Some(intern_date) = crate::post_id::intern_date_from_post_id(post_id) else {
+            // Legacy numeric ID: no date to bound by, keep current behaviour.
+            return dates
+                .into_iter()
+                .map(|d| Self::post_likers_date(post_id, &d))
+                .collect();
+        };
+
+        let kept: Vec<String> = dates
+            .iter()
+            .filter(|d| d.as_str() >= intern_date)
+            .map(|d| Self::post_likers_date(post_id, d))
+            .collect();
+
+        if kept.is_empty() {
+            // Post interned after every retention date we track (clock skew, or a future-dated
+            // ID). Probe today's shard rather than returning nothing.
+            match dates.first() {
+                Some(d) => vec![Self::post_likers_date(post_id, d)],
+                None => Vec::new(),
+            }
+        } else {
+            kept
+        }
+    }
+
     /// Author's likers sorted set for a specific date: `authl:{hash}:{YYYYMMDD}`
     ///
     /// ZSET with user_hash as member and timestamp as score.
@@ -271,6 +325,37 @@ impl Keys {
         format!("apc:{}", algo_id)
     }
 
+    /// Authors present in an algorithm's candidate pool: `apa:{algo_id}`
+    ///
+    /// SET of author DID hashes, one per distinct author with at least one post in `ap:{algo_id}`.
+    /// Written by `graze-candidate-sync` alongside the pool itself, so the two never disagree about
+    /// what is in the feed.
+    ///
+    /// Exists to let co-liker derivation restrict its **seed** to the user's likes of authors this
+    /// feed actually carries — LinkLonk scopes step 1 of the walk to a channel, while we have only
+    /// ever scoped step 3 to the pool. Measured cost of scoping late: 34-56% of a user's top-128
+    /// co-likers contribute zero coverage on a given feed, and none of them were inactive.
+    #[inline]
+    pub fn algo_pool_authors(algo_id: i32) -> String {
+        format!("apa:{}", algo_id)
+    }
+
+    /// Per-feed co-liker weights: `colikes:{algo_id}:{hash}`
+    ///
+    /// Feed-scoped counterpart to [`Keys::colikes`]. Deliberately under the `colikes:` prefix so
+    /// `scripts/redis_prune_retention.py` treats it as safe-to-delete — these are recomputable, and
+    /// keeping that property is the reason the prefix is shared rather than a new one invented.
+    #[inline]
+    pub fn colikes_per_feed(algo_id: i32, user_did_hash: &str) -> String {
+        format!("colikes:{}:{}", algo_id, user_did_hash)
+    }
+
+    /// Per-feed co-liker computation timestamp: `colikes:ts:{algo_id}:{hash}`
+    #[inline]
+    pub fn colikes_per_feed_timestamp(algo_id: i32, user_did_hash: &str) -> String {
+        format!("colikes:ts:{}:{}", algo_id, user_did_hash)
+    }
+
     /// Algorithm metadata hash: `am:{algo_id}`
     ///
     /// HASH containing last_sync timestamp and other metadata.
@@ -295,14 +380,32 @@ impl Keys {
     // URI Interning
     // ═══════════════════════════════════════════════════════════════════════════════
 
-    /// URI to ID mapping hash.
+    /// Legacy global URI to ID mapping (pre date-sharding).
     pub const URI_TO_ID: &'static str = "uri2id";
 
-    /// ID to URI mapping hash.
+    /// Legacy global ID to URI mapping.
     pub const ID_TO_URI: &'static str = "id2uri";
 
-    /// URI counter for generating new IDs.
+    /// Legacy global URI counter.
     pub const URI_COUNTER: &'static str = "uri:counter";
+
+    /// Date-sharded URI to ID: `uri2id:{YYYYMMDD}`
+    #[inline]
+    pub fn uri_to_id_date(date: &str) -> String {
+        format!("uri2id:{}", date)
+    }
+
+    /// Date-sharded ID to URI: `id2uri:{YYYYMMDD}`
+    #[inline]
+    pub fn id_to_uri_date(date: &str) -> String {
+        format!("id2uri:{}", date)
+    }
+
+    /// Daily intern sequence: `uri:counter:{YYYYMMDD}`
+    #[inline]
+    pub fn uri_counter_date(date: &str) -> String {
+        format!("uri:counter:{}", date)
+    }
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // Operational Keys
@@ -420,6 +523,28 @@ impl Keys {
     #[inline]
     pub fn user_liked_authors(user_did_hash: &str) -> String {
         format!("ula:{}", user_did_hash)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Durable Co-liker Profile Keys
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    /// Durable co-liker taste profile: `ucl:{hash}`
+    ///
+    /// A packed binary STRING (not a ZSET) holding the user's top-K co-likers, built
+    /// offline from long-range like history. See `coliker_profile` for the wire format.
+    ///
+    /// Deliberately NOT under the `colikes:` prefix, for two reasons:
+    /// - `scripts/redis_prune_retention.py` treats `colikes:*` as safe-to-delete.
+    /// - The co-liker cache-hit branch gates on `ttl > 0`, so a long-lived key placed
+    ///   there would fall through to a full recompute on every request.
+    ///
+    /// Flat key with a flat TTL (like `ula:`), NOT date-sharded: `ttl_for_date` clamps
+    /// dates outside the retention window to 1 second, which would delete these
+    /// immediately.
+    #[inline]
+    pub fn user_colikers(user_did_hash: &str) -> String {
+        format!("ucl:{}", user_did_hash)
     }
 
     /// DEPRECATED: Use author_likers_date() for new writes.
@@ -673,7 +798,101 @@ mod tests {
     }
 
     #[test]
+    fn test_pool_author_and_per_feed_coliker_keys() {
+        assert_eq!(Keys::algo_pool_authors(123), "apa:123");
+        assert_eq!(Keys::colikes_per_feed(123, "abc"), "colikes:123:abc");
+        assert_eq!(
+            Keys::colikes_per_feed_timestamp(123, "abc"),
+            "colikes:ts:123:abc"
+        );
+    }
+
+    #[test]
+    fn per_feed_coliker_keys_stay_under_the_prunable_prefix() {
+        // `scripts/redis_prune_retention.py` deletes `colikes:*` as recomputable cache. These keys
+        // are recomputable, so they must keep matching that prefix; a new top-level prefix would
+        // silently become unprunable and accumulate forever.
+        assert!(Keys::colikes_per_feed(7, "h").starts_with("colikes:"));
+        assert!(Keys::colikes_per_feed_timestamp(7, "h").starts_with("colikes:"));
+    }
+
+    #[test]
+    fn per_feed_colikers_never_collide_with_global_colikers() {
+        // A global key is `colikes:{hash}` and a per-feed key is `colikes:{algo}:{hash}`. Hashes are
+        // decimal, so a global key could in principle be read as a per-feed key for a numeric
+        // "algo"; assert the two spaces stay distinguishable by segment count.
+        let global = Keys::colikes("12345");
+        let per_feed = Keys::colikes_per_feed(1, "2345");
+        assert_ne!(global, per_feed);
+        assert_eq!(global.split(':').count(), 2);
+        assert_eq!(per_feed.split(':').count(), 3);
+    }
+
+    #[test]
     fn test_algo_posts_key() {
         assert_eq!(Keys::algo_posts(123), "ap:123");
+    }
+}
+
+#[cfg(test)]
+mod bounded_shard_tests {
+    use super::*;
+
+    /// A like cannot predate the post's intern date, so older shards are provably empty and
+    /// must be skipped. Measured 72% fewer shard probes on live pools.
+    #[test]
+    fn skips_shards_older_than_the_posts_intern_date() {
+        let dates = retention_dates(6);
+        let today = dates[0].clone();
+        let oldest = dates[5].clone();
+
+        // A post interned today can only have likes today.
+        let id_today = format!("{}0000000042", today);
+        let keys = Keys::post_likers_retention_bounded(&id_today, 6);
+        assert_eq!(keys.len(), 1, "today's post needs exactly one shard");
+        assert!(keys[0].ends_with(&today));
+
+        // A post interned at the oldest retained date needs the whole window.
+        let id_oldest = format!("{}0000000042", oldest);
+        assert_eq!(Keys::post_likers_retention_bounded(&id_oldest, 6).len(), 6);
+    }
+
+    #[test]
+    fn bounded_is_always_a_subset_of_unbounded() {
+        let dates = retention_dates(6);
+        for d in &dates {
+            let id = format!("{}0000000001", d);
+            let full = Keys::post_likers_retention(&id, 6);
+            let bounded = Keys::post_likers_retention_bounded(&id, 6);
+            assert!(bounded.len() <= full.len());
+            for k in &bounded {
+                assert!(
+                    full.contains(k),
+                    "bounded produced a key unbounded would not: {}",
+                    k
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_non_dated_ids_keep_the_full_window() {
+        // Legacy numeric IDs carry no date, so we cannot safely narrow.
+        for legacy in ["12345", "999999999", "abc"] {
+            assert_eq!(
+                Keys::post_likers_retention_bounded(legacy, 6).len(),
+                Keys::post_likers_retention(legacy, 6).len(),
+                "legacy id {} must not be narrowed",
+                legacy
+            );
+        }
+    }
+
+    #[test]
+    fn never_returns_an_empty_group() {
+        // Future-dated / clock-skewed IDs must still yield a probe target.
+        let future = "29991231".to_string() + "0000000001";
+        assert!(!Keys::post_likers_retention_bounded(&future, 6).is_empty());
+        assert!(!Keys::post_likers_retention_bounded("20260811000000001", 6).is_empty());
     }
 }

--- a/crates/graze-common/src/services/interactions.rs
+++ b/crates/graze-common/src/services/interactions.rs
@@ -6,10 +6,12 @@
 use base64::{engine::general_purpose::URL_SAFE, Engine};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 use crate::clickhouse::traits::InteractionWriter;
+use crate::exclusion::should_log_interaction;
 use crate::models::{FeedInteractionRow, Interaction, UserActionLogRow};
 use crate::redis::{Keys, RedisClient};
 
@@ -39,6 +41,7 @@ pub struct InteractionsClient {
     config: Arc<InteractionsConfig>,
     redis: Arc<RedisClient>,
     writer: Arc<dyn InteractionWriter>,
+    exclusion_dids: Arc<HashSet<String>>,
 }
 
 impl InteractionsClient {
@@ -47,11 +50,13 @@ impl InteractionsClient {
         config: Arc<InteractionsConfig>,
         redis: Arc<RedisClient>,
         writer: Arc<dyn InteractionWriter>,
+        exclusion_dids: Arc<HashSet<String>>,
     ) -> Self {
         Self {
             config,
             redis,
             writer,
+            exclusion_dids,
         }
     }
 
@@ -141,6 +146,10 @@ impl InteractionsClient {
         let mut action_log_rows = Vec::new();
 
         for interaction in interactions {
+            if !should_log_interaction(user_did, &interaction.item, self.exclusion_dids.as_ref()) {
+                continue;
+            }
+
             // Decode feedContext
             let (feed_uri, attribution) = match &interaction.feed_context {
                 Some(ctx) => {

--- a/crates/graze-common/src/services/uri_interner.rs
+++ b/crates/graze-common/src/services/uri_interner.rs
@@ -1,79 +1,64 @@
-//! URI Interning for memory-efficient storage.
+//! URI interning with date-sharded Redis storage.
 //!
-//! This module provides bidirectional mapping between URIs and integer IDs,
-//! reducing memory usage by ~80% compared to storing full URIs.
+//! New mappings live in per-day hashes with TTL aligned to like-graph retention:
+//! - `uri2id:{YYYYMMDD}` / `id2uri:{YYYYMMDD}` / `uri:counter:{YYYYMMDD}`
+//! - Post IDs: `{YYYYMMDD}{seq:010}` (see [`crate::post_id`])
 //!
-//! Redis Keys:
-//! - uri2id: HASH mapping URI -> ID
-//! - id2uri: HASH mapping ID -> URI
-//! - uri:counter: STRING for auto-incrementing IDs
+//! Legacy global `uri2id` / `id2uri` are read for lookups only; new writes use shards.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use lru::LruCache;
 use parking_lot::Mutex;
 
 use crate::error::Result;
-use crate::redis::{Keys, RedisClient};
+use crate::post_id::{intern_date_from_post_id, is_legacy_numeric};
+use crate::redis::{retention_dates, ttl_for_date, Keys, RedisClient, DEFAULT_RETENTION_DAYS};
 
 /// Default size for each LRU cache.
 const DEFAULT_CACHE_SIZE: usize = 50_000;
 
-/// Lua script for atomic get-or-create ID operation.
-const GET_OR_CREATE_SCRIPT: &str = r#"
-local uri = ARGV[1]
-local existing = redis.call('HGET', KEYS[1], uri)
-if existing then
-    return existing
-end
-local new_id = redis.call('INCR', KEYS[3])
-redis.call('HSET', KEYS[1], uri, new_id)
-redis.call('HSET', KEYS[2], new_id, uri)
-return new_id
-"#;
-
-/// Lua script for atomic batch get-or-create IDs operation.
-const BATCH_GET_OR_CREATE_SCRIPT: &str = r#"
+/// Batch get-or-create within one intern date shard.
+const SHARD_BATCH_GET_OR_CREATE_SCRIPT: &str = r#"
 local uri_to_id_key = KEYS[1]
 local id_to_uri_key = KEYS[2]
 local counter_key = KEYS[3]
+local date = ARGV[1]
 local results = {}
-
-for i, uri in ipairs(ARGV) do
+for i = 2, #ARGV do
+    local uri = ARGV[i]
     local existing = redis.call('HGET', uri_to_id_key, uri)
     if existing then
-        results[i] = existing
+        results[i - 1] = existing
     else
-        local new_id = redis.call('INCR', counter_key)
-        redis.call('HSET', uri_to_id_key, uri, new_id)
-        redis.call('HSET', id_to_uri_key, new_id, uri)
-        results[i] = new_id
+        local seq = redis.call('INCR', counter_key)
+        local id = date .. string.format('%010d', seq)
+        redis.call('HSET', uri_to_id_key, uri, id)
+        redis.call('HSET', id_to_uri_key, id, uri)
+        results[i - 1] = id
     end
 end
 return results
 "#;
 
-/// Manages URI <-> ID mapping for memory efficiency.
-///
-/// Includes an in-process LRU cache layer to reduce Redis calls.
+/// Manages URI <-> post ID mapping.
 pub struct UriInterner {
     redis: Arc<RedisClient>,
-    /// Cache: URI -> ID
-    id_cache: Mutex<LruCache<String, i64>>,
-    /// Cache: ID -> URI
-    uri_cache: Mutex<LruCache<i64, String>>,
+    retention_days: u32,
+    id_cache: Mutex<LruCache<String, String>>,
+    uri_cache: Mutex<LruCache<String, String>>,
 }
 
 impl UriInterner {
-    /// Create a new URI interner with the default cache size.
     pub fn new(redis: Arc<RedisClient>) -> Self {
-        Self::with_cache_size(redis, DEFAULT_CACHE_SIZE)
+        Self::with_retention(redis, DEFAULT_RETENTION_DAYS)
     }
 
-    /// Create a new URI interner with a custom cache size.
     pub fn with_cache_size(redis: Arc<RedisClient>, cache_size: usize) -> Self {
         Self {
             redis,
+            retention_days: DEFAULT_RETENTION_DAYS,
             id_cache: Mutex::new(LruCache::new(
                 std::num::NonZeroUsize::new(cache_size).unwrap(),
             )),
@@ -83,200 +68,253 @@ impl UriInterner {
         }
     }
 
-    /// Get the integer ID for a URI, creating one if it doesn't exist.
-    ///
-    /// This is an atomic operation that ensures no duplicate IDs are assigned.
-    /// Checks in-process LRU cache first before going to Redis.
-    pub async fn get_or_create_id(&self, uri: &str) -> Result<i64> {
-        // Check in-process cache first
-        {
-            let mut cache = self.id_cache.lock();
-            if let Some(&id) = cache.get(uri) {
-                return Ok(id);
-            }
+    pub fn with_retention(redis: Arc<RedisClient>, retention_days: u32) -> Self {
+        Self {
+            redis,
+            retention_days,
+            id_cache: Mutex::new(LruCache::new(
+                std::num::NonZeroUsize::new(DEFAULT_CACHE_SIZE).unwrap(),
+            )),
+            uri_cache: Mutex::new(LruCache::new(
+                std::num::NonZeroUsize::new(DEFAULT_CACHE_SIZE).unwrap(),
+            )),
         }
-
-        // Execute atomic get-or-create in Redis
-        let id: i64 = self
-            .redis
-            .eval(
-                GET_OR_CREATE_SCRIPT,
-                &[Keys::URI_TO_ID, Keys::ID_TO_URI, Keys::URI_COUNTER],
-                &[uri],
-            )
-            .await?;
-
-        // Populate both caches
-        {
-            let mut id_cache = self.id_cache.lock();
-            let mut uri_cache = self.uri_cache.lock();
-            id_cache.put(uri.to_string(), id);
-            uri_cache.put(id, uri.to_string());
-        }
-
-        Ok(id)
     }
 
-    /// Get or create IDs for multiple URIs efficiently.
-    ///
-    /// Returns a mapping of URI -> ID.
-    /// Checks in-process LRU cache first before going to Redis.
+    /// Get or create a post ID for `uri` on intern date `YYYYMMDD`.
+    pub async fn get_or_create_id(&self, uri: &str, intern_date: &str) -> Result<String> {
+        let map = self
+            .get_or_create_ids_batch(&[uri.to_string()], intern_date)
+            .await?;
+        map.get(uri)
+            .cloned()
+            .ok_or_else(|| crate::error::GrazeError::Internal("interner missing id".into()))
+    }
+
+    /// Batch intern URIs under `intern_date` (`YYYYMMDD`).
     pub async fn get_or_create_ids_batch(
         &self,
         uris: &[String],
-    ) -> Result<std::collections::HashMap<String, i64>> {
-        use std::collections::HashMap;
-
+        intern_date: &str,
+    ) -> Result<HashMap<String, String>> {
         if uris.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let mut result: HashMap<String, i64> = HashMap::with_capacity(uris.len());
-        let mut uris_to_fetch: Vec<&str> = Vec::new();
+        let mut result = HashMap::with_capacity(uris.len());
+        let mut uris_to_fetch: Vec<String> = Vec::new();
 
-        // First, check in-process cache
         {
             let mut cache = self.id_cache.lock();
             for uri in uris {
-                if let Some(&id) = cache.get(uri) {
-                    result.insert(uri.clone(), id);
+                if let Some(id) = cache.get(uri) {
+                    result.insert(uri.clone(), id.clone());
                 } else {
-                    uris_to_fetch.push(uri.as_str());
+                    uris_to_fetch.push(uri.clone());
                 }
             }
         }
 
-        if uris_to_fetch.is_empty() {
-            return Ok(result);
-        }
+        if !uris_to_fetch.is_empty() {
+            // Reuse legacy or any retention shard ID so ap:* stays aligned with ul:/pl:
+            let existing = self.get_ids_batch(&uris_to_fetch).await?;
+            let mut still_missing: Vec<String> = Vec::new();
+            {
+                let mut id_cache = self.id_cache.lock();
+                let mut uri_cache = self.uri_cache.lock();
+                for uri in uris_to_fetch {
+                    if let Some(id) = existing.get(&uri) {
+                        result.insert(uri.clone(), id.clone());
+                        id_cache.put(uri.clone(), id.clone());
+                        uri_cache.put(id.clone(), uri.clone());
+                    } else {
+                        still_missing.push(uri);
+                    }
+                }
+            }
 
-        // Execute batch get-or-create in Redis
-        let ids: Vec<i64> = self
-            .redis
-            .eval(
-                BATCH_GET_OR_CREATE_SCRIPT,
-                &[Keys::URI_TO_ID, Keys::ID_TO_URI, Keys::URI_COUNTER],
-                &uris_to_fetch,
-            )
-            .await?;
+            if still_missing.is_empty() {
+                return Ok(result);
+            }
 
-        // Populate caches and result
-        {
+            let mut eval_args: Vec<&str> = Vec::with_capacity(1 + still_missing.len());
+            eval_args.push(intern_date);
+            for u in &still_missing {
+                eval_args.push(u);
+            }
+            let uri2id_key = Keys::uri_to_id_date(intern_date);
+            let id2uri_key = Keys::id_to_uri_date(intern_date);
+            let counter_key = Keys::uri_counter_date(intern_date);
+            let ids: Vec<String> = self
+                .redis
+                .eval(
+                    SHARD_BATCH_GET_OR_CREATE_SCRIPT,
+                    &[&uri2id_key, &id2uri_key, &counter_key],
+                    &eval_args,
+                )
+                .await?;
+
+            let ttl = ttl_for_date(intern_date, self.retention_days);
+            if ttl > 0 {
+                self.redis.expire(&uri2id_key, ttl).await?;
+                self.redis.expire(&id2uri_key, ttl).await?;
+                self.redis.expire(&counter_key, ttl).await?;
+            }
+
             let mut id_cache = self.id_cache.lock();
             let mut uri_cache = self.uri_cache.lock();
-
-            for (uri, id) in uris_to_fetch.iter().zip(ids.iter()) {
-                result.insert((*uri).to_string(), *id);
-                id_cache.put((*uri).to_string(), *id);
-                uri_cache.put(*id, (*uri).to_string());
+            for (uri, id) in still_missing.iter().zip(ids.iter()) {
+                result.insert(uri.clone(), id.clone());
+                id_cache.put(uri.clone(), id.clone());
+                uri_cache.put(id.clone(), uri.clone());
             }
         }
 
         Ok(result)
     }
 
-    /// Get the ID for a URI, or None if not interned.
-    ///
-    /// Checks in-process LRU cache first before going to Redis.
-    pub async fn get_id(&self, uri: &str) -> Result<Option<i64>> {
-        // Check in-process cache first
-        {
-            let mut cache = self.id_cache.lock();
-            if let Some(&id) = cache.get(uri) {
-                return Ok(Some(id));
-            }
+    /// Intern URIs using each entry's event date (`YYYYMMDD`).
+    pub async fn get_or_create_ids_by_event_date(
+        &self,
+        uri_and_dates: &[(String, String)],
+    ) -> Result<HashMap<String, String>> {
+        if uri_and_dates.is_empty() {
+            return Ok(HashMap::new());
         }
 
-        // Check Redis
-        let id_str = self.redis.hget(Keys::URI_TO_ID, uri).await?;
-        if let Some(s) = id_str {
-            let id: i64 = s.parse().unwrap_or(0);
-            // Populate both caches
-            {
-                let mut id_cache = self.id_cache.lock();
-                let mut uri_cache = self.uri_cache.lock();
-                id_cache.put(uri.to_string(), id);
-                uri_cache.put(id, uri.to_string());
-            }
-            Ok(Some(id))
-        } else {
-            Ok(None)
+        let mut by_date: HashMap<String, Vec<String>> = HashMap::new();
+        for (uri, date) in uri_and_dates {
+            by_date.entry(date.clone()).or_default().push(uri.clone());
         }
+
+        let mut result = HashMap::with_capacity(uri_and_dates.len());
+        for (date, mut uris) in by_date {
+            uris.sort();
+            uris.dedup();
+            let chunk = self.get_or_create_ids_batch(&uris, &date).await?;
+            result.extend(chunk);
+        }
+        Ok(result)
     }
 
-    /// Get the URI for an ID, or None if not found.
-    ///
-    /// Checks in-process LRU cache first before going to Redis.
-    pub async fn get_uri(&self, id: i64) -> Result<Option<String>> {
-        // Check in-process cache first
+    /// Look up an existing post ID for `uri` (legacy global hash, then retention shards).
+    pub async fn get_id(&self, uri: &str) -> Result<Option<String>> {
+        {
+            let mut cache = self.id_cache.lock();
+            if let Some(id) = cache.get(uri) {
+                return Ok(Some(id.clone()));
+            }
+        }
+
+        if let Some(s) = self.redis.hget(Keys::URI_TO_ID, uri).await? {
+            self.cache_pair(uri, &s);
+            return Ok(Some(s));
+        }
+
+        for date in retention_dates(self.retention_days) {
+            let key = Keys::uri_to_id_date(&date);
+            if let Some(s) = self.redis.hget(&key, uri).await? {
+                self.cache_pair(uri, &s);
+                return Ok(Some(s));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Resolve post ID to AT-URI (dated shard, then legacy global).
+    pub async fn get_uri(&self, post_id: &str) -> Result<Option<String>> {
         {
             let mut cache = self.uri_cache.lock();
-            if let Some(uri) = cache.get(&id) {
+            if let Some(uri) = cache.get(post_id) {
                 return Ok(Some(uri.clone()));
             }
         }
 
-        // Check Redis
-        let uri = self.redis.hget(Keys::ID_TO_URI, &id.to_string()).await?;
-        if let Some(ref u) = uri {
-            // Populate both caches
+        if let Some(date) = intern_date_from_post_id(post_id) {
+            if let Some(uri) = self
+                .redis
+                .hget(&Keys::id_to_uri_date(date), post_id)
+                .await?
             {
-                let mut id_cache = self.id_cache.lock();
-                let mut uri_cache = self.uri_cache.lock();
-                uri_cache.put(id, u.clone());
-                id_cache.put(u.clone(), id);
+                self.cache_pair(&uri, post_id);
+                return Ok(Some(uri));
             }
         }
-        Ok(uri)
+
+        if is_legacy_numeric(post_id) {
+            if let Some(uri) = self.redis.hget(Keys::ID_TO_URI, post_id).await? {
+                self.cache_pair(&uri, post_id);
+                return Ok(Some(uri));
+            }
+        }
+
+        Ok(None)
     }
 
-    /// Get URIs for multiple IDs efficiently.
-    ///
-    /// Returns a mapping of ID -> URI (only for found IDs).
-    pub async fn get_uris_batch(
-        &self,
-        ids: &[i64],
-    ) -> Result<std::collections::HashMap<i64, String>> {
-        use std::collections::HashMap;
-
-        if ids.is_empty() {
+    /// Batch resolve post IDs to URIs.
+    pub async fn get_uris_batch(&self, post_ids: &[String]) -> Result<HashMap<String, String>> {
+        if post_ids.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let mut result: HashMap<i64, String> = HashMap::with_capacity(ids.len());
-        let mut ids_to_fetch: Vec<i64> = Vec::new();
+        let mut result = HashMap::with_capacity(post_ids.len());
+        let mut to_fetch: Vec<String> = Vec::new();
 
-        // First, check in-process cache
         {
             let mut cache = self.uri_cache.lock();
-            for &id in ids {
-                if let Some(uri) = cache.get(&id) {
-                    result.insert(id, uri.clone());
+            for id in post_ids {
+                if let Some(uri) = cache.get(id) {
+                    result.insert(id.clone(), uri.clone());
                 } else {
-                    ids_to_fetch.push(id);
+                    to_fetch.push(id.clone());
                 }
             }
         }
 
-        if ids_to_fetch.is_empty() {
+        if to_fetch.is_empty() {
             return Ok(result);
         }
 
-        // Fetch from Redis
-        let str_ids: Vec<String> = ids_to_fetch.iter().map(|id| id.to_string()).collect();
-        let str_refs: Vec<&str> = str_ids.iter().map(|s| s.as_str()).collect();
-        let uris = self.redis.hmget(Keys::ID_TO_URI, &str_refs).await?;
+        let mut legacy_ids: Vec<&str> = Vec::new();
+        let mut by_date: HashMap<String, Vec<String>> = HashMap::new();
 
-        // Populate caches and result
-        {
+        for id in &to_fetch {
+            if let Some(date) = intern_date_from_post_id(id) {
+                by_date
+                    .entry(date.to_string())
+                    .or_default()
+                    .push(id.clone());
+            } else if is_legacy_numeric(id) {
+                legacy_ids.push(id.as_str());
+            }
+        }
+
+        if !legacy_ids.is_empty() {
+            let refs: Vec<&str> = legacy_ids.to_vec();
+            let uris = self.redis.hmget(Keys::ID_TO_URI, &refs).await?;
             let mut id_cache = self.id_cache.lock();
             let mut uri_cache = self.uri_cache.lock();
-
-            for (id, uri_opt) in ids_to_fetch.iter().zip(uris.iter()) {
+            for (id, uri_opt) in legacy_ids.iter().zip(uris.iter()) {
                 if let Some(uri) = uri_opt {
-                    result.insert(*id, uri.clone());
-                    uri_cache.put(*id, uri.clone());
-                    id_cache.put(uri.clone(), *id);
+                    result.insert((*id).to_string(), uri.clone());
+                    uri_cache.put((*id).to_string(), uri.clone());
+                    id_cache.put(uri.clone(), (*id).to_string());
+                }
+            }
+        }
+
+        for (date, ids) in by_date {
+            let key = Keys::id_to_uri_date(&date);
+            let refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+            let uris = self.redis.hmget(&key, &refs).await?;
+            let mut id_cache = self.id_cache.lock();
+            let mut uri_cache = self.uri_cache.lock();
+            for (id, uri_opt) in ids.iter().zip(uris.iter()) {
+                if let Some(uri) = uri_opt {
+                    result.insert(id.clone(), uri.clone());
+                    uri_cache.put(id.clone(), uri.clone());
+                    id_cache.put(uri.clone(), id.clone());
                 }
             }
         }
@@ -284,108 +322,73 @@ impl UriInterner {
         Ok(result)
     }
 
-    /// Get IDs for multiple URIs (only existing ones).
-    ///
-    /// Returns a mapping of URI -> ID (only for found URIs).
-    pub async fn get_ids_batch(
-        &self,
-        uris: &[String],
-    ) -> Result<std::collections::HashMap<String, i64>> {
-        use std::collections::HashMap;
-
+    /// Batch lookup URI -> post ID without creating entries.
+    pub async fn get_ids_batch(&self, uris: &[String]) -> Result<HashMap<String, String>> {
         if uris.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let mut result: HashMap<String, i64> = HashMap::with_capacity(uris.len());
-        let mut uris_to_fetch: Vec<&str> = Vec::new();
+        let mut result = HashMap::with_capacity(uris.len());
+        let mut to_fetch: Vec<String> = Vec::new();
 
-        // First, check in-process cache
         {
             let mut cache = self.id_cache.lock();
             for uri in uris {
-                if let Some(&id) = cache.get(uri) {
-                    result.insert(uri.clone(), id);
+                if let Some(id) = cache.get(uri) {
+                    result.insert(uri.clone(), id.clone());
                 } else {
-                    uris_to_fetch.push(uri.as_str());
+                    to_fetch.push(uri.clone());
                 }
             }
         }
 
-        if uris_to_fetch.is_empty() {
-            return Ok(result);
-        }
-
-        // Fetch from Redis
-        let ids = self.redis.hmget(Keys::URI_TO_ID, &uris_to_fetch).await?;
-
-        // Populate caches and result
-        {
-            let mut id_cache = self.id_cache.lock();
-            let mut uri_cache = self.uri_cache.lock();
-
-            for (uri, id_opt) in uris_to_fetch.iter().zip(ids.iter()) {
-                if let Some(id_str) = id_opt {
-                    let id: i64 = id_str.parse().unwrap_or(0);
-                    result.insert((*uri).to_string(), id);
-                    id_cache.put((*uri).to_string(), id);
-                    uri_cache.put(id, (*uri).to_string());
-                }
+        for uri in to_fetch {
+            if let Some(id) = self.get_id(&uri).await? {
+                result.insert(uri, id);
             }
         }
 
         Ok(result)
     }
 
-    /// Get the number of URIs in the interning table.
+    /// Total entries in legacy + visible date shards (approximate; for metrics).
     pub async fn get_table_size(&self) -> Result<usize> {
-        self.redis.hlen(Keys::URI_TO_ID).await
+        let mut total = self.redis.hlen(Keys::URI_TO_ID).await?;
+        for date in retention_dates(self.retention_days) {
+            total += self.redis.hlen(&Keys::uri_to_id_date(&date)).await?;
+        }
+        Ok(total)
     }
 
-    /// Get current cache sizes for monitoring.
     pub fn cache_sizes(&self) -> (usize, usize) {
         let id_cache = self.id_cache.lock();
         let uri_cache = self.uri_cache.lock();
         (id_cache.len(), uri_cache.len())
+    }
+
+    fn cache_pair(&self, uri: &str, post_id: &str) {
+        let mut id_cache = self.id_cache.lock();
+        let mut uri_cache = self.uri_cache.lock();
+        id_cache.put(uri.to_string(), post_id.to_string());
+        uri_cache.put(post_id.to_string(), uri.to_string());
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::post_id::{format_post_id, is_dated};
 
     #[test]
-    fn test_script_syntax() {
-        // Basic syntax check - ensure scripts compile
-        assert!(GET_OR_CREATE_SCRIPT.contains("HGET"));
-        assert!(BATCH_GET_OR_CREATE_SCRIPT.contains("INCR"));
+    fn shard_script_references_keys() {
+        assert!(SHARD_BATCH_GET_OR_CREATE_SCRIPT.contains("uri_to_id_key"));
+        assert!(SHARD_BATCH_GET_OR_CREATE_SCRIPT.contains("%010d"));
     }
 
     #[test]
-    fn test_get_or_create_script_content() {
-        // Verify script structure
-        assert!(GET_OR_CREATE_SCRIPT.contains("KEYS[1]")); // uri_to_id
-        assert!(GET_OR_CREATE_SCRIPT.contains("KEYS[2]")); // id_to_uri
-        assert!(GET_OR_CREATE_SCRIPT.contains("KEYS[3]")); // counter
-        assert!(GET_OR_CREATE_SCRIPT.contains("ARGV[1]")); // uri
-    }
-
-    #[test]
-    fn test_batch_script_content() {
-        // Verify batch script structure
-        assert!(BATCH_GET_OR_CREATE_SCRIPT.contains("for i, uri in ipairs(ARGV)"));
-        assert!(BATCH_GET_OR_CREATE_SCRIPT.contains("results[i]"));
-    }
-
-    #[test]
-    fn test_default_cache_size() {
-        assert_eq!(DEFAULT_CACHE_SIZE, 50_000);
-    }
-
-    #[test]
-    fn test_keys_constants() {
-        assert_eq!(Keys::URI_TO_ID, "uri2id");
-        assert_eq!(Keys::ID_TO_URI, "id2uri");
-        assert_eq!(Keys::URI_COUNTER, "uri:counter");
+    fn dated_id_format_in_script_matches_rust() {
+        let id = format_post_id("20260513", 7);
+        assert_eq!(id.len(), crate::post_id::DATED_ID_LEN);
+        assert!(is_dated(&id));
     }
 }

--- a/crates/graze-feed-stats/Cargo.toml
+++ b/crates/graze-feed-stats/Cargo.toml
@@ -1,46 +1,51 @@
 [package]
-name = "graze-candidate-sync"
+name = "graze-feed-stats"
 version = "0.2.0"
 edition = "2021"
-description = "Graze ClickHouse to Redis candidate synchronization"
+description = "Graze feed-serve telemetry -> ClickHouse analytics + ad-billing worker (Rust port of feed_stats_runner.py)"
 license = "MIT"
 
 [[bin]]
-name = "graze-candidate-sync"
+name = "graze-feed-stats"
 path = "src/main.rs"
 
-# Phase A of the durable co-liker profile design: offline profile builder.
-[[bin]]
-name = "graze-build-coliker-profiles"
-path = "src/bin/build_coliker_profiles.rs"
-
 [lib]
-name = "graze_candidate_sync"
+name = "graze_feed_stats"
 path = "src/lib.rs"
 
 [dependencies]
-# Internal dependencies
+# Internal
 graze-common = { path = "../graze-common" }
 
 # Async runtime
 tokio = { version = "1.43", features = ["full", "signal"] }
 
-# HTTP client (for ClickHouse)
+# HTTP client (for ClickHouse inserts)
 reqwest = { version = "0.12", features = ["json", "gzip", "rustls-tls"], default-features = false }
 
 # Redis
 deadpool-redis = "0.22"
 
+# Postgres (billing mutations + reads) — NOT provided by graze-common
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio-rustls",
+    "postgres",
+    "chrono",
+    "json",
+] }
+
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-# Utilities
-rayon = "1.10"
-parking_lot = "0.12"
+# JWT payload decode (unverified — read `iss`)
+base64 = "0.22"
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }
+
+# UUID (reqId fallback)
+uuid = { version = "1", features = ["v4"] }
 
 # Error handling
 thiserror = "2.0"
@@ -50,8 +55,8 @@ anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
-# AT Protocol
-atproto-record = { version = "0.14", default-features = false }
-
 # Metrics
 prometheus-client = "0.22"
+
+[dev-dependencies]
+tokio = { version = "1.43", features = ["full", "test-util"] }

--- a/crates/graze-feed-stats/src/clickhouse_sink.rs
+++ b/crates/graze-feed-stats/src/clickhouse_sink.rs
@@ -1,0 +1,236 @@
+//! ClickHouse analytics sink.
+//!
+//! Ports `insert_clickhouse_data_http` + the two active writers from
+//! `feed_stats_runner.py`. Preserves the wire contract exactly:
+//!   * HTTP `INSERT ... FORMAT TabSeparated`
+//!   * `None` values encoded as the empty string (NOT `\N`), matching Python
+//!   * `X-ClickHouse-User` / basic-auth against the same host
+//!
+//! The generic [`insert_rows`] helper is the public equivalent of the private
+//! `ClickHouseInteractionWriter::insert_tabseparated` in graze-common; we keep a
+//! local copy so the column list / table name stay arbitrary.
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use chrono::NaiveDateTime;
+use graze_common::ClickHouseConfig;
+use reqwest::Client;
+
+use crate::parse::{AttributableRow, PostView};
+
+/// A single TSV cell. `Null` renders as the empty string (Python `None -> ""`).
+#[derive(Debug, Clone)]
+pub enum Cell {
+    Null,
+    Str(String),
+    Int(i64),
+    DateTime(NaiveDateTime),
+}
+
+impl Cell {
+    fn render(&self) -> String {
+        match self {
+            Cell::Null => String::new(),
+            Cell::Str(s) => escape_tab_value(s),
+            Cell::Int(i) => i.to_string(),
+            Cell::DateTime(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+        }
+    }
+}
+
+fn opt_int(v: Option<i64>) -> Cell {
+    v.map(Cell::Int).unwrap_or(Cell::Null)
+}
+fn opt_str(v: Option<String>) -> Cell {
+    v.map(Cell::Str).unwrap_or(Cell::Null)
+}
+
+pub struct ClickHouseSink {
+    http: Client,
+    config: ClickHouseConfig,
+    table_prefix: String,
+}
+
+impl ClickHouseSink {
+    pub fn new(config: ClickHouseConfig, table_prefix: String) -> Self {
+        Self {
+            http: Client::new(),
+            config,
+            table_prefix,
+        }
+    }
+
+    fn table(&self, name: &str) -> String {
+        format!("{}{}", self.table_prefix, name)
+    }
+
+    /// Generic TSV insert into `{database}.{table}` with an explicit column list.
+    pub async fn insert_rows(
+        &self,
+        table: &str,
+        columns: &[&str],
+        rows: Vec<Vec<Cell>>,
+    ) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let query = format!(
+            "INSERT INTO {}.{} ({}) FORMAT TabSeparated",
+            self.config.database,
+            self.table(table),
+            columns.join(", ")
+        );
+        let body = rows
+            .iter()
+            .map(|row| row.iter().map(Cell::render).collect::<Vec<_>>().join("\t"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let resp = self
+            .http
+            .post(self.config.base_url())
+            .basic_auth(&self.config.user, Some(&self.config.password))
+            .header("Content-Type", "text/plain")
+            .query(&[("query", query.as_str())])
+            .body(body)
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(|e| anyhow!("ClickHouse connection error: {e}"))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "ClickHouse insert into {} failed: {} {}",
+                self.table(table),
+                status,
+                &text[..text.len().min(500)]
+            ));
+        }
+        Ok(())
+    }
+
+    /// Port of `insert_into_post_render_log` — exact 16-column order.
+    pub async fn insert_post_render_log(
+        &self,
+        views: &[PostView],
+        campaign_accounts: &HashMap<i64, i64>,
+        algorithm_accounts: &HashMap<i64, i64>,
+    ) -> Result<usize> {
+        if views.is_empty() {
+            return Ok(0);
+        }
+        const COLS: &[&str] = &[
+            "attribution_id",
+            "campaign_id",
+            "paying_account_id",
+            "post_id",
+            "position",
+            "uuid",
+            "algorithm_id",
+            "paid_account_id",
+            "user_did",
+            "cpm_cents",
+            "created_at",
+            "feed_operator_did",
+            "slug",
+            "cursor",
+            "limit",
+            "post_count",
+        ];
+        let rows: Vec<Vec<Cell>> = views
+            .iter()
+            .map(|v| {
+                let paying = v
+                    .campaign_id
+                    .and_then(|c| campaign_accounts.get(&c).copied());
+                // Python only looks up paid_account when algorithm_id is truthy.
+                let paid = if v.algorithm_id != 0 {
+                    algorithm_accounts.get(&v.algorithm_id).copied()
+                } else {
+                    None
+                };
+                vec![
+                    opt_int(v.attribution_id),
+                    opt_int(v.campaign_id),
+                    opt_int(paying),
+                    Cell::Str(v.post_id.clone()),
+                    Cell::Int(v.position as i64),
+                    Cell::Str(v.uuid.clone()),
+                    Cell::Int(v.algorithm_id),
+                    opt_int(paid),
+                    Cell::Str(v.user_did.clone()),
+                    opt_int(v.cpm_cents),
+                    Cell::DateTime(v.created_at),
+                    Cell::Str(v.feed_operator_did.clone()),
+                    Cell::Str(v.slug.clone()),
+                    opt_str(v.cursor.clone()),
+                    Cell::Int(v.limit),
+                    Cell::Int(v.post_count as i64),
+                ]
+            })
+            .collect();
+        let n = rows.len();
+        self.insert_rows("post_render_log", COLS, rows).await?;
+        Ok(n)
+    }
+
+    /// Port of `insert_into_clickhouse_sponsored_feed_impressions` — 10 columns.
+    pub async fn insert_sponsored_feed_impressions(
+        &self,
+        rows_in: &[AttributableRow],
+        campaign_accounts: &HashMap<i64, i64>,
+        algorithm_accounts: &HashMap<i64, i64>,
+    ) -> Result<usize> {
+        if rows_in.is_empty() {
+            return Ok(0);
+        }
+        const COLS: &[&str] = &[
+            "post_uri",
+            "feed_view_uuid",
+            "attribution_id",
+            "campaign_id",
+            "algorithm_id",
+            "user_did",
+            "created_at",
+            "cpm_cents",
+            "paying_account_id",
+            "paid_account_id",
+        ];
+        let rows: Vec<Vec<Cell>> = rows_in
+            .iter()
+            .map(|r| {
+                let paying = r
+                    .campaign_id
+                    .and_then(|c| campaign_accounts.get(&c).copied());
+                let paid = algorithm_accounts.get(&r.algorithm_id).copied();
+                vec![
+                    Cell::Str(r.post_id.clone()),
+                    Cell::Str(r.uuid.clone()),
+                    Cell::Int(r.attribution_id),
+                    opt_int(r.campaign_id),
+                    Cell::Int(r.algorithm_id),
+                    opt_str(r.user_did.clone()),
+                    Cell::DateTime(r.created_at),
+                    opt_int(r.cpm_cents),
+                    opt_int(paying),
+                    opt_int(paid),
+                ]
+            })
+            .collect();
+        let n = rows.len();
+        self.insert_rows("sponsored_feed_impressions", COLS, rows)
+            .await?;
+        Ok(n)
+    }
+}
+
+/// Backslash-escape TSV control characters (from graze-common's writer).
+fn escape_tab_value(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}

--- a/crates/graze-feed-stats/src/config.rs
+++ b/crates/graze-feed-stats/src/config.rs
@@ -1,0 +1,219 @@
+//! Configuration for the Graze Feed Stats worker.
+//!
+//! All configuration is loaded from environment variables. This worker is a
+//! drop-in replacement for the Python `feed_stats_runner.py` and preserves its
+//! Redis / ClickHouse / Postgres contract exactly (see the crate docs).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use graze_common::{exclusion_set_from_env_opt, ClickHouseConfig, RedisConfig};
+
+/// Application settings loaded from environment variables.
+#[derive(Debug, Clone)]
+pub struct Config {
+    // ─── Redis ──────────────────────────────────────────────────────────────
+    pub redis_url: String,
+    pub redis_pool_size: usize,
+    pub redis_connect_max_retries: u32,
+    pub redis_connect_initial_delay_ms: u64,
+
+    // ─── ClickHouse (analytics sink) ────────────────────────────────────────
+    pub clickhouse_host: String,
+    pub clickhouse_port: u16,
+    pub clickhouse_database: String,
+    pub clickhouse_user: String,
+    pub clickhouse_password: String,
+    pub clickhouse_secure: bool,
+
+    // ─── Postgres (billing sink) ────────────────────────────────────────────
+    pub database_url: String,
+    pub pg_max_connections: u32,
+
+    // ─── Worker tuning ──────────────────────────────────────────────────────
+    /// Max log_tasks pulled per batch before flushing (Python: 500).
+    pub log_batch_size: usize,
+    /// Max seconds to spend filling a batch (Python: 60).
+    pub log_batch_timeout_secs: u64,
+    /// feed_requests -> last_delivered_time flush cadence (Python default 60).
+    pub feed_requests_flush_interval_secs: u64,
+
+    // ─── Metrics ────────────────────────────────────────────────────────────
+    pub metrics_port: u16,
+
+    // ─── Privacy / opt-out (EXCLUSION_LIST) ─────────────────────────────────
+    pub exclusion_dids: Arc<HashSet<String>>,
+
+    // ─── Shadow mode ────────────────────────────────────────────────────────
+    /// When true every sink is redirected to an isolated target so no
+    /// production data is mutated. See [`ShadowConfig`].
+    pub shadow: ShadowConfig,
+}
+
+/// Shadow-mode isolation knobs. Off by default (real production sinks).
+#[derive(Debug, Clone)]
+pub struct ShadowConfig {
+    /// Master switch. When false, everything else here is ignored.
+    pub enabled: bool,
+    /// Redis list consumed for feed-render logs. Real: `log_tasks`.
+    /// Shadow default: `log_tasks_shadow`.
+    pub log_tasks_key: String,
+    /// Redis list consumed for feed-request pings. Real: `feed_requests`.
+    /// Shadow default: `feed_requests_shadow`.
+    pub feed_requests_key: String,
+    /// Prefix prepended to ClickHouse table names. Real: "" -> `post_render_log`.
+    /// Shadow default: `shadow_` -> `shadow_post_render_log`.
+    pub ch_table_prefix: String,
+    /// Prefix prepended to the four Redis counter keys. Real: "".
+    /// Shadow default: `shadow:` -> `shadow:campaign_algo:{id}` etc.
+    pub redis_key_prefix: String,
+    /// When true, Postgres billing mutations are NOT applied — the intended
+    /// statement + params are recorded for golden-diffing instead. Reads
+    /// (algorithm/account lookups) still hit the real DB (they are read-only).
+    pub pg_dry_run: bool,
+}
+
+impl Default for ShadowConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            log_tasks_key: "log_tasks".to_string(),
+            feed_requests_key: "feed_requests".to_string(),
+            ch_table_prefix: String::new(),
+            redis_key_prefix: String::new(),
+            pg_dry_run: false,
+        }
+    }
+}
+
+impl Config {
+    /// Load configuration from environment variables.
+    pub fn from_env() -> Self {
+        let shadow_enabled = parse_bool_env("SHADOW_MODE", false);
+
+        // In shadow mode the queue keys / sink prefixes default to isolated
+        // targets, but each is still individually overridable so the golden-diff
+        // harness can point them wherever it needs.
+        let shadow = ShadowConfig {
+            enabled: shadow_enabled,
+            log_tasks_key: default_env(
+                "LOG_TASKS_KEY",
+                if shadow_enabled {
+                    "log_tasks_shadow"
+                } else {
+                    "log_tasks"
+                },
+            ),
+            feed_requests_key: default_env(
+                "FEED_REQUESTS_KEY",
+                if shadow_enabled {
+                    "feed_requests_shadow"
+                } else {
+                    "feed_requests"
+                },
+            ),
+            ch_table_prefix: default_env(
+                "SHADOW_CH_TABLE_PREFIX",
+                if shadow_enabled { "shadow_" } else { "" },
+            ),
+            redis_key_prefix: default_env(
+                "SHADOW_REDIS_KEY_PREFIX",
+                if shadow_enabled { "shadow:" } else { "" },
+            ),
+            pg_dry_run: parse_bool_env("SHADOW_PG_DRY_RUN", shadow_enabled),
+        };
+
+        Self {
+            redis_url: default_env("REDIS_URL", "redis://localhost:6379"),
+            redis_pool_size: parse_usize_env("REDIS_POOL_SIZE", 100),
+            redis_connect_max_retries: parse_u32_env("REDIS_CONNECT_MAX_RETRIES", 10),
+            redis_connect_initial_delay_ms: parse_u64_env("REDIS_CONNECT_INITIAL_DELAY_MS", 500),
+
+            // ClickHouse Cloud is HTTPS on 443 (Python posts to `https://$HOST`
+            // with no explicit port). Keep it env-driven so local/dev can point
+            // at a plain-HTTP instance on 8123.
+            clickhouse_host: default_env("CLICKHOUSE_HOST", "localhost"),
+            clickhouse_port: parse_u16_env("CLICKHOUSE_PORT", 443),
+            clickhouse_database: default_env("CLICKHOUSE_DATABASE", "default"),
+            clickhouse_user: default_env("CLICKHOUSE_USER", "default"),
+            clickhouse_password: default_env("CLICKHOUSE_PASSWORD", ""),
+            clickhouse_secure: parse_bool_env("CLICKHOUSE_SECURE", true),
+
+            database_url: default_env("DATABASE_URL", "postgres://localhost/graze"),
+            pg_max_connections: parse_u32_env("PG_MAX_CONNECTIONS", 8),
+
+            log_batch_size: parse_usize_env("LOG_BATCH_SIZE", 500),
+            log_batch_timeout_secs: parse_u64_env("LOG_BATCH_TIMEOUT_SECS", 60),
+            feed_requests_flush_interval_secs: parse_u64_env("FEED_REQUESTS_FLUSH_INTERVAL", 60),
+
+            metrics_port: parse_u16_env("METRICS_PORT", 0),
+
+            exclusion_dids: exclusion_set_from_env_opt(std::env::var("EXCLUSION_LIST").ok()),
+
+            shadow,
+        }
+    }
+
+    /// Convert to `RedisConfig` for graze-common.
+    pub fn redis_config(&self) -> RedisConfig {
+        RedisConfig {
+            url: self.redis_url.clone(),
+            pool_size: self.redis_pool_size,
+            connect_max_retries: self.redis_connect_max_retries,
+            connect_initial_delay_ms: self.redis_connect_initial_delay_ms,
+        }
+    }
+
+    /// Convert to `ClickHouseConfig` for the analytics sink.
+    pub fn clickhouse_config(&self) -> ClickHouseConfig {
+        ClickHouseConfig {
+            host: self.clickhouse_host.clone(),
+            port: self.clickhouse_port,
+            database: self.clickhouse_database.clone(),
+            user: self.clickhouse_user.clone(),
+            password: self.clickhouse_password.clone(),
+            secure: self.clickhouse_secure,
+        }
+    }
+}
+
+// ─── Environment variable helpers (copied from graze-candidate-sync) ────────
+
+fn default_env(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
+fn parse_usize_env(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn parse_u16_env(name: &str, default: u16) -> u16 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn parse_u32_env(name: &str, default: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn parse_u64_env(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn parse_bool_env(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(v) => matches!(v.to_lowercase().as_str(), "true" | "1" | "yes"),
+        Err(_) => default,
+    }
+}

--- a/crates/graze-feed-stats/src/feed_requests.rs
+++ b/crates/graze-feed-stats/src/feed_requests.rs
@@ -1,0 +1,126 @@
+//! `feed_requests` drain + periodic `last_delivered_time` flush.
+//!
+//! Port of `feed_requests_worker` / `drain_feed_requests` / `flush_last_access_times`.
+//! Runs as its own tokio task (Python ran it as a daemon thread): it keeps the
+//! newest `requested_at` per feed in memory and flushes to Postgres every
+//! `feed_requests_flush_interval_secs`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use chrono::{DateTime, NaiveDateTime};
+use deadpool_redis::redis;
+use graze_common::RedisClient;
+use serde::Deserialize;
+use tokio::time::Instant;
+use tracing::{error, warn};
+
+use crate::config::Config;
+use crate::metrics::FeedStatsMetrics;
+use crate::pg::PgStore;
+
+#[derive(Debug, Deserialize)]
+struct FeedRequestEvent {
+    feed_uri: String,
+    requested_at: String,
+}
+
+pub struct FeedRequestsWorker {
+    redis: Arc<RedisClient>,
+    pg: Arc<PgStore>,
+    metrics: Arc<FeedStatsMetrics>,
+    config: Arc<Config>,
+}
+
+impl FeedRequestsWorker {
+    pub fn new(
+        redis: Arc<RedisClient>,
+        pg: Arc<PgStore>,
+        metrics: Arc<FeedStatsMetrics>,
+        config: Arc<Config>,
+    ) -> Self {
+        Self {
+            redis,
+            pg,
+            metrics,
+            config,
+        }
+    }
+
+    pub async fn run(&self) -> Result<()> {
+        let interval = Duration::from_secs(self.config.feed_requests_flush_interval_secs);
+        let mut latest: HashMap<String, NaiveDateTime> = HashMap::new();
+        let mut last_flush = Instant::now();
+
+        loop {
+            if let Err(e) = self.drain(&mut latest).await {
+                error!(error = %e, "feed_requests drain error");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+
+            if last_flush.elapsed() >= interval {
+                let to_flush = std::mem::take(&mut latest);
+                match self.pg.flush_last_delivered(&to_flush).await {
+                    Ok(n) => {
+                        if n > 0 {
+                            self.metrics.feed_requests_flushed.inc_by(n as u64);
+                        }
+                    }
+                    Err(e) => {
+                        self.metrics.pg_errors.inc();
+                        error!(error = %e, "flush_last_delivered failed");
+                    }
+                }
+                last_flush = Instant::now();
+            }
+        }
+    }
+
+    /// Drain up to 500 events, keeping the max `requested_at` per feed_uri.
+    async fn drain(&self, latest: &mut HashMap<String, NaiveDateTime>) -> Result<()> {
+        let key = &self.config.shadow.feed_requests_key;
+        let mut count = 0;
+        while count < 500 {
+            let mut conn = self.redis.get().await?;
+            let result: Option<(String, String)> = redis::cmd("BLPOP")
+                .arg(key)
+                .arg(1) // 1s block, matching Python
+                .query_async(&mut conn)
+                .await?;
+            let raw = match result {
+                Some((_, raw)) => raw,
+                None => break,
+            };
+            match serde_json::from_str::<FeedRequestEvent>(&raw) {
+                Ok(ev) => {
+                    if let Some(ts) = parse_ts(&ev.requested_at) {
+                        latest
+                            .entry(ev.feed_uri)
+                            .and_modify(|e| {
+                                if ts > *e {
+                                    *e = ts;
+                                }
+                            })
+                            .or_insert(ts);
+                    }
+                }
+                Err(e) => warn!(error = %e, "bad feed_request event"),
+            }
+            count += 1;
+        }
+        Ok(())
+    }
+}
+
+/// Parse `requested_at` (ISO-8601, with or without timezone / `Z`).
+fn parse_ts(s: &str) -> Option<NaiveDateTime> {
+    let normalized = s.replace('Z', "+00:00");
+    if let Ok(dt) = DateTime::parse_from_rfc3339(&normalized) {
+        return Some(dt.naive_utc());
+    }
+    NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
+        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S"))
+        .ok()
+}

--- a/crates/graze-feed-stats/src/lib.rs
+++ b/crates/graze-feed-stats/src/lib.rs
@@ -1,0 +1,25 @@
+//! Graze Feed Stats — Rust drop-in replacement for `feed_stats_runner.py`.
+//!
+//! Consumes feed-serve telemetry from Redis (`log_tasks`, `feed_requests`) and
+//! fans it out to three sinks, preserving the Python worker's contract exactly:
+//!   * ClickHouse analytics: `post_render_log`, `sponsored_feed_impressions`
+//!   * Redis ad-spend counters (consumed by clickhouse_materializer.py)
+//!   * Postgres billing: sticky-post credit decrement, `CreditUsage`,
+//!     `Algorithm.settings.last_delivered_time`
+//!
+//! Shadow mode ([`config::ShadowConfig`]) redirects every sink to an isolated
+//! target so it can run against mirrored production traffic with zero risk.
+
+pub mod clickhouse_sink;
+pub mod config;
+pub mod feed_requests;
+pub mod log_worker;
+pub mod metrics;
+pub mod parse;
+pub mod pg;
+pub mod redis_counters;
+
+pub use config::{Config, ShadowConfig};
+pub use feed_requests::FeedRequestsWorker;
+pub use log_worker::LogWorker;
+pub use metrics::FeedStatsMetrics;

--- a/crates/graze-feed-stats/src/log_worker.rs
+++ b/crates/graze-feed-stats/src/log_worker.rs
@@ -1,0 +1,265 @@
+//! Main `log_tasks` consumer — port of `fetch_logs` + `process_logs` +
+//! `worker()` from feed_stats_runner.py.
+//!
+//! Flow per batch (order preserved from Python):
+//!   1. BLPOP up to `log_batch_size` events (or `log_batch_timeout_secs`).
+//!   2. Resolve algorithms for the batch's feed_uris (one Postgres round-trip).
+//!   3. Expand each log → post_render rows + attributable rows + credit pairs.
+//!   4. Insert post_render_log, then sponsored_feed_impressions (ClickHouse).
+//!   5. Bump the four Redis ad counters.
+//!   6. Decrement sticky-post credits + write CreditUsage (Postgres).
+//!
+//! Parity note: feed_stats_runner.py does NOT consult EXCLUSION_LIST (the env var
+//! is set on the deployment but the script never reads it), so we do not filter
+//! on it either. On a sink error we log + count a metric and continue to the next
+//! batch rather than crashing the pod — the events are already popped, so this
+//! matches Python's effective delivery semantics without killing the worker.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use chrono::Utc;
+use deadpool_redis::redis;
+use graze_common::RedisClient;
+use tokio::time::Instant;
+use tracing::{error, warn};
+
+use crate::clickhouse_sink::ClickHouseSink;
+use crate::config::Config;
+use crate::metrics::FeedStatsMetrics;
+use crate::parse::{expand_log, RawLog};
+use crate::pg::PgStore;
+use crate::redis_counters::RedisCounters;
+
+pub struct LogWorker {
+    redis: Arc<RedisClient>,
+    ch: Arc<ClickHouseSink>,
+    pg: Arc<PgStore>,
+    counters: RedisCounters,
+    metrics: Arc<FeedStatsMetrics>,
+    config: Arc<Config>,
+}
+
+impl LogWorker {
+    pub fn new(
+        redis: Arc<RedisClient>,
+        ch: Arc<ClickHouseSink>,
+        pg: Arc<PgStore>,
+        counters: RedisCounters,
+        metrics: Arc<FeedStatsMetrics>,
+        config: Arc<Config>,
+    ) -> Self {
+        Self {
+            redis,
+            ch,
+            pg,
+            counters,
+            metrics,
+            config,
+        }
+    }
+
+    /// Run forever: fetch a batch, process it, repeat.
+    pub async fn run(&self) -> Result<()> {
+        loop {
+            let batch = self.fetch_logs().await?;
+            if batch.is_empty() {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+            if let Err(e) = self.process_logs(batch).await {
+                error!(error = %e, "process_logs failed for batch");
+            }
+            self.metrics.batches_processed.inc();
+        }
+    }
+
+    /// BLPOP up to `log_batch_size` events, bounded by `log_batch_timeout_secs`.
+    async fn fetch_logs(&self) -> Result<Vec<String>> {
+        let key = &self.config.shadow.log_tasks_key;
+        let mut batch = Vec::new();
+        let start = Instant::now();
+        let deadline = Duration::from_secs(self.config.log_batch_timeout_secs);
+
+        while batch.len() < self.config.log_batch_size {
+            let mut conn = self.redis.get().await?;
+            let result: Option<(String, String)> = redis::cmd("BLPOP")
+                .arg(key)
+                .arg(5) // 5s server-side block, matching Python
+                .query_async(&mut conn)
+                .await?;
+            match result {
+                Some((_, raw)) => batch.push(raw),
+                None => break, // timeout, no events waiting
+            }
+            if start.elapsed() >= deadline {
+                break;
+            }
+        }
+        Ok(batch)
+    }
+
+    async fn process_logs(&self, batch: Vec<String>) -> Result<()> {
+        // Decode JSON; a decode failure skips that event (Python fetch_logs).
+        let mut raws: Vec<RawLog> = Vec::with_capacity(batch.len());
+        for raw in &batch {
+            match serde_json::from_str::<RawLog>(raw) {
+                Ok(r) => raws.push(r),
+                Err(e) => {
+                    warn!(error = %e, "skipping undecodable log_tasks entry");
+                    self.metrics.log_parse_errors.inc();
+                }
+            }
+        }
+        if raws.is_empty() {
+            return Ok(());
+        }
+
+        // Resolve algorithms for every distinct feed_uri in the batch.
+        let uris: Vec<String> = raws
+            .iter()
+            .filter_map(|r| r.feed_uri.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        let algorithms = match self.pg.algorithms_by_uri(&uris).await {
+            Ok(m) => m,
+            Err(e) => {
+                self.metrics.pg_errors.inc();
+                return Err(e);
+            }
+        };
+
+        let now = Utc::now().naive_utc();
+        let mut post_views = Vec::new();
+        let mut attributable_rows = Vec::new();
+        let mut post_algo_pairs: Vec<(String, i64)> = Vec::new();
+
+        for raw in &raws {
+            let mut expanded = match expand_log(raw, now) {
+                Ok(e) => e,
+                Err(e) => {
+                    warn!(error = %e, "skipping log on expand error");
+                    self.metrics.log_parse_errors.inc();
+                    continue;
+                }
+            };
+            // Resolve this log's algorithm and stamp the id onto its rows.
+            let algo = algorithms.get(&expanded.feed_uri).copied();
+            let algo_id = algo.map(|a| a.id).unwrap_or(0);
+            for v in expanded.post_views.iter_mut() {
+                v.algorithm_id = algo_id;
+            }
+            for r in expanded.attributable_rows.iter_mut() {
+                r.algorithm_id = algo_id;
+            }
+            // post_algo_pairs: one per post_id, only when the feed has an algo.
+            if algo.is_some() {
+                for post_id in &raw.post_ids {
+                    post_algo_pairs.push((post_id.clone(), algo_id));
+                }
+            }
+
+            post_views.append(&mut expanded.post_views);
+            attributable_rows.append(&mut expanded.attributable_rows);
+            self.metrics.logs_processed.inc();
+        }
+
+        // Account maps (union of ids across both row sets — keyed lookups).
+        let mut campaign_ids: HashSet<i64> = HashSet::new();
+        let mut algorithm_ids: HashSet<i64> = HashSet::new();
+        for v in &post_views {
+            if let Some(c) = v.campaign_id {
+                campaign_ids.insert(c);
+            }
+            if v.algorithm_id != 0 {
+                algorithm_ids.insert(v.algorithm_id);
+            }
+        }
+        for r in &attributable_rows {
+            if let Some(c) = r.campaign_id {
+                campaign_ids.insert(c);
+            }
+            if r.algorithm_id != 0 {
+                algorithm_ids.insert(r.algorithm_id);
+            }
+        }
+        let campaign_ids: Vec<i64> = campaign_ids.into_iter().collect();
+        let algorithm_ids: Vec<i64> = algorithm_ids.into_iter().collect();
+
+        let campaign_accounts = self
+            .pg
+            .campaign_account_map(&campaign_ids)
+            .await
+            .unwrap_or_else(|e| {
+                self.metrics.pg_errors.inc();
+                error!(error = %e, "campaign_account_map failed");
+                HashMap::new()
+            });
+        let algorithm_accounts = self
+            .pg
+            .algorithm_account_map(&algorithm_ids)
+            .await
+            .unwrap_or_else(|e| {
+                self.metrics.pg_errors.inc();
+                error!(error = %e, "algorithm_account_map failed");
+                HashMap::new()
+            });
+
+        // 1) post_render_log
+        match self
+            .ch
+            .insert_post_render_log(&post_views, &campaign_accounts, &algorithm_accounts)
+            .await
+        {
+            Ok(n) => {
+                self.metrics.post_render_log_inserts.inc_by(n as u64);
+            }
+            Err(e) => {
+                self.metrics.clickhouse_errors.inc();
+                error!(error = %e, "post_render_log insert failed");
+            }
+        }
+
+        // 2) sponsored_feed_impressions
+        match self
+            .ch
+            .insert_sponsored_feed_impressions(
+                &attributable_rows,
+                &campaign_accounts,
+                &algorithm_accounts,
+            )
+            .await
+        {
+            Ok(n) => {
+                self.metrics
+                    .sponsored_feed_impressions_inserts
+                    .inc_by(n as u64);
+            }
+            Err(e) => {
+                self.metrics.clickhouse_errors.inc();
+                error!(error = %e, "sponsored_feed_impressions insert failed");
+            }
+        }
+
+        // 3) Redis ad counters
+        if let Err(e) = self.counters.update(&self.redis, &attributable_rows).await {
+            self.metrics.redis_errors.inc();
+            error!(error = %e, "redis counter update failed");
+        }
+
+        // 4) Postgres: sticky-credit decrement + CreditUsage
+        if let Err(e) = self
+            .pg
+            .decrement_available_impressions(&post_algo_pairs)
+            .await
+        {
+            self.metrics.pg_errors.inc();
+            error!(error = %e, "decrement_available_impressions failed");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/graze-feed-stats/src/main.rs
+++ b/crates/graze-feed-stats/src/main.rs
@@ -1,0 +1,123 @@
+//! Feed Stats worker binary — Rust drop-in for `feed_stats_runner.py`.
+
+use std::sync::Arc;
+
+use tokio::signal;
+use tracing::{info, Level};
+use tracing_subscriber::EnvFilter;
+
+use graze_common::{maybe_run_metrics_server, RedisClient};
+use graze_feed_stats::clickhouse_sink::ClickHouseSink;
+use graze_feed_stats::pg::PgStore;
+use graze_feed_stats::redis_counters::RedisCounters;
+use graze_feed_stats::{Config, FeedRequestsWorker, FeedStatsMetrics, LogWorker};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(Level::INFO.into())
+                .from_env_lossy(),
+        )
+        .json()
+        .init();
+
+    info!("Starting Graze Feed Stats worker");
+
+    let config = Config::from_env();
+    let metrics_port = config.metrics_port;
+    info!(
+        shadow_mode = config.shadow.enabled,
+        log_tasks_key = %config.shadow.log_tasks_key,
+        feed_requests_key = %config.shadow.feed_requests_key,
+        ch_table_prefix = %config.shadow.ch_table_prefix,
+        redis_key_prefix = %config.shadow.redis_key_prefix,
+        pg_dry_run = config.shadow.pg_dry_run,
+        clickhouse_host = %config.clickhouse_host,
+        "Configuration loaded"
+    );
+    let config = Arc::new(config);
+
+    // Shared clients.
+    let redis = Arc::new(RedisClient::new(&config.redis_config()).await?);
+    info!("Connected to Redis");
+    let pg = Arc::new(
+        PgStore::connect(
+            &config.database_url,
+            config.pg_max_connections,
+            config.shadow.pg_dry_run,
+        )
+        .await?,
+    );
+    info!(dry_run = pg.dry_run(), "Connected to Postgres");
+    let ch = Arc::new(ClickHouseSink::new(
+        config.clickhouse_config(),
+        config.shadow.ch_table_prefix.clone(),
+    ));
+    let counters = RedisCounters::new(config.shadow.redis_key_prefix.clone());
+    let metrics = Arc::new(FeedStatsMetrics::new());
+
+    // Main log_tasks worker.
+    let log_worker = LogWorker::new(
+        redis.clone(),
+        ch.clone(),
+        pg.clone(),
+        counters,
+        metrics.clone(),
+        config.clone(),
+    );
+
+    // Background feed_requests flusher (Python's daemon thread).
+    let feed_requests =
+        FeedRequestsWorker::new(redis.clone(), pg.clone(), metrics.clone(), config.clone());
+    let feed_requests_handle = tokio::spawn(async move {
+        if let Err(e) = feed_requests.run().await {
+            tracing::error!(error = %e, "feed_requests worker exited");
+        }
+    });
+
+    tokio::select! {
+        result = log_worker.run() => {
+            if let Err(e) = result {
+                tracing::error!(error = %e, "log worker error");
+            }
+        }
+        _ = shutdown_signal() => {
+            info!("Shutdown signal received");
+        }
+        result = maybe_run_metrics_server(metrics_port, "0.0.0.0", metrics) => {
+            if let Err(e) = result {
+                tracing::error!(error = %e, "Metrics server error");
+            }
+        }
+    }
+
+    feed_requests_handle.abort();
+    info!("Feed Stats worker shutdown complete");
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}

--- a/crates/graze-feed-stats/src/metrics.rs
+++ b/crates/graze-feed-stats/src/metrics.rs
@@ -1,0 +1,107 @@
+//! Prometheus metrics for the Feed Stats worker.
+//!
+//! Mirrors the `telemetry.record_gauge(...)` call sites in feed_stats_runner.py
+//! as counters, plus worker-health counters. Namespaced `graze_feed_stats_*`.
+
+use prometheus_client::encoding::text::encode;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::registry::Registry;
+
+pub struct FeedStatsMetrics {
+    registry: Registry,
+
+    /// Rows inserted into post_render_log.
+    pub post_render_log_inserts: Counter,
+    /// Rows inserted into sponsored_feed_impressions.
+    pub sponsored_feed_impressions_inserts: Counter,
+    /// log_tasks batches processed.
+    pub batches_processed: Counter,
+    /// Individual log lines processed (successful expansions).
+    pub logs_processed: Counter,
+    /// Log lines skipped due to a parse error (Python per-log try/except).
+    pub log_parse_errors: Counter,
+    /// feed_requests flushed to last_delivered_time.
+    pub feed_requests_flushed: Counter,
+    /// ClickHouse insert errors.
+    pub clickhouse_errors: Counter,
+    /// Postgres errors.
+    pub pg_errors: Counter,
+    /// Redis errors.
+    pub redis_errors: Counter,
+}
+
+impl FeedStatsMetrics {
+    pub fn new() -> Self {
+        let mut registry = Registry::default();
+
+        macro_rules! reg {
+            ($name:expr, $help:expr) => {{
+                let c = Counter::default();
+                registry.register($name, $help, c.clone());
+                c
+            }};
+        }
+
+        let post_render_log_inserts = reg!(
+            "graze_feed_stats_post_render_log_inserts_total",
+            "Rows inserted into post_render_log"
+        );
+        let sponsored_feed_impressions_inserts = reg!(
+            "graze_feed_stats_sponsored_feed_impressions_inserts_total",
+            "Rows inserted into sponsored_feed_impressions"
+        );
+        let batches_processed = reg!(
+            "graze_feed_stats_batches_processed_total",
+            "log_tasks batches processed"
+        );
+        let logs_processed = reg!(
+            "graze_feed_stats_logs_processed_total",
+            "Log lines processed"
+        );
+        let log_parse_errors = reg!(
+            "graze_feed_stats_log_parse_errors_total",
+            "Log lines skipped on parse error"
+        );
+        let feed_requests_flushed = reg!(
+            "graze_feed_stats_feed_requests_flushed_total",
+            "feed_requests flushed to last_delivered_time"
+        );
+        let clickhouse_errors = reg!(
+            "graze_feed_stats_clickhouse_errors_total",
+            "ClickHouse insert errors"
+        );
+        let pg_errors = reg!("graze_feed_stats_pg_errors_total", "Postgres errors");
+        let redis_errors = reg!("graze_feed_stats_redis_errors_total", "Redis errors");
+
+        Self {
+            registry,
+            post_render_log_inserts,
+            sponsored_feed_impressions_inserts,
+            batches_processed,
+            logs_processed,
+            log_parse_errors,
+            feed_requests_flushed,
+            clickhouse_errors,
+            pg_errors,
+            redis_errors,
+        }
+    }
+
+    pub fn encode(&self) -> String {
+        let mut buffer = String::new();
+        encode(&mut buffer, &self.registry).unwrap();
+        buffer
+    }
+}
+
+impl Default for FeedStatsMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl graze_common::MetricsEncodable for FeedStatsMetrics {
+    fn encode(&self) -> String {
+        self.encode()
+    }
+}

--- a/crates/graze-feed-stats/src/parse.rs
+++ b/crates/graze-feed-stats/src/parse.rs
@@ -1,0 +1,366 @@
+//! Parsing of `log_tasks` payloads — a faithful port of the field reads in
+//! `feed_stats_runner.py::process_logs`.
+//!
+//! Parity notes (replicated bug-for-bug; see crate docs):
+//!  * `cpm_cents` is gated on the presence of `_c` in the attribution string,
+//!    even though it is split on `_p` (feed_stats_runner.py:313-314, :340-341).
+//!  * `limit` is coerced to an integer for `post_render_log` (`int(limit)`).
+//!  * `reqId` missing → a fresh uuid4; `iss`-less / missing auth → "anonymous".
+//!  * A record that fails any of these conversions aborts processing of that
+//!    single log (Python wraps each log in try/except), so callers should treat
+//!    a parse error as "skip this one log".
+
+use base64::Engine;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::Deserialize;
+
+/// Raw `log_tasks` JSON payload. Every field is optional at the JSON layer;
+/// semantic requirements (e.g. `feed_uri`) are enforced during expansion.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RawLog {
+    #[serde(default, rename = "reqId")]
+    pub req_id: Option<String>,
+    pub feed_uri: Option<String>,
+    #[serde(default)]
+    pub post_ids: Vec<String>,
+    #[serde(default)]
+    pub attributions: Option<Vec<Option<String>>>,
+    #[serde(default)]
+    pub cursor: Option<String>,
+    #[serde(default)]
+    pub limit: Option<serde_json::Value>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub authorization_header: Option<String>,
+}
+
+/// A parsed attribution tag: `s{attribution_id}_c{campaign_id}_p{cpm_cents}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Attribution {
+    pub attribution_id: i64,
+    pub campaign_id: Option<i64>,
+    pub cpm_cents: Option<i64>,
+}
+
+/// One row of `post_render_log` (a fully-expanded post impression).
+#[derive(Debug, Clone)]
+pub struct PostView {
+    pub attribution_id: Option<i64>,
+    pub campaign_id: Option<i64>,
+    pub post_id: String,
+    pub position: usize,
+    pub uuid: String,
+    pub algorithm_id: i64,
+    pub user_did: String,
+    pub cpm_cents: Option<i64>,
+    pub created_at: NaiveDateTime,
+    pub feed_operator_did: String,
+    pub slug: String,
+    pub cursor: Option<String>,
+    pub limit: i64,
+    pub post_count: usize,
+}
+
+/// One attributable (paid) impression → a row of `sponsored_feed_impressions`
+/// and a Redis-counter / credit event.
+#[derive(Debug, Clone)]
+pub struct AttributableRow {
+    pub attribution_id: i64,
+    pub campaign_id: Option<i64>,
+    pub post_id: String,
+    pub uuid: String,
+    pub algorithm_id: i64,
+    pub user_did: Option<String>,
+    pub cpm_cents: Option<i64>,
+    pub created_at: NaiveDateTime,
+}
+
+/// The result of expanding a single log line.
+#[derive(Debug, Clone, Default)]
+pub struct ExpandedLog {
+    pub post_views: Vec<PostView>,
+    pub attributable_rows: Vec<AttributableRow>,
+    /// (post_uri, algo_id) pairs used to decrement sticky-post credits.
+    pub post_algo_pairs: Vec<(String, i64)>,
+    /// Distinct feed_uris referenced (for the algorithm lookup up the stack).
+    pub feed_uri: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("missing feed_uri")]
+    MissingFeedUri,
+    #[error("bad attribution `{0}`")]
+    BadAttribution(String),
+    #[error("bad limit")]
+    BadLimit,
+    #[error("index out of range")]
+    IndexOutOfRange,
+}
+
+/// Parse a single attribution tag. Returns `Ok(None)` when the tag is null or
+/// does not start with `s` (i.e. not attributable). Returns `Err` when it looks
+/// attributable but the embedded integers fail to parse — matching Python's
+/// `int(...)` raising and aborting the log.
+pub fn parse_attribution(tag: Option<&str>) -> Result<Option<Attribution>, ParseError> {
+    let e = match tag {
+        Some(e) if e.starts_with('s') => e,
+        _ => return Ok(None),
+    };
+
+    // attribution_id = int(e.split("s")[1].split("_")[0])
+    let after_first_s = e
+        .split('s')
+        .nth(1)
+        .ok_or_else(|| ParseError::BadAttribution(e.to_string()))?;
+    let attribution_id: i64 = after_first_s
+        .split('_')
+        .next()
+        .unwrap_or("")
+        .parse()
+        .map_err(|_| ParseError::BadAttribution(e.to_string()))?;
+
+    let has_c = e.contains("_c");
+
+    // campaign_id present iff `_c` substring.
+    let campaign_id = if has_c {
+        let seg = e
+            .split("_c")
+            .nth(1)
+            .ok_or_else(|| ParseError::BadAttribution(e.to_string()))?;
+        Some(
+            seg.split('_')
+                .next()
+                .unwrap_or("")
+                .parse()
+                .map_err(|_| ParseError::BadAttribution(e.to_string()))?,
+        )
+    } else {
+        None
+    };
+
+    // PARITY QUIRK: cpm gated on `_c`, but split on `_p`.
+    let cpm_cents = if has_c {
+        let seg = e
+            .split("_p")
+            .nth(1)
+            .ok_or_else(|| ParseError::BadAttribution(e.to_string()))?;
+        Some(
+            seg.parse()
+                .map_err(|_| ParseError::BadAttribution(e.to_string()))?,
+        )
+    } else {
+        None
+    };
+
+    Ok(Some(Attribution {
+        attribution_id,
+        campaign_id,
+        cpm_cents,
+    }))
+}
+
+/// Decode the `iss` claim from a `Bearer <jwt>` header WITHOUT verifying the
+/// signature (mirrors `jwt.decode(..., verify_signature=False)`). Any failure
+/// yields `None`, matching the Python `try/except: user_did = None`.
+pub fn user_did_from_auth(header: Option<&str>) -> Option<String> {
+    let header = header.unwrap_or("Bearer ");
+    let token = header.split("Bearer ").nth(1)?;
+    let payload_b64 = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64.trim())
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    claims
+        .get("iss")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Parse `created_at` (ISO-8601, trailing `Z` accepted) to a naive-UTC datetime,
+/// falling back to "now" when absent — matching `datetime.utcnow()`.
+pub fn parse_created_at(raw: Option<&str>, now: NaiveDateTime) -> NaiveDateTime {
+    match raw {
+        Some(s) if !s.is_empty() => {
+            let normalized = s.replace('Z', "+00:00");
+            DateTime::parse_from_rfc3339(&normalized)
+                .map(|dt| dt.with_timezone(&Utc).naive_utc())
+                .unwrap_or(now)
+        }
+        _ => now,
+    }
+}
+
+/// Coerce `limit` the way `int(limit)` does in Python: accepts JSON numbers and
+/// numeric strings; anything else is a parse error that aborts the log.
+fn coerce_limit(v: &Option<serde_json::Value>) -> Result<i64, ParseError> {
+    match v {
+        Some(serde_json::Value::Number(n)) => n
+            .as_i64()
+            .or_else(|| n.as_f64().map(|f| f as i64))
+            .ok_or(ParseError::BadLimit),
+        Some(serde_json::Value::String(s)) => s.trim().parse().map_err(|_| ParseError::BadLimit),
+        _ => Err(ParseError::BadLimit),
+    }
+}
+
+/// Expand one raw log into its rows. Returns `Err` if the log should be skipped
+/// entirely (Python's per-log `try/except`).
+pub fn expand_log(raw: &RawLog, now: NaiveDateTime) -> Result<ExpandedLog, ParseError> {
+    let feed_uri = raw.feed_uri.clone().ok_or(ParseError::MissingFeedUri)?;
+    let feed_uuid = raw
+        .req_id
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    let created_at = parse_created_at(raw.created_at.as_deref(), now);
+    let user_did = user_did_from_auth(raw.authorization_header.as_deref());
+
+    // feed_operator_did = feed_uri.split("/")[2]; slug = feed_uri.split("/")[-1]
+    let segments: Vec<&str> = feed_uri.split('/').collect();
+    let feed_operator_did = segments.get(2).copied().unwrap_or("").to_string();
+    let slug = segments.last().copied().unwrap_or("").to_string();
+
+    let post_count = raw.post_ids.len();
+
+    // `limit` is only coerced when there are posts to render (Python casts it at
+    // row-build time). With zero posts the cast never runs, so tolerate absence.
+    let limit = if post_count > 0 {
+        coerce_limit(&raw.limit)?
+    } else {
+        0
+    };
+
+    let mut out = ExpandedLog {
+        feed_uri: feed_uri.clone(),
+        ..Default::default()
+    };
+
+    // attribution_list defaults to [None; len(post_ids)] and is indexed by i.
+    let empty_attr: Vec<Option<String>> = vec![None; post_count];
+    let attribution_list = raw.attributions.as_ref().unwrap_or(&empty_attr);
+
+    // ── Pass 1: one PostView per post_id (post_render_log) ──────────────────
+    for (i, post_id) in raw.post_ids.iter().enumerate() {
+        let tag = attribution_list.get(i).and_then(|o| o.as_deref());
+        let attr = parse_attribution(tag)?;
+        out.post_views.push(PostView {
+            attribution_id: attr.map(|a| a.attribution_id),
+            campaign_id: attr.and_then(|a| a.campaign_id),
+            post_id: post_id.clone(),
+            position: i,
+            uuid: feed_uuid.clone(),
+            algorithm_id: 0, // filled in by the caller once the algo is resolved
+            user_did: user_did.clone().unwrap_or_else(|| "anonymous".to_string()),
+            cpm_cents: attr.and_then(|a| a.cpm_cents),
+            created_at,
+            feed_operator_did: feed_operator_did.clone(),
+            slug: slug.clone(),
+            cursor: raw.cursor.clone(),
+            limit,
+            post_count,
+        });
+    }
+
+    // ── Pass 2: attributable rows (sponsored_feed_impressions) ──────────────
+    // Mirrors the SECOND loop in Python which iterates `attributions` and
+    // indexes `post_ids[i]` — an out-of-range index aborts the whole log.
+    for (i, tag) in attribution_list.iter().enumerate() {
+        if let Some(attr) = parse_attribution(tag.as_deref())? {
+            let post_id = raw.post_ids.get(i).ok_or(ParseError::IndexOutOfRange)?;
+            out.attributable_rows.push(AttributableRow {
+                attribution_id: attr.attribution_id,
+                campaign_id: attr.campaign_id,
+                post_id: post_id.clone(),
+                uuid: feed_uuid.clone(),
+                algorithm_id: 0, // filled in by the caller
+                user_did: user_did.clone(),
+                cpm_cents: attr.cpm_cents,
+                created_at,
+            });
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> NaiveDateTime {
+        NaiveDateTime::parse_from_str("2026-08-06 12:00:00", "%Y-%m-%d %H:%M:%S").unwrap()
+    }
+
+    #[test]
+    fn attribution_full() {
+        let a = parse_attribution(Some("s123_c45_p678")).unwrap().unwrap();
+        assert_eq!(a.attribution_id, 123);
+        assert_eq!(a.campaign_id, Some(45));
+        assert_eq!(a.cpm_cents, Some(678));
+    }
+
+    #[test]
+    fn attribution_null_and_non_s() {
+        assert_eq!(parse_attribution(None).unwrap(), None);
+        assert_eq!(parse_attribution(Some("nope")).unwrap(), None);
+    }
+
+    #[test]
+    fn attribution_quirk_cpm_gated_on_c() {
+        // `_p` present but no `_c`: cpm stays None because the gate is `_c`.
+        let a = parse_attribution(Some("s7_p900")).unwrap().unwrap();
+        assert_eq!(a.attribution_id, 7);
+        assert_eq!(a.campaign_id, None);
+        assert_eq!(a.cpm_cents, None);
+    }
+
+    #[test]
+    fn jwt_iss_extracted_unverified() {
+        // header.payload.signature where payload = {"iss":"did:plc:abc"}
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"iss":"did:plc:abc"}"#);
+        let token = format!("aaa.{}.bbb", payload);
+        let did = user_did_from_auth(Some(&format!("Bearer {}", token)));
+        assert_eq!(did.as_deref(), Some("did:plc:abc"));
+    }
+
+    #[test]
+    fn missing_auth_is_none() {
+        assert_eq!(user_did_from_auth(None), None);
+        assert_eq!(user_did_from_auth(Some("Bearer ")), None);
+    }
+
+    #[test]
+    fn created_at_z_suffix() {
+        let dt = parse_created_at(Some("2026-08-06T12:00:00Z"), now());
+        assert_eq!(
+            dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-08-06 12:00:00"
+        );
+    }
+
+    #[test]
+    fn anonymous_user_and_expansion() {
+        let raw = RawLog {
+            req_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+            feed_uri: Some("at://did:plc:op/app.bsky.feed.generator/myfeed".to_string()),
+            post_ids: vec!["at://did:plc:a/app.bsky.feed.post/1".to_string()],
+            attributions: Some(vec![Some("s1_c2_p3".to_string())]),
+            cursor: None,
+            limit: Some(serde_json::json!(20)),
+            created_at: Some("2026-08-06T12:00:00Z".to_string()),
+            authorization_header: None,
+        };
+        let ex = expand_log(&raw, now()).unwrap();
+        assert_eq!(ex.post_views.len(), 1);
+        assert_eq!(ex.post_views[0].user_did, "anonymous");
+        assert_eq!(ex.post_views[0].feed_operator_did, "did:plc:op");
+        assert_eq!(ex.post_views[0].slug, "myfeed");
+        assert_eq!(ex.post_views[0].limit, 20);
+        assert_eq!(ex.attributable_rows.len(), 1);
+        assert_eq!(ex.attributable_rows[0].attribution_id, 1);
+    }
+}

--- a/crates/graze-feed-stats/src/pg.rs
+++ b/crates/graze-feed-stats/src/pg.rs
@@ -1,0 +1,268 @@
+//! Postgres billing + lookup layer.
+//!
+//! Ports the SQLAlchemy work in `feed_stats_runner.py`: algorithm/account
+//! lookups, sticky-post credit decrement, `CreditUsage` inserts, and the
+//! `last_delivered_time` flush. graze-common has no SQL driver, so this is the
+//! one net-new dependency (sqlx).
+//!
+//! Reads always execute (they are side-effect free). Writes are gated by
+//! `dry_run`: when set (shadow / mirror mode) the intended statement + params
+//! are logged instead of applied, so no production row is mutated.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use chrono::NaiveDateTime;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::Row;
+use tracing::info;
+
+/// Resolved algorithm: its numeric id and owning user.
+#[derive(Debug, Clone, Copy)]
+pub struct AlgoRef {
+    pub id: i64,
+    pub user_id: i64,
+}
+
+pub struct PgStore {
+    pool: PgPool,
+    dry_run: bool,
+}
+
+impl PgStore {
+    pub async fn connect(database_url: &str, max_connections: u32, dry_run: bool) -> Result<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .connect(database_url)
+            .await?;
+        Ok(Self { pool, dry_run })
+    }
+
+    pub fn dry_run(&self) -> bool {
+        self.dry_run
+    }
+
+    /// `select Algorithm where algorithm_uri in (:uris)` → uri → {id, user_id}.
+    pub async fn algorithms_by_uri(&self, uris: &[String]) -> Result<HashMap<String, AlgoRef>> {
+        let mut map = HashMap::new();
+        if uris.is_empty() {
+            return Ok(map);
+        }
+        let rows = sqlx::query(
+            "SELECT algorithm_uri, id, user_id FROM algorithms WHERE algorithm_uri = ANY($1)",
+        )
+        .bind(uris)
+        .fetch_all(&self.pool)
+        .await?;
+        for row in rows {
+            let uri: String = row.get("algorithm_uri");
+            let id: i32 = row.get("id");
+            let user_id: i32 = row.get("user_id");
+            map.insert(
+                uri,
+                AlgoRef {
+                    id: id as i64,
+                    user_id: user_id as i64,
+                },
+            );
+        }
+        Ok(map)
+    }
+
+    /// `Campaign.id JOIN Account ON Campaign.user_id == Account.user_id` filtered
+    /// to the given campaign ids → campaign_id → account_id.
+    pub async fn campaign_account_map(&self, campaign_ids: &[i64]) -> Result<HashMap<i64, i64>> {
+        self.id_account_map(
+            "SELECT c.id, a.id AS account_id FROM campaigns c \
+             JOIN accounts a ON c.user_id = a.user_id WHERE c.id = ANY($1)",
+            campaign_ids,
+        )
+        .await
+    }
+
+    /// `Algorithm.id JOIN Account ON Algorithm.user_id == Account.user_id`
+    /// filtered to the given algorithm ids → algorithm_id → account_id.
+    pub async fn algorithm_account_map(&self, algorithm_ids: &[i64]) -> Result<HashMap<i64, i64>> {
+        self.id_account_map(
+            "SELECT al.id, a.id AS account_id FROM algorithms al \
+             JOIN accounts a ON al.user_id = a.user_id WHERE al.id = ANY($1)",
+            algorithm_ids,
+        )
+        .await
+    }
+
+    async fn id_account_map(&self, sql: &str, ids: &[i64]) -> Result<HashMap<i64, i64>> {
+        let mut map = HashMap::new();
+        if ids.is_empty() {
+            return Ok(map);
+        }
+        let ids32: Vec<i32> = ids.iter().map(|&v| v as i32).collect();
+        let rows = sqlx::query(sql).bind(&ids32).fetch_all(&self.pool).await?;
+        for row in rows {
+            let id: i32 = row.get(0);
+            let account_id: i32 = row.get("account_id");
+            map.insert(id as i64, account_id as i64);
+        }
+        Ok(map)
+    }
+
+    /// Port of `decrement_available_impressions` + `process_results`:
+    /// resolve which (algo, post) pairs correspond to injected sticky posts,
+    /// decrement their `credits_remaining`, deactivate exhausted ones, and record
+    /// `CreditUsage` rows. Everything runs inside one transaction.
+    pub async fn decrement_available_impressions(
+        &self,
+        post_algo_pairs: &[(String, i64)],
+    ) -> Result<()> {
+        if post_algo_pairs.is_empty() {
+            return Ok(());
+        }
+        let algo_ids: Vec<i32> = post_algo_pairs.iter().map(|(_, a)| *a as i32).collect();
+        let uris: Vec<String> = post_algo_pairs.iter().map(|(u, _)| u.clone()).collect();
+
+        // input_cases CTE → (algorithm_id, uri, sticky_post_id) rows.
+        let results = sqlx::query(
+            "WITH input_cases AS (\
+                 SELECT UNNEST($1::int[]) AS algorithm_id, UNNEST($2::text[]) AS uri\
+             )\
+             SELECT i.algorithm_id, i.uri, a.sticky_post_id \
+             FROM input_cases i \
+             JOIN algorithms_sticky_posts_association a ON i.algorithm_id = a.algorithm_id \
+             JOIN sticky_posts s ON s.id = a.sticky_post_id AND s.uri = i.uri",
+        )
+        .bind(&algo_ids)
+        .bind(&uris)
+        .fetch_all(&self.pool)
+        .await?;
+
+        if results.is_empty() {
+            return Ok(());
+        }
+
+        // (algorithm_id, sticky_post_id) pairs for the credit-decrement UPDATE.
+        let mut upd_algo: Vec<i32> = Vec::with_capacity(results.len());
+        let mut upd_sticky: Vec<i32> = Vec::with_capacity(results.len());
+        // per-algo impression counts (→ CreditUsage.credit_amount)
+        let mut algo_hits: HashMap<i64, i64> = HashMap::new();
+        let mut result_algo_ids: Vec<i32> = Vec::new();
+        for row in &results {
+            let algorithm_id: i32 = row.get("algorithm_id");
+            let sticky_post_id: i32 = row.get("sticky_post_id");
+            upd_algo.push(algorithm_id);
+            upd_sticky.push(sticky_post_id);
+            *algo_hits.entry(algorithm_id as i64).or_insert(0) += 1;
+            result_algo_ids.push(algorithm_id);
+        }
+
+        // Map the matched algos → their owning user for CreditUsage rows.
+        let mut algo_user: HashMap<i64, i64> = HashMap::new();
+        let user_rows = sqlx::query("SELECT id, user_id FROM algorithms WHERE id = ANY($1)")
+            .bind(&result_algo_ids)
+            .fetch_all(&self.pool)
+            .await?;
+        for row in user_rows {
+            let id: i32 = row.get("id");
+            let user_id: i32 = row.get("user_id");
+            algo_user.insert(id as i64, user_id as i64);
+        }
+
+        // Build (user_id, algorithm_id, count) usage records.
+        let mut usage: Vec<(i64, i64, i64)> = Vec::new();
+        for (algo_id, count) in &algo_hits {
+            if let Some(user_id) = algo_user.get(algo_id) {
+                usage.push((*user_id, *algo_id, *count));
+            }
+        }
+
+        if self.dry_run {
+            info!(
+                target: "feed_stats::pg_dry_run",
+                matched = results.len(),
+                credit_decrements = upd_algo.len(),
+                credit_usage_rows = usage.len(),
+                "DRY-RUN decrement_available_impressions (no rows mutated)"
+            );
+            return Ok(());
+        }
+
+        let mut tx = self.pool.begin().await?;
+
+        // process_results: decrement credits_remaining by 1 and toggle is_active.
+        sqlx::query(
+            "UPDATE algorithms_sticky_posts_association t \
+             SET stopping_criteria = jsonb_set(\
+                     t.stopping_criteria, '{credits_remaining}', \
+                     to_jsonb((t.stopping_criteria->>'credits_remaining')::int - 1), false), \
+                 is_active = ((t.stopping_criteria->>'credits_remaining')::int - 1) > 0 \
+             FROM (SELECT UNNEST($1::int[]) AS algorithm_id, UNNEST($2::int[]) AS sticky_post_id) p \
+             WHERE t.sticky_type = 'injected' \
+               AND t.stopping_criteria ? 'credits_remaining' \
+               AND t.algorithm_id = p.algorithm_id \
+               AND t.sticky_post_id = p.sticky_post_id",
+        )
+        .bind(&upd_algo)
+        .bind(&upd_sticky)
+        .execute(&mut *tx)
+        .await?;
+
+        for (user_id, algorithm_id, count) in &usage {
+            sqlx::query(
+                "INSERT INTO credit_usages (credit_amount, user_id, algorithm_id, created_at, updated_at) \
+                 VALUES ($1, $2, $3, now(), now())",
+            )
+            .bind(*count as i32)
+            .bind(*user_id as i32)
+            .bind(*algorithm_id as i32)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Port of `flush_last_access_times`: set `settings.last_delivered_time` on
+    /// each algorithm to the newest observed request time.
+    pub async fn flush_last_delivered(
+        &self,
+        latest: &HashMap<String, NaiveDateTime>,
+    ) -> Result<usize> {
+        if latest.is_empty() {
+            return Ok(0);
+        }
+        if self.dry_run {
+            info!(
+                target: "feed_stats::pg_dry_run",
+                feeds = latest.len(),
+                "DRY-RUN flush_last_delivered (no rows mutated)"
+            );
+            return Ok(0);
+        }
+        let mut updated = 0usize;
+        for (uri, ts) in latest {
+            let iso = format_isoformat(ts);
+            let res = sqlx::query(
+                "UPDATE algorithms \
+                 SET settings = jsonb_set(COALESCE(settings, '{}'::jsonb), \
+                                          '{last_delivered_time}', to_jsonb($1::text), true), \
+                     updated_at = now() \
+                 WHERE algorithm_uri = $2",
+            )
+            .bind(&iso)
+            .bind(uri)
+            .execute(&self.pool)
+            .await?;
+            updated += res.rows_affected() as usize;
+        }
+        Ok(updated)
+    }
+}
+
+/// Match Python `datetime.isoformat()`: omit the fractional part when it is zero.
+fn format_isoformat(ts: &NaiveDateTime) -> String {
+    if ts.and_utc().timestamp_subsec_nanos() == 0 {
+        ts.format("%Y-%m-%dT%H:%M:%S").to_string()
+    } else {
+        ts.format("%Y-%m-%dT%H:%M:%S%.6f").to_string()
+    }
+}

--- a/crates/graze-feed-stats/src/redis_counters.rs
+++ b/crates/graze-feed-stats/src/redis_counters.rs
@@ -1,0 +1,112 @@
+//! Redis ad-spend counters.
+//!
+//! Port of `update_sponsored_impressions`. Writes four hashes, consumed
+//! (destructively) by `clickhouse_materializer.py` every ~10 min:
+//!   * `campaign_algo:{campaign_id}`      HINCRBY      field=algorithm_id
+//!   * `campaign_algo_cpm:{campaign_id}`  HINCRBYFLOAT field=algorithm_id
+//!   * `attribution_count`                HINCRBY      field=attribution_id
+//!   * `attribution_cpm`                  HINCRBYFLOAT field=attribution_id
+//!
+//! In shadow mode every key is prefixed (default `shadow:`) so the materializer
+//! never sees the shadow counters.
+//!
+//! Parity note: Python computes the CPM contribution as `cpm_cents / 1000`. When
+//! `cpm_cents` is null that expression raises and crashes the batch — a latent
+//! bug. We instead treat a null CPM as a `0.0` contribution (the impression is
+//! still counted). This is a deliberate, documented deviation; sponsored rows in
+//! practice always carry a CPM, so the golden-diff should stay clean.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use deadpool_redis::redis;
+use graze_common::RedisClient;
+
+use crate::parse::AttributableRow;
+
+pub struct RedisCounters {
+    key_prefix: String,
+}
+
+impl RedisCounters {
+    pub fn new(key_prefix: String) -> Self {
+        Self { key_prefix }
+    }
+
+    fn key(&self, k: &str) -> String {
+        format!("{}{}", self.key_prefix, k)
+    }
+
+    /// Increment the four counter hashes for a batch of attributable rows.
+    pub async fn update(&self, redis: &RedisClient, rows: &[AttributableRow]) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        // (campaign_id -> (algorithm_id -> (count, cpm_sum)))
+        let mut campaign_algo: HashMap<String, HashMap<i64, (i64, f64)>> = HashMap::new();
+        // attribution_id -> (count, cpm_sum)
+        let mut attribution: HashMap<i64, (i64, f64)> = HashMap::new();
+
+        for r in rows {
+            let cpm = r.cpm_cents.unwrap_or(0) as f64 / 1000.0;
+
+            // campaign_id renders as "None" when absent, matching Python's f-string.
+            let campaign_key = match r.campaign_id {
+                Some(c) => c.to_string(),
+                None => "None".to_string(),
+            };
+            let entry = campaign_algo
+                .entry(campaign_key)
+                .or_default()
+                .entry(r.algorithm_id)
+                .or_insert((0, 0.0));
+            entry.0 += 1;
+            entry.1 += cpm;
+
+            let attr = attribution.entry(r.attribution_id).or_insert((0, 0.0));
+            attr.0 += 1;
+            attr.1 += cpm;
+        }
+
+        let mut conn = redis.get().await?;
+
+        for (campaign_id, algos) in &campaign_algo {
+            let count_key = self.key(&format!("campaign_algo:{campaign_id}"));
+            let cpm_key = self.key(&format!("campaign_algo_cpm:{campaign_id}"));
+            for (algo_id, (count, cpm_sum)) in algos {
+                let _: () = redis::cmd("HINCRBY")
+                    .arg(&count_key)
+                    .arg(*algo_id)
+                    .arg(*count)
+                    .query_async(&mut conn)
+                    .await?;
+                let _: () = redis::cmd("HINCRBYFLOAT")
+                    .arg(&cpm_key)
+                    .arg(*algo_id)
+                    .arg(*cpm_sum)
+                    .query_async(&mut conn)
+                    .await?;
+            }
+        }
+
+        let attribution_count_key = self.key("attribution_count");
+        let attribution_cpm_key = self.key("attribution_cpm");
+        for (attribution_id, (count, cpm_sum)) in &attribution {
+            let _: () = redis::cmd("HINCRBY")
+                .arg(&attribution_count_key)
+                .arg(*attribution_id)
+                .arg(*count)
+                .query_async(&mut conn)
+                .await?;
+            let _: () = redis::cmd("HINCRBYFLOAT")
+                .arg(&attribution_cpm_key)
+                .arg(*attribution_id)
+                .arg(*cpm_sum)
+                .query_async(&mut conn)
+                .await?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/graze-like-streamer/src/bin/backfill_likes.rs
+++ b/crates/graze-like-streamer/src/bin/backfill_likes.rs
@@ -21,7 +21,9 @@ use tracing::{debug, error, info, warn, Level};
 use tracing_subscriber::EnvFilter;
 
 use graze_common::services::UriInterner;
-use graze_common::{hash_did, Keys, RedisClient};
+use graze_common::{
+    author_did_from_at_uri, hash_did, should_process_like_event, Keys, RedisClient,
+};
 use graze_like_streamer::config::Config;
 
 // ============================================================================
@@ -92,20 +94,6 @@ fn parse_like_event(message: &str) -> Option<LikeEvent> {
         post_uri,
         timestamp,
     })
-}
-
-fn extract_author_did(post_uri: &str) -> Option<&str> {
-    if !post_uri.starts_with("at://") {
-        return None;
-    }
-    let path = &post_uri[5..];
-    let end = path.find('/')?;
-    let did = &path[..end];
-    if did.starts_with("did:") {
-        Some(did)
-    } else {
-        None
-    }
 }
 
 // ============================================================================
@@ -310,6 +298,13 @@ impl BackfillRunner {
                     last_event_time = Instant::now();
 
                     if let Some(event) = parse_like_event(&text) {
+                        if !should_process_like_event(
+                            &event.user_did,
+                            &event.post_uri,
+                            self.config.exclusion_dids.as_ref(),
+                        ) {
+                            continue;
+                        }
                         // Check if we've reached the end
                         if event.timestamp >= self.backfill_config.end_cursor {
                             info!(
@@ -419,9 +414,17 @@ impl BackfillRunner {
 
         debug!(batch_size = events.len(), "Flushing backfill batch");
 
-        // Convert URIs to numeric IDs
-        let unique_uris: Vec<String> = events.iter().map(|e| e.post_uri.clone()).collect();
-        let uri_to_id = self.interner.get_or_create_ids_batch(&unique_uris).await?;
+        let uri_and_dates: Vec<(String, String)> = events
+            .iter()
+            .map(|e| {
+                let ts = e.timestamp as f64 / 1_000_000.0;
+                (e.post_uri.clone(), graze_common::date_from_timestamp(ts))
+            })
+            .collect();
+        let uri_to_id = self
+            .interner
+            .get_or_create_ids_by_event_date(&uri_and_dates)
+            .await?;
 
         // Build ZADD items
         let mut user_likes_items: HashMap<String, Vec<(f64, String)>> = HashMap::new();
@@ -455,7 +458,7 @@ impl BackfillRunner {
                 .push((timestamp_sec, user_hash.clone()));
 
             // Author-level tracking
-            if let Some(author_did) = extract_author_did(&event.post_uri) {
+            if let Some(author_did) = author_did_from_at_uri(&event.post_uri) {
                 let author_hash = hash_did(author_did);
 
                 // Author likers

--- a/crates/graze-like-streamer/src/bin/backfill_ula.rs
+++ b/crates/graze-like-streamer/src/bin/backfill_ula.rs
@@ -266,13 +266,11 @@ async fn process_single_user(
         return Ok(ProcessResult::Skipped);
     }
 
-    // Convert post IDs to URIs
-    let post_ids: Vec<i64> = posts.iter().filter_map(|p| p.parse().ok()).collect();
-    if post_ids.is_empty() {
+    if posts.is_empty() {
         return Ok(ProcessResult::Skipped);
     }
 
-    let id_to_uri = interner.get_uris_batch(&post_ids).await?;
+    let id_to_uri = interner.get_uris_batch(&posts).await?;
 
     // Count likes per author
     let mut author_counts: HashMap<String, f64> = HashMap::new();

--- a/crates/graze-like-streamer/src/config.rs
+++ b/crates/graze-like-streamer/src/config.rs
@@ -2,7 +2,10 @@
 //!
 //! All configuration is loaded from environment variables.
 
-use graze_common::RedisConfig;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use graze_common::{exclusion_set_from_env_opt, RedisConfig};
 
 /// Application settings loaded from environment variables.
 #[derive(Debug, Clone)]
@@ -61,6 +64,11 @@ pub struct Config {
     // Metrics Configuration
     // ═══════════════════════════════════════════════════════════════════════════════
     pub metrics_port: u16,
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Privacy / opt-out (EXCLUSION_LIST)
+    // ═══════════════════════════════════════════════════════════════════════════════
+    pub exclusion_dids: Arc<HashSet<String>>,
 }
 
 impl Config {
@@ -82,7 +90,7 @@ impl Config {
             jetstream_stale_timeout_seconds: parse_u64_env("JETSTREAM_STALE_TIMEOUT_SECONDS", 60),
 
             // Like Graph
-            like_ttl_days: parse_u32_env("LIKE_TTL_DAYS", 8),
+            like_ttl_days: parse_u32_env("LIKE_TTL_DAYS", 6),
             like_batch_size: parse_usize_env("LIKE_BATCH_SIZE", 5000),
             like_batch_interval_ms: parse_u64_env("LIKE_BATCH_INTERVAL_MS", 5000),
             like_ttl_refresh_interval_seconds: parse_u64_env(
@@ -111,6 +119,9 @@ impl Config {
 
             // Metrics
             metrics_port: parse_u16_env("METRICS_PORT", 0),
+
+            // Privacy: comma/newline-separated DIDs to skip for like ingestion
+            exclusion_dids: exclusion_set_from_env_opt(std::env::var("EXCLUSION_LIST").ok()),
         }
     }
 

--- a/crates/graze-like-streamer/src/main.rs
+++ b/crates/graze-like-streamer/src/main.rs
@@ -28,6 +28,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Load configuration
     let config = Config::from_env();
+    info!(
+        exclusion_did_count = config.exclusion_dids.len(),
+        "like_streamer_exclusion_config"
+    );
 
     // Capture metrics port before wrapping config
     let metrics_port = config.metrics_port;

--- a/crates/graze-like-streamer/src/streamer.rs
+++ b/crates/graze-like-streamer/src/streamer.rs
@@ -24,7 +24,10 @@ use tracing::{debug, error, info, warn};
 use crate::config::Config;
 use graze_common::services::UriInterner;
 use graze_common::Result;
-use graze_common::{date_from_timestamp, hash_did, ttl_for_date, Keys, RedisClient};
+use graze_common::{
+    author_did_from_at_uri, date_from_timestamp, hash_did, should_process_like_event, ttl_for_date,
+    Keys, RedisClient,
+};
 
 /// A like event from Jetstream.
 #[derive(Debug, Clone)]
@@ -61,23 +64,6 @@ struct JetstreamRecord {
 #[derive(Debug, Deserialize)]
 struct JetstreamSubject {
     uri: Option<String>,
-}
-
-/// Extract author DID from AT-URI.
-///
-/// AT-URI format: at://did:plc:xxx/app.bsky.feed.post/rkey
-fn extract_author_did(post_uri: &str) -> Option<&str> {
-    if !post_uri.starts_with("at://") {
-        return None;
-    }
-    let path = &post_uri[5..];
-    let end = path.find('/')?;
-    let did = &path[..end];
-    if did.starts_with("did:") {
-        Some(did)
-    } else {
-        None
-    }
 }
 
 /// Calculate backoff delay with jitter to prevent thundering herd.
@@ -211,6 +197,7 @@ impl LikeStreamer {
         let event_tx_clone = event_tx.clone();
         drop(event_tx); // Drop original so event_rx.recv() returns None when task exits
         let read_timeout = Duration::from_secs(self.config.jetstream_read_timeout_seconds);
+        let exclusion_dids = self.config.exclusion_dids.clone();
         let mut shutdown_rx_msg = shutdown_tx.subscribe();
         let mut msg_task = tokio::spawn(async move {
             loop {
@@ -219,6 +206,13 @@ impl LikeStreamer {
                         match result {
                             Ok(Some(Ok(Message::Text(text)))) => {
                                 if let Some(event) = parse_like_event(&text) {
+                                    if !should_process_like_event(
+                                        &event.user_did,
+                                        &event.post_uri,
+                                        exclusion_dids.as_ref(),
+                                    ) {
+                                        continue;
+                                    }
                                     if event_tx_clone.send(event).await.is_err() {
                                         warn!("Event channel closed, stopping message task");
                                         break;
@@ -391,9 +385,18 @@ impl LikeStreamer {
             )
             .await?;
 
-        // Convert URIs to numeric IDs using the interner (batch operation)
-        let unique_uris: Vec<String> = events.iter().map(|e| e.post_uri.clone()).collect();
-        let uri_to_id = self.interner.get_or_create_ids_batch(&unique_uris).await?;
+        // Convert URIs to dated post IDs (shard = like event date)
+        let uri_and_dates: Vec<(String, String)> = events
+            .iter()
+            .map(|e| {
+                let ts = e.timestamp as f64 / 1_000_000.0;
+                (e.post_uri.clone(), date_from_timestamp(ts))
+            })
+            .collect();
+        let uri_to_id = self
+            .interner
+            .get_or_create_ids_by_event_date(&uri_and_dates)
+            .await?;
 
         // Track unique keys to avoid redundant commands
         let mut user_likes_keys: HashSet<String> = HashSet::new();
@@ -442,7 +445,7 @@ impl LikeStreamer {
                 .push((timestamp_sec, user_hash.clone()));
 
             // Author-level tracking
-            if let Some(author_did) = extract_author_did(&event.post_uri) {
+            if let Some(author_did) = author_did_from_at_uri(&event.post_uri) {
                 let author_hash = hash_did(author_did);
 
                 // User liked authors - track for increment (NOT date-based, accumulates counts)
@@ -819,43 +822,43 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_author_did_valid_uri() {
+    fn test_author_did_from_at_uri_valid_uri() {
         let uri = "at://did:plc:author123/app.bsky.feed.post/rkey456";
-        let result = extract_author_did(uri);
+        let result = author_did_from_at_uri(uri);
         assert_eq!(result, Some("did:plc:author123"));
     }
 
     #[test]
-    fn test_extract_author_did_different_collection() {
+    fn test_author_did_from_at_uri_different_collection() {
         let uri = "at://did:plc:author123/app.bsky.feed.generator/abc";
-        let result = extract_author_did(uri);
+        let result = author_did_from_at_uri(uri);
         assert_eq!(result, Some("did:plc:author123"));
     }
 
     #[test]
-    fn test_extract_author_did_web_did() {
+    fn test_author_did_from_at_uri_web_did() {
         let uri = "at://did:web:example.com/app.bsky.feed.post/xyz";
-        let result = extract_author_did(uri);
+        let result = author_did_from_at_uri(uri);
         assert_eq!(result, Some("did:web:example.com"));
     }
 
     #[test]
-    fn test_extract_author_did_invalid_prefix() {
+    fn test_author_did_from_at_uri_invalid_prefix() {
         let uri = "https://did:plc:author123/app.bsky.feed.post/rkey456";
-        let result = extract_author_did(uri);
+        let result = author_did_from_at_uri(uri);
         assert_eq!(result, None);
     }
 
     #[test]
-    fn test_extract_author_did_empty_string() {
-        let result = extract_author_did("");
+    fn test_author_did_from_at_uri_empty_string() {
+        let result = author_did_from_at_uri("");
         assert_eq!(result, None);
     }
 
     #[test]
-    fn test_extract_author_did_no_did() {
+    fn test_author_did_from_at_uri_no_did() {
         let uri = "at://notadid/app.bsky.feed.post/rkey456";
-        let result = extract_author_did(uri);
+        let result = author_did_from_at_uri(uri);
         assert_eq!(result, None);
     }
 


### PR DESCRIPTION
⚠️ **Please review rather than auto-merging.** The first commit is large and was not written as one reviewable unit. Opening it as a PR rather than merging it, unlike the three that preceded it.

Two commits, deliberately separate.

## 1. Land the code already running in production

`main` did not contain the code serving production. The live `personalization-api` image carries ~4,900 lines that existed only on one laptop — including several things this repo's own docs and experiments describe as shipped:

- the **pool like-density gate** (`MIN_POOL_SCOREABLE_SHARE`), live at 0.04, currently skipping ~45% of scoring work
- **per-user personalization holdout** assignment — the randomization the running holdout experiment depends on
- the **team-draft interleaving harness** and its provenance `ranker` field
- **durable co-liker profiles** (`ucl:`) and the sampled-walk ranker
- **`graze-feed-stats`**

This commit is that state, unchanged, so `main` matches what is deployed. **No behavioural change: this is already what production does.** It is split from the second commit because reviewing "what is already running" is a different question from reviewing a new change.

This is the bus-factor risk worth naming: until this lands, a lost laptop loses the source of what is serving traffic, and no experiment result is reproducible from version control.

## 2. Record why a response was not personalized

`fallback_reason` was only ever written to a **log line**, so coverage failures could not be decomposed in ClickHouse and every experiment silently mixed users the engine served with users it *could not* serve.

**Measured 2026-08-25 on the running holdout: 52% of the treatment arm received zero personalized impressions.** The experiment is not comparing "personalized" vs "not personalized" — it is comparing "not personalized" against *a coin flip on whether you get personalized*. Those users contribute variance and no signal, which is why the readout's interval narrowed only ~5% while its sample nearly doubled over eight days.

Adds `no_user_data | no_auth | no_algo_posts | personalization_holdout | personalization_error`, omitted entirely when the response *was* personalized.

A first decomposition from logs puts the dominant cause at **`no_user_data`, 73%** of non-personalized responses — ~92% of the *addressable* ones once the intentional holdout and unauthenticated requests are set aside. That points at seed availability rather than the density gate or `min_post_likes`, and is worth confirming in SQL over a full window rather than a 6-hour log scrape.

**Migration-free**, for the same reason `ranker` was: the blob is stored verbatim in `interaction_feed_context String`, `decode` uses plain `serde_json::from_str` (ignores unknown keys), and the lenient consumer decoder reads only two fields. Both properties are pinned by tests.

## Testing

198 tests passing, `cargo fmt --check` clean, `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)