### PR TITLE
Land the remaining uncommitted operational files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,154 @@
+# Graze Personalization Service
+
+High-performance microservice for real-time personalized feed ranking using the LinkLonk algorithm. Written in Rust with Axum and deadpool-redis.
+
+## Project Structure
+
+```
+src/
+├── lib.rs                      # Library exports
+├── config.rs                   # Configuration
+├── error.rs                    # Error types with Axum integration
+├── metrics.rs                  # Prometheus metrics
+├── models/                     # Request/response models
+│   ├── requests.rs             # API request types
+│   ├── responses.rs            # API response types
+│   └── atproto.rs              # ATProto-specific types
+├── redis/                      # Redis client and utilities
+│   ├── client.rs               # Connection pool management
+│   ├── keys.rs                 # Key patterns (Keys struct)
+│   ├── hash.rs                 # hash_did() implementation
+│   └── scripts.rs              # Lua script manager
+├── services/                   # External service clients
+│   ├── uri_interner.rs         # URI <-> ID mapping with LRU cache
+│   └── special_posts.rs        # Pinned/sticky/sponsored posts
+├── algorithm/                  # LinkLonk algorithm
+│   ├── mod.rs                  # LinkLonkAlgorithm orchestration
+│   ├── params.rs               # Algorithm parameters and presets
+│   ├── coliker.rs              # Co-liker computation
+│   ├── scorer.rs               # Post scoring
+│   ├── scoring_core.rs         # Parallel scoring implementation
+│   ├── thompson.rs             # Thompson sampling for A/B testing
+│   ├── liker_cache.rs          # Hot post liker cache
+│   ├── feed_cache.rs           # Feed skeleton cache
+│   └── author_affinity.rs      # Author-level personalization
+├── api/                        # HTTP handlers
+│   ├── mod.rs                  # Router setup
+│   ├── personalize.rs          # POST /v1/personalize
+│   ├── feed.rs                 # ATProto feed endpoints
+│   ├── cursor.rs               # Feed cursor encoding/decoding
+│   ├── fallback.rs             # Fallback tranche blending
+│   ├── special_posts.rs        # Special posts injection
+│   ├── health.rs               # Health and metrics endpoints
+│   └── admin.rs                # Admin endpoints
+├── workers/                    # Background workers
+│   ├── like_streamer.rs        # Jetstream consumer for likes
+│   ├── candidate_sync.rs       # ClickHouse sync + fallback tranches
+│   └── bot_filter.rs           # Bot detection and filtering
+└── bin/                        # Binary entry points
+    ├── api.rs                  # graze-api server
+    ├── like_streamer.rs        # graze-like-streamer worker
+    └── candidate_sync.rs       # graze-candidate-sync worker
+
+lua/
+├── graze_compute.lua           # Core scoring algorithm (runs in Redis)
+└── graze_compute_inverted.lua  # Inverted scoring variant
+
+scripts/
+└── clickhouse-init/            # ClickHouse schema initialization
+    └── 01-schema.sql
+
+tests/
+├── integration_redis.rs        # Redis integration tests
+├── common/                     # Test utilities
+└── helpers/                    # Test helpers
+```
+
+## Key Concepts
+
+### LinkLonk Algorithm (3-step random walk)
+1. Get user's recent likes
+2. Find co-likers (users who liked same posts before)
+3. Score candidate posts from co-likers' likes
+
+### URI interner (date-sharded)
+
+- New post IDs: `{YYYYMMDD}{seq:010}` (18 digits, no colons)
+- `uri2id:{date}` / `id2uri:{date}` / `uri:counter:{date}` — EXPIRE aligned with `LIKE_TTL_DAYS`
+- Legacy global `uri2id` / `id2uri` — read-only fallback; orphan GC via `scripts/redis_interner_gc.py`
+
+### Redis Key Patterns (see `src/redis/keys.rs` Keys struct)
+- `ul:{hash}` - User likes (ZSET, score=timestamp)
+- `pl:{hash}` - Post likers (ZSET, score=timestamp)
+- `ap:{algo_id}` - Algorithm eligible posts (SET)
+- `ll:{algo_id}:{hash}` - Cached personalization results (ZSET)
+- `fsc:{algo_id}:{hash}` - Feed skeleton cache (LIST)
+- `colikes:{hash}` - Pre-computed co-liker weights (ZSET)
+- `trending:{algo_id}` - Trending posts fallback (ZSET)
+- `popular:{algo_id}` - Popular posts fallback (ZSET)
+- `velocity:{algo_id}` - Velocity-based fallback (ZSET)
+- `discovery:{algo_id}` - Discovery posts fallback (ZSET)
+
+### Algorithm Presets
+- `default` - Balanced personalization
+- `discovery` - Favor newer, niche content
+- `stable` - Broader, more consistent results
+- `fast` - Optimized for speed
+
+## Development Commands
+
+```bash
+# Run API server
+cargo run --bin graze-api
+
+# Run like streamer worker
+cargo run --bin graze-like-streamer
+
+# Run candidate sync worker
+cargo run --bin graze-candidate-sync
+
+# Run tests
+cargo test
+
+# Run tests with output
+cargo test -- --nocapture
+
+# Run clippy
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Format code
+cargo fmt
+
+# Build release binaries
+cargo build --release --bin graze-api --bin graze-like-streamer --bin graze-candidate-sync
+```
+
+## Configuration
+
+Key environment variables:
+- `HTTP_HOST` - HTTP host to bind services to (default: 0.0.0.0)
+- `HTTP_PORT` - HTTP port to bind services to (default: 8080)
+- `HTTP_EXTERNAL` - Public hostname the service is running on
+- `METRICS_PORT` - HTTP port to publish metrics on
+- `REDIS_URL` - Redis connection string
+- `CLICKHOUSE_HOST` - ClickHouse host for algorithm posts
+- `CLICKHOUSE_PORT` - ClickHouse port (default: 8123)
+- `CLICKHOUSE_DATABASE` - ClickHouse database name
+- `JETSTREAM_URL` - Jetstream WebSocket URL
+- `FEED_GENERATOR_DID` - Service DID for ATProto
+
+## Docker
+
+```bash
+# Build image
+docker build -t graze .
+
+# Run API server
+docker run -e REDIS_URL=redis://host:6379 graze
+
+# Run like streamer
+docker run -e REDIS_URL=redis://host:6379 graze /app/graze-like-streamer
+
+# Run candidate sync
+docker run -e REDIS_URL=redis://host:6379 graze /app/graze-candidate-sync
+```

--- a/DEBUG.md
+++ b/DEBUG.md
@@ -1,0 +1,432 @@
+# Debugging Guide
+
+This guide covers tools and techniques for debugging the Graze Personalization Service.
+
+## Quick Start: Which Tool to Use
+
+| Problem | Tool | Command |
+|---------|------|---------|
+| Feed returns empty | Feed Status API | `curl https://localhost:8081/v1/feeds/status/{algo_id}` |
+| Wrong/unexpected posts | Prove API | `curl -X POST https://localhost:8081/v1/prove -d '{"user_did":"...","algo_id":N}'` |
+| Debug specific user | Audit API | `curl -X POST https://localhost:8081/v1/audit/users -d '{"dids":["..."]}'` |
+| Step-by-step simulation | Debug Script | `python scripts/debug_feed_query.py <did> <algo_id> --verbose` |
+| Performance issues | Metrics | `curl https://localhost:8081/metrics` |
+
+---
+
+## Feed Query Simulator
+
+The `debug_feed_query.py` script simulates the feed query process step-by-step, showing each Redis query, timing, and diagnostic information. This helps debug user experience and performance issues.
+
+### Usage
+
+```bash
+python scripts/debug_feed_query.py <user_did> <algo_id> [options]
+```
+
+**Arguments:**
+- `user_did` - User DID (e.g., `did:plc:abc123xyz`)
+- `algo_id` - Algorithm ID (integer)
+
+**Options:**
+- `--preset PRESET` - Algorithm preset: `default`, `discovery`, `stable`, `fast`
+- `--limit N` - Number of results to simulate (default: 30)
+- `--redis-url URL` - Redis URL (overrides `REDIS_URL`)
+- `--json` - Output as JSON instead of human-readable
+- `--verbose, -v` - Show sample data from each stage
+
+**Default behavior:** Interactive step-by-step mode. After each stage:
+- Press `Enter` to continue
+- Press `q` to quit
+- Press `s` to skip to summary
+
+### Simulation Stages
+
+The tool replicates the LinkLonk algorithm flow:
+
+| Stage | Name | What It Checks |
+|-------|------|----------------|
+| 0 | Identity Resolution | DID hashing |
+| 1 | Prerequisites Check | Algorithm posts, user likes, co-likers, trending |
+| 2 | Cache Status | Personalization cache, feed cache TTLs |
+| 3 | User Likes Analysis | Recent likes within time window |
+| 4 | Co-liker Discovery | Source users who liked same posts |
+| 5 | Candidate Collection | Posts from co-likers' likes |
+| 6 | Algorithm Membership | Filter candidates to algorithm posts |
+| 7 | Scoring & Results | Final scoring with popularity penalty |
+
+### Running with Docker
+
+#### Using `docker run`
+
+```bash
+# Basic usage - connect to a Redis instance
+docker run --rm -it \
+  -e REDIS_URL=redis://your-redis-host:6379 \
+  dgaff/graze-personalization:latest \
+  python scripts/debug_feed_query.py did:plc:abc123xyz 12345
+
+# With verbose output
+docker run --rm -it \
+  -e REDIS_URL=redis://your-redis-host:6379 \
+  dgaff/graze-personalization:latest \
+  python scripts/debug_feed_query.py did:plc:abc123xyz 12345 --verbose
+
+# JSON output (non-interactive)
+docker run --rm \
+  -e REDIS_URL=redis://your-redis-host:6379 \
+  dgaff/graze-personalization:latest \
+  python scripts/debug_feed_query.py did:plc:abc123xyz 12345 --json
+
+# With a specific preset
+docker run --rm -it \
+  -e REDIS_URL=redis://your-redis-host:6379 \
+  dgaff/graze-personalization:latest \
+  python scripts/debug_feed_query.py did:plc:abc123xyz 12345 --preset discovery --verbose
+
+# Override Redis URL via CLI argument
+docker run --rm -it \
+  dgaff/graze-personalization:latest \
+  python scripts/debug_feed_query.py did:plc:abc123xyz 12345 \
+  --redis-url redis://your-redis-host:6379
+```
+
+#### Using Docker Compose
+
+```bash
+# Run against the same Redis as your docker-compose setup
+docker compose run --rm api \
+  python scripts/debug_feed_query.py did:plc:abc123xyz 12345 --verbose
+```
+
+#### In Kubernetes
+
+```bash
+# Execute in an existing pod
+kubectl exec -it <pod-name> -- \
+  python scripts/debug_feed_query.py did:plc:abc123xyz 12345 --verbose
+
+# Run as a one-off job with JSON output
+kubectl run debug-feed --rm -it --restart=Never \
+  --image=dgaff/graze-personalization:latest \
+  --env="REDIS_URL=redis://redis-service:6379" \
+  -- python scripts/debug_feed_query.py did:plc:abc123xyz 12345 --json
+```
+
+### Example Output
+
+```
+======================================================================
+Stage 1: Prerequisites Check [OK]
+======================================================================
+Status: All prerequisites met
+Time: 3.42ms
+
+Redis commands executed:
+  > EXISTS ap:12345
+  > SCARD ap:12345
+  > EXISTS ul:7a8b9c0d1e2f3a4b
+  > ZCARD ul:7a8b9c0d1e2f3a4b
+  > EXISTS colikes:7a8b9c0d1e2f3a4b
+  > TTL colikes:7a8b9c0d1e2f3a4b
+  > ZCARD colikes:7a8b9c0d1e2f3a4b
+  > EXISTS trending:12345
+  > ZCARD trending:12345
+
+Data:
+  algo_posts:
+    exists: True
+    count: 18432
+  user_likes:
+    exists: True
+    count: 347
+  colikes:
+    exists: True
+    ttl_seconds: 2847
+    count: 412
+  trending:
+    exists: True
+    count: 500
+
+[Enter=continue, q=quit, s=skip to summary]
+```
+
+### Recommendations Engine
+
+The tool provides actionable recommendations based on findings:
+
+| Condition | Recommendation |
+|-----------|----------------|
+| No algorithm posts | "Sync algorithm posts: POST /v1/sync with algo_id=X" |
+| No user likes | "User has no likes - will see trending posts only" |
+| < 5 likes | "Cold user - feed will blend 80% trending, 20% personalized" |
+| No co-likers | "No pre-computed co-likers - first request will be slower" |
+| Low algo hit rate | "Consider increasing max_algo_checks" |
+
+### Troubleshooting
+
+**Redis connection errors:**
+```bash
+# Verify Redis is reachable
+docker run --rm dgaff/graze-personalization:latest \
+  python -c "import redis; r = redis.from_url('redis://your-host:6379'); print(r.ping())"
+```
+
+**User has no personalized results:**
+1. Check if user has likes (Stage 3)
+2. Check if algorithm posts are synced (Stage 1)
+3. Check co-liker cache status (Stage 4)
+4. Verify algorithm membership hit rate (Stage 6)
+
+**Slow performance:**
+1. Look at timing breakdown in summary
+2. Check if co-liker cache is fresh (Stage 1)
+3. Check candidate collection time (Stage 5)
+4. Consider using `--preset fast` for debugging
+
+---
+
+## API Debugging Endpoints
+
+These HTTP endpoints provide real-time debugging without needing CLI access.
+
+### Feed Health Check
+
+**Endpoint:** `GET /v1/feeds/status/:algo_id`
+
+Returns comprehensive diagnostic information about a feed's health status. Use this first when feeds return empty.
+
+```bash
+curl -s https://localhost:8081/v1/feeds/status/12345 | jq
+```
+
+**Response fields:**
+
+| Field | Description |
+|-------|-------------|
+| `healthy` | Overall health status (true/false) |
+| `algo_posts.exists` | Whether algorithm posts are synced |
+| `algo_posts.count` | Number of posts in the algorithm |
+| `algo_posts.ttl_seconds` | Time until posts expire (-1 = no expiry) |
+| `sync_metadata.last_sync_timestamp` | Unix timestamp of last sync |
+| `sync_metadata.last_sync_age_seconds` | Seconds since last sync |
+| `rate_limit.locked` | Whether sync is rate-limited |
+| `fallback_tranches` | Status of trending/popular/velocity/discovery fallbacks |
+| `diagnosis` | Human-readable diagnosis message |
+
+**Common diagnosis messages:**
+
+| Message | Meaning | Action |
+|---------|---------|--------|
+| "Sync has never been triggered" | No data exists | Run `POST /v1/sync` |
+| "Posts key expired" | Data is stale | Run `POST /v1/sync` |
+| "Posts key exists but is empty" | ClickHouse returned no data | Check ClickHouse query |
+| "Posts key will expire in X seconds" | Data expiring soon | Consider preemptive sync |
+| "Feed appears healthy" | Everything looks good | Issue is elsewhere |
+
+### Algorithm Explainability (Prove)
+
+**Endpoint:** `POST /v1/prove`
+
+Shows exactly how personalization results were computed for a user. Use this to understand why specific posts appear (or don't appear) in a feed.
+
+```bash
+# Basic usage
+curl -s -X POST https://localhost:8081/v1/prove \
+  -H "Content-Type: application/json" \
+  -d '{"user_did": "did:plc:abc123xyz", "algo_id": 12345}' | jq
+
+# With specific preset
+curl -s -X POST https://localhost:8081/v1/prove \
+  -H "Content-Type: application/json" \
+  -d '{"user_did": "did:plc:abc123xyz", "algo_id": 12345, "preset": "discovery"}' | jq
+```
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `user_did` | string | Yes | User's DID |
+| `algo_id` | integer | Yes | Algorithm ID |
+| `preset` | string | No | Algorithm preset: `default`, `discovery`, `stable`, `fast` |
+
+**Response structure:**
+
+The response shows the 3-step LinkLonk algorithm:
+
+**Step 1 - User Likes:** Shows the user's recent liked posts used as seeds.
+```json
+{
+  "step1_user_likes": {
+    "total_likes": 347,
+    "likes_in_window": 50,
+    "likes_used": 20,
+    "sample_posts": [
+      {
+        "post_id": 12345,
+        "uri": "at://did:plc:.../app.bsky.feed.post/...",
+        "like_timestamp": 1704067200,
+        "other_likers_count": 42
+      }
+    ]
+  }
+}
+```
+
+**Step 2 - Co-likers:** Shows users who liked the same posts (weighted by recency).
+```json
+{
+  "step2_colikers": {
+    "total_colikers": 412,
+    "top_colikers": [
+      {
+        "coliker_hash": "7a8b9c0d1e2f",
+        "weight": 2.847,
+        "shared_posts_count": 8,
+        "sample_shared_posts": [...]
+      }
+    ]
+  }
+}
+```
+
+**Step 3 - Post Scoring:** Shows how candidate posts were scored.
+```json
+{
+  "step3_scoring": {
+    "candidates_considered": 1500,
+    "top_posts": [
+      {
+        "post_id": 67890,
+        "uri": "at://did:plc:.../app.bsky.feed.post/...",
+        "raw_score": 4.23,
+        "popularity_penalty": 0.85,
+        "final_score": 3.60,
+        "total_likers": 150,
+        "top_contributors": [
+          {"coliker_hash": "7a8b9c", "weight": 2.1, "recency": 0.95, "contribution": 1.99}
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Timing breakdown:** The response includes `timing` with millisecond breakdowns for each step.
+
+### User-Level Audit Logging
+
+Enable detailed logging for specific users to debug their feed experience.
+
+**Check audit status:**
+```bash
+curl -s https://localhost:8081/v1/audit/status | jq
+```
+
+**Add users to audit set:**
+```bash
+curl -s -X POST https://localhost:8081/v1/audit/users \
+  -H "Content-Type: application/json" \
+  -d '{"dids": ["did:plc:abc123xyz", "did:plc:user2"]}' | jq
+```
+
+**List audited users:**
+```bash
+curl -s https://localhost:8081/v1/audit/users | jq
+```
+
+**Remove users from audit:**
+```bash
+curl -s -X DELETE https://localhost:8081/v1/audit/users \
+  -H "Content-Type: application/json" \
+  -d '{"dids": ["did:plc:abc123xyz"]}' | jq
+```
+
+**Audit configuration (environment variables):**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUDIT_ENABLED` | `false` | Master switch for audit logging |
+| `AUDIT_ALL_USERS` | `false` | Audit 100% of traffic |
+| `AUDIT_SAMPLE_RATE` | `0.0` | Random sampling rate (0.0-1.0) |
+| `AUDIT_LOG_FULL_BREAKDOWN` | `false` | Include per-co-liker details |
+| `AUDIT_MAX_CONTRIBUTORS` | `10` | Max co-likers to log per post |
+
+Audit logs are emitted to the `graze_audit` log target as structured JSON.
+
+### Other Useful Endpoints
+
+```bash
+# Trigger algorithm sync from ClickHouse
+curl -s -X POST https://localhost:8081/v1/sync \
+  -H "Content-Type: application/json" \
+  -d '{"algo_id": 12345}' | jq
+
+# List all registered feeds
+curl -s https://localhost:8081/v1/feeds | jq
+
+# Health check (Redis connectivity)
+curl -s https://localhost:8081/internal/ready | jq
+
+# Prometheus metrics
+curl -s https://localhost:8081/metrics
+```
+
+---
+
+## Troubleshooting Flowchart
+
+### Empty Feed
+
+```
+1. Check feed health
+   curl https://localhost:8081/v1/feeds/status/{algo_id}
+   │
+   ├─ "Sync has never been triggered" → POST /v1/sync
+   ├─ "Posts key expired" → POST /v1/sync
+   ├─ "Posts key exists but is empty" → Check ClickHouse
+   └─ "Feed appears healthy" → Continue to step 2
+
+2. Check user data with debug script
+   python scripts/debug_feed_query.py <did> <algo_id> --verbose
+   │
+   ├─ No user likes → User is "cold", will see trending only
+   ├─ No co-likers → First request, co-likers will be computed
+   └─ Low algo hit rate → Candidates don't match algorithm posts
+
+3. Check user-specific scoring
+   curl -X POST https://localhost:8081/v1/prove -d '{"user_did":"...","algo_id":N}'
+   │
+   └─ Review step1/step2/step3 to identify where the pipeline breaks
+```
+
+### Wrong Posts Appearing
+
+```
+1. Get proof of ranking
+   curl -X POST https://localhost:8081/v1/prove -d '{"user_did":"...","algo_id":N}'
+
+2. Check step3_scoring.top_contributors
+   - Which co-likers contributed to unwanted posts?
+   - Are weights unexpectedly high for certain users?
+
+3. Check step1_user_likes
+   - What posts is the user liking that lead to these co-likers?
+```
+
+### Slow Performance
+
+```
+1. Check metrics
+   curl https://localhost:8081/metrics | grep duration
+
+2. Check timing in prove response
+   - step1 slow → Redis ZRANGEBYSCORE on user likes
+   - step2 slow → Co-liker aggregation (expected for uncached)
+   - step3 slow → Candidate scoring (try reducing max_sources)
+
+3. Check cache status
+   python scripts/debug_feed_query.py <did> <algo_id>
+   - Stage 2 shows cache TTLs
+   - Low/no cache → First request for user, will be faster next time
+```

--- a/DESIGN-durable-coliker-profiles.md
+++ b/DESIGN-durable-coliker-profiles.md
@@ -1,0 +1,465 @@
+# Durable co-liker profiles — design proposal
+
+**Status:** proposal, 2026-08-11. Supersedes the accumulate-in-API design in
+`~/.claude/plans/proceed-with-this-proposal-joyful-dream.md` (Phase 1).
+
+**Goal:** serve highly relevant content to users who like *infrequently*, by using their
+longitudinal like history to find taste-neighbours, then ranking the live candidate pool by
+what those neighbours liked recently.
+
+---
+
+## 1. What the measurements established
+
+**The historical like graph exists.** `default.user_action_logs`, `action_type =
+'app.bsky.feed.like'` — **141,040,158 likes across 985,880 distinct users**, with `user_did`
+(actor), `action_identifier` (post AT-URI) and `action_time`. 10.08 GiB, continuous at 5–8M
+likes/month. (An earlier gate wrongly used `feed_interactions`, which records only likes on
+Graze-*served* posts — 13× fewer likes — and produced a false negative. `global_action_logs`
+has no actor column and is useless here.)
+
+**The gap is large.** Of 357,575 feed requesters in 30 days, **64,241 have ≥20 likes of
+history**. Of 3-day requesters, **13,196 have zero likes in the live 6-day window but ≥20 in
+history** — versus 21,597 currently personalizable. That is a **+61% larger addressable
+population**.
+
+**The chain yields abundant candidates.** Five randomly sampled real lurkers (0 likes in 6d,
+120–1,200 in 365d) produced 280–39,900 co-likers reaching 7,236–36,982 posts liked in the last
+3 days. Against a **live** pool — lurker `65lxax66` (real user of algo 396, 367 impressions/7d,
+`ap:396` = 10,473 candidates):
+
+| | today | with historical co-likers |
+|---|---|---|
+| scoreable pool posts | **0** | **4,736 (45% of pool)** |
+| ≥2 overlapping co-likers | 0 | 2,950 |
+| ≥3 | 0 | 2,096 |
+
+Active users reach only ~1,700–1,860 scoreable. **The lurker beats them 2.5×**, because a year
+of history yields 3,550 co-likers where a 6-day window yields 127.
+
+**Coverage saturates fast, which is what makes this cheap.** Same lurker, top-K co-likers
+ranked by overlap:
+
+| K | scoreable posts | ≥2 overlap | random-K baseline | % of full |
+|---|---|---|---|---|
+| 25 | 1,054 | 213 | 139 | 22% |
+| 50 | 1,672 | 446 | 257 | 35% |
+| 100 | 2,113 | 753 | 429 | 45% |
+| 200 | 2,886 | 1,278 | 931 | 61% |
+| 3,550 | 4,738 | 2,954 | 4,738 | 100% |
+
+Ranking beats random by **7.6× at K=25**, so the ordering carries real signal. And **K=128
+lands ~2,300 scoreable candidates — already above what active users get today.** A feed page is
+30–50 posts, so that is 45–75× oversupply. We do not need full coverage.
+
+---
+
+## 2. Design
+
+### 2.1 Nightly batch job, chunked
+
+The co-liker self-join full-scans 141M rows — impossible on the request path, viable as a
+nightly job. **It does not fit in one query.** Measured: a naive single query succeeded at 500
+users but **OOMed at 2,000** (`Code: 241 ... would use 18.01 GiB ... While executing
+JoiningTransform`, after 2m53s). Two changes fix it, and both *improve* the signal:
+
+1. **Cap seed at the 128 most recent liked posts per user** (`LIMIT 128 BY u` on the seed CTE).
+   Production already caps `max_user_likes`. For a lurker with 124 lifetime likes this is a
+   no-op; for heavy users 128 recent posts is ample.
+2. **Drop ultra-popular seed posts (`HAVING L <= 500`).** A post with 5,000 likers drags 5,000
+   rows into the join while contributing `1/5000 = 0.0002` to `Σ 1/L_j` — negligible against a
+   niche post's `1/5 = 0.2`. This is the dominant cost term, and cutting it *raises* average
+   specificity, which is exactly what we want for relevance.
+
+Measured result at 2,000 users: **3m50s, no OOM, 1,999 of 2,000 users profiled, average 123.8
+co-likers of max 128** — the cap still binds, so the popularity filter does not starve profiles.
+
+**Chunk size: prefer large.** The per-chunk 141M-row scan is a fixed cost, so cost is strongly
+sublinear in users:
+
+| users/chunk | wall clock | users profiled | avg co-likers |
+|---|---|---|---|
+| 2,000 | 3m50s | 1,999 | 123.8 |
+| 8,000 | **4m50s** | 7,994 | 123.7 |
+
+4× the users for 1.26× the time. Fitting `t ≈ 210s + 10s per 1,000 users` implies ~14 min for
+all 64,241 in a single query — but memory, not time, is the binding constraint, and 18 GiB is
+the observed ceiling. **Plan on 8 chunks of 8,000 ≈ 40 minutes total**, and probe upward from
+there. Bucket on `cityHash64(user_did) % N` so chunks are stable across runs and independently
+retryable; pipeline the Valkey writes per chunk so nothing large is held client-side.
+
+**Floor on profile size.** `min_cl` was 1 in the 8,000-user run — a few users derive almost no
+co-likers. Serving a 1-member profile yields near-zero coverage and gives `overlap_count` no
+room to discriminate. Gate with a `MIN_PROFILE_SIZE` (start ~10) and skip the write below it;
+those users keep today's fallback behaviour.
+
+The query, with both fixes:
+
+```sql
+WITH targets AS (                       -- profile-eligible users
+  SELECT user_did FROM (
+    SELECT user_did, count() c FROM user_action_logs
+    WHERE action_type='app.bsky.feed.like' AND action_time >= now()-INTERVAL 365 DAY
+    GROUP BY user_did HAVING c BETWEEN 20 AND 5000      -- excl. 959 hyper-likers
+  ) WHERE user_did IN (SELECT DISTINCT user_did FROM user_action_logs
+        WHERE action_type='app.bsky.feed.defs#interactionSeen'
+          AND action_time >= now()-INTERVAL 30 DAY)),
+seed0 AS (                              -- cap: 128 most recent liked posts per user
+  SELECT user_did u, action_identifier post, min(action_time) t
+  FROM user_action_logs
+  WHERE action_type='app.bsky.feed.like' AND action_time >= now()-INTERVAL 365 DAY
+    AND user_did IN (SELECT user_did FROM targets)
+  GROUP BY u, post
+  ORDER BY u, t DESC LIMIT 128 BY u),
+Lj AS (                                 -- post specificity 1/L_j; drop viral posts
+  SELECT action_identifier post, count() L FROM user_action_logs
+  WHERE action_type='app.bsky.feed.like'
+    AND action_identifier IN (SELECT DISTINCT post FROM seed0)
+  GROUP BY post HAVING L <= 500),
+seed AS (
+  SELECT s.u u, s.post post, s.t t, L.L L
+  FROM seed0 s INNER JOIN Lj L ON L.post = s.post)
+SELECT s.u AS u, o.user_did AS cl, sum(1.0/s.L) AS score
+FROM user_action_logs o
+INNER JOIN seed s ON o.action_identifier = s.post
+WHERE o.action_type='app.bsky.feed.like'
+  AND o.user_did != s.u
+  AND o.action_time < s.t               -- "liked before me", matches coliker.rs:223-232
+GROUP BY u, cl
+ORDER BY u, score DESC
+LIMIT 128 BY u                          -- ClickHouse per-group top-K
+SETTINGS join_algorithm='parallel_hash'
+```
+
+`LIMIT 128 BY u` does top-K per user server-side, so nothing oversized is ever materialised
+client-side. Folding `Lj` into `seed` (rather than joining it a second time in the main query)
+removes one of the two chained joins that caused the OOM.
+
+**Score = `Σ 1/L_j` over overlapping posts.** This is the specificity-weighted measure from the
+prior design: a neighbour who overlaps on 3 obscure posts outranks one who overlaps on 5 viral
+posts. It is exactly the one factor in `scoring_core.rs:480` that is stable at profile-build
+time (`likers.len()` is a property of the post). The activity term (`1/source_total_likes`) and
+recency stay at read time, as today.
+
+**This eliminates the entire accumulation machinery.** The prior design needed `ZINCRBY`, a
+watermark for idempotency, a `SET NX` lock, and throttled `EXPIRE` — because it accumulated
+incrementally in the request path. A nightly full rebuild over 365 days of history *inherently*
+includes yesterday's likes, so:
+
+- **no changes to `graze-like-streamer`**
+- **no changes to the request write path**
+- no watermark, no lock, no replay-idempotency problem
+- staleness ≤24h on the *co-liker set*, which is irrelevant — taste-neighbours are durable, and
+  the candidates being ranked come from live data
+
+### 2.2 Storage: packed binary string, not a zset
+
+Measured on the production Valkey instance:
+
+| representation | bytes/user @K=128 | encoding |
+|---|---|---|
+| ZSET (16-hex member + float score) | 3,632 | listpack |
+| ZSET @K=300 | 25,512 | **skiplist** |
+| **packed string (8B hash + 4B f32) × 128** | **1,840** | raw |
+| packed string @K=64 | 944 | raw |
+
+Two things fall out:
+
+1. **K=300 costs 7× the memory of K=128 for 2.3× the data** — the listpack→skiplist cliff at
+   128 members (28.4 vs 85.0 B/member). K=128 is the natural design point, and the coverage
+   curve says it is more than sufficient.
+2. **A packed string halves K=128 again**, because a nightly wholesale overwrite never needs
+   `ZADD`, `ZINCRBY`, or `ZREMRANGEBYRANK`. We were paying zset overhead for capabilities the
+   batch design makes worthless. The read path wants all 128 entries anyway — never a range or
+   a partial — so one `GET` of 1,840 B beats a `ZREVRANGE` of 128 members on allocations and
+   round-trip payload too.
+
+```
+Key:    ucl:{user_hash}                       (flat, not date-sharded)
+Value:  128 × [ 8-byte co-liker hash | 4-byte f32 score ]   = 1,536 B, big-endian
+TTL:    7 days                                (survives several failed nightly runs)
+```
+
+Flat key with a flat TTL, following the `ula:` precedent (`keys.rs:439`). **Must not** live
+under the `colikes:` prefix: `scripts/redis_prune_retention.py:38-49` treats that prefix as
+safe-to-delete, and `coliker.rs:80-82` gates the cache-hit branch on `ttl > 0` so a persistent
+key would fall through to a full recompute on every request.
+
+### 2.3 Memory budget
+
+| | |
+|---|---|
+| 64,241 profiles × 1,840 B | **118 MB** |
+| same as ZSET (for comparison) | 233 MB |
+| `ula:` reclaimed on retirement | **−23,700 MB** |
+| **net change** | **≈ −23.6 GB** |
+
+Also removes `zincrby`'s **7.8% of Valkey command CPU** — it is used *only* for `ula:`.
+
+### 2.4 Read path: strictly additive
+
+Integration point is the existing early-exit at `mod.rs:286`:
+
+```rust
+if coliker_weights.is_empty() {
+    // NEW: fall back to the durable profile instead of returning nothing
+    if let Some(w) = self.coliker.get_durable_profile(user_hash).await? { ... }
+    else { return Ok(ScoringResult::empty()); }
+}
+```
+
+**This is the key risk property.** Only users who *today* get an early-exit and 100% fallback
+are affected. The 21,597 currently-personalized users take a byte-identical path. There is no
+regression surface for existing traffic, and the new segment's comparison baseline is fallback,
+not better personalization.
+
+`scorer.score()` takes `source_weights: &HashMap<String, f64>` (`scorer.rs:77-84`), so the
+profile just needs to produce that map. Absolute score magnitude is load-bearing in exactly two
+places — `weight.min(max_coliker_weight)` (`scorer.rs:326,397`, cap `1e-6`) and `score > 0.0`
+(`:358,419`) — so a **rank-preserving rescale to a max just under the cap** is provably safe and
+needs no calibration against live `colikes:` values.
+
+---
+
+## 3. On compression: roaring bitmaps, bloom filters, embeddings
+
+Directly addressing whether a compression play helps. Short version: **memory is not the
+constraint** — 118 MB in a service where one dead key family wastes 23.7 GB. But one of these
+ideas is strategically the most important thing on this list.
+
+**Packed binary string — yes, adopt.** Measured 2× win over the zset (1,840 vs 3,632 B),
+already folded into the design above. This is the whole of the available "compression" win, and
+it comes from removing unused capability rather than from clever encoding.
+
+**Roaring bitmaps — no for v1, but the right escape hatch.** Roaring compresses sets of
+*integers*, and wins when they are dense or clustered. Our members are 64-bit hashes — uniformly
+random and maximally sparse, roaring's worst case; at 128 members it would be *larger* than
+packed raw. It becomes genuinely attractive only if we ever want full coverage (K=3,550 →
+42 KB/user → 2.7 GB packed). Then the move is to intern co-liker DIDs into dense sequential
+integer IDs — exactly what this codebase already does for post URIs via the URI interner — so
+~1M active likers fit in 20-bit IDs and roaring's run-length encoding starts paying. Worth
+keeping in the back pocket; not worth building while K=128 already exceeds active-user coverage.
+
+**Bloom filters — no.** A bloom answers "is X in the set?" probabilistically and cannot
+enumerate or carry weights. We need *both* the co-liker identity and its score to compute
+relevance, and false positives would inject neighbours the user has no affinity with — directly
+against the relevance goal. As a cheap pre-filter ("does this candidate have any of my
+co-likers?") it is technically apt, given 87% of candidates have zero likers, but that test is
+already done server-side via `pl:` and is not the measured bottleneck. Optimization without a
+demonstrated cost.
+
+**Graph embeddings — not compression, but the strategically right v2.** Instead of storing 128
+neighbour IDs, learn one vector per user from the like graph (e.g. 64 floats = 256 B) and one
+per post, then score by similarity. This is smaller than the packed profile, but the size is
+beside the point. What matters is that it is **dense by construction**: every candidate gets a
+score, with no overlap required. That dissolves the wall behind all of this work — **87% of
+candidates have zero likers and the median pool post has 1 like** — which no amount of seed
+history can fix, because the sparsity is on the candidate side. It also generalises past direct
+intersection: two users who share *no* posts can still sit close in the graph if their tastes
+meet one hop away. We have 141M edges to train on. Costs are real (training pipeline, ANN index,
+much harder to audit and debug), so this is a follow-on, not a v1 — but it subsumes the co-liker
+profile entirely and is where the ceiling actually is.
+
+---
+
+## 4. Risks
+
+1. **Coverage ≠ engagement — the main unknown.** The +13% personalized lift (within-user,
+   z≈2.9, p≈0.004) was measured on *active* users. This segment is defined by not liking things
+   recently. More rankable candidates is proven; more engagement is not. Ship behind a flag with
+   a holdback and measure.
+2. **`overlap_count` distortion.** It is weight-independent (`scorer.rs:286,354,415`) and feeds
+   a nonlinear `paths_boost = overlap_count^num_paths_power` (`:360-362`). Lurker sets are ~28×
+   larger than active-user sets and one post drew 170 overlapping co-likers, so ranking will
+   distort, not merely rescale. Must be compared in shadow mode before serving. Mitigated by
+   §2.4: nobody currently personalized is exposed.
+3. **The bot filter is inert.** `bot:filtered` holds **13 users**, because
+   `BOT_LIKE_THRESHOLD=5000` per 6-day window ≈ 833/day. Sampling turned up accounts with
+   216,073 and 101,288 likes/year. The batch job must not rely on it — hence the explicit
+   `HAVING c BETWEEN 20 AND 5000` band, which excludes 959 hyper-likers. Also consider capping
+   any single co-liker's contribution; one co-liker supplied 572 of 10,473 pool posts.
+4. **Selection optimises coverage, not relevance.** A greedy coverage oracle reaches 88% with
+   100 co-likers vs 45% for overlap-ranked — but the co-likers it picks are prolific likers,
+   which is precisely the low-specificity signal `Σ 1/L_j` is designed to down-rank. Do **not**
+   chase the oracle; it optimises the wrong objective.
+5. **`user_action_logs` has dirty timestamps** — `app.bsky.feed.like` spans 2017→2038. Bound
+   every window with `BETWEEN now()-INTERVAL N DAY AND now()`.
+
+---
+
+## 5. Phases
+
+**Phase A — batch job, dark. ✅ BUILT AND VALIDATED 2026-08-11.**
+
+Shipped as `graze-build-coliker-profiles`
+(`crates/graze-candidate-sync/src/bin/build_coliker_profiles.rs`, logic in
+`src/coliker_profiles.rs`, codec in `graze-common/src/coliker_profile.rs`). Writes `ucl:` keys
+and nothing else — no read path exists, so it cannot change what any user is served.
+
+Validated end-to-end against production (bucket 0 of 256, i.e. ~1/256 of the population):
+
+| check | result |
+|---|---|
+| users returned / profiles written | 242 / 241 (1 skipped below `MIN_PROFILE_SIZE`) |
+| mean profile size | **124.7** of a 128 cap — matches the 123.7 the SQL predicted |
+| `STRLEN` of a full profile | **1,536 B** (128 × 12), exactly as designed |
+| `MEMORY USAGE` | **1,840 B**, matching the synthetic measurement exactly |
+| `TTL` / `OBJECT ENCODING` | 604,152 s (6.99 d) / `raw` |
+| stored co-likers' live activity | all 8 sampled have **55–1,733 likes in the live 6-day window** |
+
+That last row is the one that matters: profiles built from a dormant user's year-old history point
+at co-likers who are active *now*, whose recent likes are in `ul:`/`pl:` — so the set is directly
+usable by the scorer.
+
+Runtime: 129 s for 242 users at `PROFILE_CHUNK_COUNT=256`. The ~120 s scan is a fixed per-chunk
+cost (242 users → 129 s vs 8,000 → 290 s), so run few, large chunks: **`PROFILE_CHUNK_COUNT=8`
+projects to ~39 min for all 64,241 users.** Confirm on the first full run.
+
+Remaining before Phase B: nothing blocking. `bin/` defaults are the measured design points; start
+with `PROFILE_DRY_RUN=1` on a new environment.
+
+**Phase B — shadow. ✅ BUILT 2026-08-11, not yet enabled.**
+
+Attaches at the `coliker_weights.is_empty()` early-exit in `algorithm/mod.rs` via
+`try_durable_profile`, which loads `ucl:`, runs a full scoring pass, emits a
+`durable_profile_shadow` log line, and then **discards the result** so the response is
+byte-identical to today. Serving is a separate flag.
+
+| piece | where |
+|---|---|
+| `get_durable_profile` + `profile_weights_from_scores` | `graze-api/src/algorithm/coliker.rs` |
+| overlap observability on `ScoringResult` | `graze-api/src/algorithm/scorer.rs` |
+| shadow arm | `graze-api/src/algorithm/mod.rs` (`try_durable_profile`) |
+| flags | `graze-api/src/config.rs` |
+
+**Flags (both default off — deploying the image changes nothing):**
+
+- `DURABLE_PROFILE_SHADOW_MODE=1` — compute + log, serve nothing. This is Phase B.
+- `DURABLE_PROFILE_ENABLED=1` — actually serve. This is Phase C; leave off.
+- `DURABLE_PROFILE_WEIGHT_TARGET` — default `2e-7`, must stay under `MAX_COLIKER_WEIGHT` (1e-6).
+
+**Weight conversion.** Stored `Σ 1/L_j` scores (order 1e-3..1e2) are rescaled so the top entry
+lands on `durable_profile_weight_target`. Dividing by the *max* (not the sum) preserves ranking
+exactly, keeps every weight below the `weight.min(max_coliker_weight)` clamp — which would
+otherwise flatten the profile into arbitrary ties — and stops a 12-member profile from being
+handed larger per-entry weights than a 128-member one. Six unit tests cover these properties;
+a config test asserts `target < max_coliker_weight`.
+
+**What to read in the logs.** `durable_profile_shadow` carries `profile_size`, `scored_count`,
+`posts_checked`, all three skip reasons, and `overlap_mean` / `overlap_max` / `overlap_hist`
+(buckets `1,2,3-4,5-8,9-16,17-32,33-64,65+`). Compare its `overlap_hist` against the same fields
+now emitted on `scorer_completed` for the live arm. **If the profile arm's distribution is shifted
+well right of the live arm's, `paths_boost = overlap_count^num_paths_power` is distorting rather
+than rescaling, and Phase C needs `num_paths_power` retuned before it serves.** A real lurker
+profile was observed with 170 overlapping co-likers on a single post, so this is a live concern.
+
+Also newly visible on both arms: **`posts_skipped_low_overlap`**, the count dropped by
+`min_overlapping_colikers`, which was previously invisible and is what separates "no reachable
+candidates" from "reachable but too thinly overlapped".
+
+**Expected firing rate.** Sampling 29 profiled users, **6 (21%) had zero live 6-day likes**, i.e.
+the shadow fires for roughly a fifth of profiled users; the rest are served by the live path and
+never reach this branch.
+
+### Phase B deployed and first results — 2026-08-11
+
+Image `dgaff/personalization:phaseb-ucl-20260811` (digest `sha256:1db15bc0…`) on
+`personalization-api` (DO sfo3), `DURABLE_PROFILE_SHADOW_MODE=1`, `DURABLE_PROFILE_ENABLED`
+unset. Phase A run across all 8 buckets first: **62,905 profiles, mean size 124.24, 89.4 MB
+wire (~116 MB in Valkey), 23.4 min, 0 chunks failed.**
+
+Four known profiled lurkers driven through `POST /v1/personalize` on algo 396
+(`ap:396` = 10,703 candidates). All defaults in play: `INVERTED_MIN_POST_LIKES=10`,
+`INVERTED_MAX_LIKERS_PER_POST=30`, `MIN_OVERLAPPING_COLIKERS=1`.
+
+| user | profile | scored | no_likers | few_likers | **low_overlap** | ovl_mean | ovl_max | hist |
+|---|---|---|---|---|---|---|---|---|
+| 2557e27f | 128 | 12 | 1,866 | 5,048 | 3,777 | 1.00 | 1 | `1:12` |
+| 4ca71711 | 128 | **500** (capped) | 1,866 | 5,048 | 3,102 | 1.10 | 3 | `1:620,2:62,3-4:5` |
+| abcd3a4e | 128 | 2 | 1,866 | 5,048 | 3,787 | 1.00 | 1 | `1:2` |
+| 260c3db6 | 128 | 24 | 1,866 | 5,048 | 3,765 | 1.04 | 2 | `1:23,2:1` |
+
+All four served nothing (`serving=false`) and still logged `no coliker weights found`, so the
+response was unchanged — shadow mode behaved exactly as specified.
+
+**Risk 2 (`overlap_count` distortion) is resolved — it is a non-issue.** Live-arm runs in the
+same window showed `overlap_max` of 8, 1, 8, 2; the profile arm showed 1, 3, 1, 2. The profile
+distribution is *not* shifted right of live — it is slightly lower. With `overlap_mean ≈ 1.0`,
+`paths_boost = overlap_count^num_paths_power ≈ 1`, so there is nothing to retune. The fear was
+that 128 co-likers would inflate overlap; in reality `pl:` is so sparse (p50 = 1 liker/post,
+truncated at 30) that two co-likers rarely land on the same candidate.
+
+**The real bottleneck is now visible, and it is not overlap.** Of 10,703 candidates:
+1,866 have no likers, **5,048 (47%) are killed by `INVERTED_MIN_POST_LIKES=10`**, and of the
+~3,789 survivors, **~3,777 have zero overlap with the 128-member profile**. So 12 score. The
+`min_post_likes=10` filter is the largest single loss and the most promising Phase C lever —
+note the modal `min_post_likes` observed in `feedContext` was 5, so 10 is already stricter than
+typical.
+
+**Correction to the offline coverage estimate.** §1's curve predicted ~2,300 scoreable at K=128,
+but production delivers 2–500. The offline harness intersected `ul:` directly and modelled
+neither `min_post_likes` (−47%) nor `max_likers_per_post=30` truncation. **The 45% / ~2,300
+figures overstate what production yields; treat 2–500 as the real range**, of which one of four
+users got a full feed page and one got a usable 24.
+
+Still 0 → non-zero for every user tested, which is the point. But the honest read is that the
+median lurker gets a partial feed, not a full one.
+
+### Correction: `min_post_likes` is NOT the bottleneck — liker truncation is
+
+The inference above ("`min_post_likes=10` is the largest loss") was **wrong**, and offline
+measurement against the four stored profiles disproves it. `few_likers` fires *before* the
+overlap check, so it was discarding candidates that had no profile overlap anyway. Scoreable
+candidates by threshold:
+
+| user | overlapping | ≥10 | ≥5 | ≥3 | ≥1 |
+|---|---|---|---|---|---|
+| 2557e27f | 41 | 39 | 41 | 41 | 41 |
+| 4ca71711 | 1,236 | 1,051 | 1,141 | 1,190 | 1,236 |
+| abcd3a4e | 7 | 7 | 7 | 7 | 7 |
+| 260c3db6 | 67 | 67 | 67 | 67 | 67 |
+
+Going 10 → 1 buys +5%, +18%, 0%, 0%. Not the lever.
+
+**The real constraint is `INVERTED_MAX_LIKERS_PER_POST=30`.** The scorer fetches the N *most
+recent* likers per candidate, so a co-liker who liked early is invisible — detection probability
+is `min(1, N/L)`. **72–100% of eligible overlapping candidates have L > 30**, and modelling that
+truncation reproduces production almost exactly:
+
+| user | predicted at N=30 | observed production |
+|---|---|---|
+| 2557e27f | 16 | 12 |
+| 4ca71711 | 589 | 500 (hit the cap) |
+| abcd3a4e | 1 | 2 |
+| 260c3db6 | 21 | 24 |
+
+Expected scoreable by N: 30 → 100 gains **+39%, +44%, +100%, +76%**, flattening past 100–200.
+
+**Shipped:** `DURABLE_PROFILE_MIN_POST_LIKES=5` and `DURABLE_PROFILE_MAX_LIKERS_PER_POST=100`,
+applied via a **separate `Scorer` instance with its own `LikerCache`**. The separate cache is
+load-bearing, not tidiness: `scorer.rs:520` writes fetched liker lists back into the cache, so a
+shared one would leak 100-liker lists into the live arm and silently change what it scores. Two
+config tests assert the live arm stays at 10/30.
+
+**Phase C — serve behind a flag,** for a fraction of the affected segment, with a holdback.
+Measure engagement by source class the established way: decode
+`JSONExtractString(tryBase64Decode(interaction_feed_context),'source')` from
+`default.feed_interactions`, **within-user** and depth-banded. (The naive cross-population
+comparison overstates the effect ~2×.) Do not measure on a short quiet-period sample — two
+comparisons in this investigation were invalidated that way.
+
+**Phase D — retire `ula:`.** Remove writes (`streamer.rs:648-710`) and the read path in the same
+PR so the flags cannot drift; a stale `AUTHOR_AFFINITY_ENABLED=true` against a missing `ula:`
+fails *open* (silently returns zero posts). Retire `bin/backfill_ula.rs`. Reclaims 23.7 GB and
+7.8% of Valkey command CPU. Independently justified — `ula:` measured 0.77% like rate vs
+fallback's 6.55% and is already read-disabled — so it need not wait on A–C.
+
+## 6. Out of scope
+
+- Extending `DEFAULT_RETENTION_DAYS` or raw `pl:`/`ul:` retention. ~1.6 GB/day, and the 24h
+  recency half-life makes a 14-day-old like worth 0.006% of a fresh one. The point of this
+  design is that the *derived* signal is durable while the raw window stays short.
+- Widening the seed window for users who already have recent likes: measured 1.04–1.10× for 23×
+  more seed. Saturation makes that pointless. The value here is entirely 0 → N.
+- Author-affinity scoring in any form. A user's 500 liked authors overlap a feed's 8,851 pool
+  authors by 1–2.

--- a/Dockerfile.iter
+++ b/Dockerfile.iter
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1.4
+#
+# Iteration Dockerfile — builds ONLY the crates needed by `personalization-api` and
+# `personalization-candidate-sync`.
+#
+# Why this exists: the main Dockerfile builds five crates with full LTO
+# (`lto = true`, `codegen-units = 1`). Under QEMU on an arm64 host that takes ~76 minutes and
+# filled the Docker VM's 40 GB disk mid-build ("No space left on device" while compiling
+# `sqlx-postgres`, pulled in by `graze-feed-stats` — unrelated in-progress work).
+#
+# This variant drops `graze-like-streamer`, `graze-frontdoor`, and `graze-feed-stats`, so the
+# resulting image is ONLY valid for the api and candidate-sync deployments. The like-streamer
+# deployment must keep using an image built from the main Dockerfile.
+#
+# Use the main Dockerfile for anything shipping to all three deployments.
+
+FROM --platform=linux/amd64 rust:1.93-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    git \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY Cargo.toml Cargo.lock* ./
+COPY crates ./crates
+COPY docs ./docs
+
+ARG GIT_HASH=0
+ENV GIT_HASH=$GIT_HASH
+
+RUN --mount=type=ssh \
+    mkdir -p /root/.ssh && \
+    ssh-keyscan github.com >> /root/.ssh/known_hosts && \
+    cargo build --release \
+    -p graze-api \
+    -p graze-candidate-sync
+
+FROM --platform=linux/amd64 gcr.io/distroless/cc-debian12
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/graze-api /app/graze-api
+COPY --from=builder /app/target/release/graze-candidate-sync /app/graze-candidate-sync
+COPY --from=builder /app/target/release/graze-build-coliker-profiles /app/graze-build-coliker-profiles
+
+COPY lua ./lua
+
+ENV HTTP_HOST=0.0.0.0
+ENV HTTP_PORT=8080
+ENV RUST_LOG=info
+ENV RUST_BACKTRACE=full
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/graze-api"]

--- a/RESEARCH-personalization-directions.md
+++ b/RESEARCH-personalization-directions.md
@@ -1,0 +1,245 @@
+# Personalization: SOTA review and four competing directions
+
+Research synthesis, 2026-08-13. Written against the measured particularities of Graze's engine
+documented in `THEORIES-personalization.md`.
+
+---
+
+## Part 0 — The constraint that determines everything
+
+From the live A/B: within-user clustering inflates variance **6.2×** (naive pooled z=3.59 vs
+cluster-correct permutation z≈1.44). Combined with ~3,600 usable impressions/day, capacity is:
+
+| effect size | time to detect (80% power) |
+|---|---|
+| 50% | 9 days |
+| 30% | 22 days |
+| 20% | **48 days** |
+| 10% | **6 months** |
+
+**~4–8 well-powered live experiments per year.** Any plan that requires testing many algorithmic
+designs is dead on arrival unless measurement sensitivity improves first. This inverts the intuitive
+priority: **the highest-leverage interventions are not algorithmic.**
+
+---
+
+## Part 1 — Measurement interventions (do these first; they are prerequisites)
+
+### 1.1 Interleaving — the single biggest lever (50–100×)
+
+Instead of splitting users between rankers, blend both rankers' outputs into **one** feed and measure
+which ranker's items win clicks/likes. Each user becomes their own control, which removes
+between-user variance — the exact 6.2× penalty we measured.
+
+Reported results:
+- [Netflix](https://netflixtechblog.com/interleaving-in-online-experiments-at-netflix-a04ee392ec55):
+  sensitivity up to **100×** vs A/B.
+- [Airbnb](https://arxiv.org/abs/2508.00751): **~50× speedup**; reached the same conclusion as the
+  corresponding A/B using **0.5% of the running time and 4% of the traffic**. Interleaving and A/B
+  agreed directionally **82%** of the time (correlation ~0.60).
+- Airbnb's design: **team-draft with "competitive pairs"** — one coin flip at the start, then draft
+  the next item from each ranker; if the two differ, they form a competitive pair, if identical the
+  item is added unassigned. Per-user statistic `τᵢ = wins(treatment) − wins(control)`, aggregated as
+  a proportion test over users.
+
+Applied to our 48-day test → **roughly a day.** This alone converts the meta-engine question from
+"impossible" to "tractable."
+
+**Three caveats, and one bites us specifically.** Airbnb documents that interleaving fails for
+(a) **set-level objectives such as diversity**, (b) results reused by other surfaces, (c) continuous
+metrics. **Graze applies a diversity re-rank** (`diversify_posts`), so interleaving must operate
+*before* diversification, and any diversity-affecting change must still go to a full A/B. Their
+observed failure mode is worth remembering: a treatment looked *worse* under interleaving than in the
+subsequent A/B because of comparative advantage from control's higher base rate.
+
+### 1.2 Counterfactual evaluation from controlled randomization (up to 100×)
+
+Airbnb's second technique, and arguably a better fit for us than interleaving because it does not
+touch what the user sees: generate **both** rankings for each request, randomly serve one, and use
+the unserved one to construct an estimator. Notably they **do not use inverse propensity weighting** —
+the randomization itself provides unbiasedness. Two estimators, averaged into one OEC:
+- **Direct decomposition** — split outcomes into items ranked similarly in both (within α positions)
+  vs differently, and reweight: `τ_decomp = τ_diff + θ·τ_sim`.
+- **Position-decay reward** — `f(r) = γ^(−r)`, gain `g_i = 1 − γ^max(|r_diff| − α, 0)`.
+
+Reported **15×–100×** speedup depending on estimator (the reward-based one hitting ~100×).
+
+For us this is attractive because it is *offline after the fact*: we already log full provenance in
+`feedContext`. We would only need to log the alternative ranking.
+
+### 1.3 CUPED (~50% variance reduction)
+
+Regress out each user's pre-experiment behaviour.
+[Deng et al.](https://dl.acm.org/doi/abs/10.1145/2433396.2433413) report **~50% variance reduction**
+at Bing — same power with half the users or half the duration. Best covariate is the same metric
+measured pre-period; adding more covariates gains only 2–3% more. A
+[KDD 2025 marketplace study](https://kdd.org/kdd2025/wp-content/uploads/2025/07/CameraReady-05.pdf)
+reports a more modest 21% CI reduction, so treat 50% as an upper bound.
+
+### 1.4 Always-valid inference (fixes a mistake I already made)
+
+I peeked at the running experiment three times in one day. Under fixed-horizon tests that inflates
+Type-I error. [Johari et al.](https://arxiv.org/abs/1512.04922) define always-valid p-values and
+confidence sequences that stay valid under continuous monitoring — now standard in commercial
+platforms. Any automated engine peeks constantly, so this is not optional for it.
+
+### 1.5 Raise the denominator
+
+Only ~15% of requests attempt personalization; the rest are cached or gated, and carry no provenance
+params. Every percentage point of coverage here is a direct multiplier on experiment throughput.
+
+---
+
+## Part 2 — Four competing algorithmic directions
+
+Each is a genuinely different bet. Ordered by expected value per unit of effort, not by ambition.
+
+### Approach A — Sampled random walk (Pixie-style), replacing exhaustive enumeration
+
+**The bet:** our cost/bias dilemma is an artifact of *enumerating* the graph, and disappears if we
+*sample* it.
+
+We measured both enumeration directions and both are bad: post-first truncates each candidate's liker
+list to the 30 most recent (systematic bias — 72–100% of overlapping candidates have >30 likers),
+while co-liker-first collapses when co-liker sets reach 5,157 (26× slower at K>256, and the shipped
+version measured 0.94× coverage).
+
+[Pixie](https://arxiv.org/abs/1711.07601) resolves exactly this. It estimates Personalized PageRank
+with many short biased random walks — order 100,000 steps — over a 3B-node/17B-edge graph at **60 ms
+p99**, and reports **up to 50% higher engagement** than the prior system. Properties that map onto our
+measured failures:
+
+| our problem | Pixie mechanism |
+|---|---|
+| truncation bias from `max_likers_per_post` | walk visits nodes in proportion to true transition probability; no per-node cap |
+| cost explodes with co-liker count | fixed step budget regardless of graph size |
+| `paths_boost` is ad-hoc, `overlap_count` ≈ 1.0 | **multi-hit booster** boosts items reached from multiple seeds *while discounting popular items* |
+| 3.8 s latency outliers observed | **early stopping** once enough candidates are visited enough times |
+| heavy seeds dominate | walk budget allocated per seed as a function of degree |
+
+**Fit to our facet:** count only visits that land in `ap:{algo}`, or bias edges toward pool members.
+Our `ul:`/`pl:` keys already *are* the bipartite user↔post graph, so no new data structure is needed —
+this is a rewrite of the traversal, not of the storage.
+
+**Cost:** medium. New traversal in `graze-api`, tunable step budget, needs the early-stopping
+criterion to hold latency.
+**Risk:** sampling variance for users with 1–2 likes (our newly-admitted segment). Mitigate by falling
+back to exhaustive for tiny seeds, where it is cheap anyway.
+**Why promising:** it is the production-hardened form of the algorithm we already run, and it fixes
+the two specific defects we measured rather than trading one for the other.
+
+### Approach B — Facet at Step 1, not Step 3 (LinkLonk's own answer)
+
+**The bet:** we are faceting in the wrong place, and that single choice causes the 34–56% dead-slot
+rate.
+
+LinkLonk restricts **Step 1** — "if you filter to a channel, Step 1 goes only into items you put into
+that channel." Graze instead computes one generic co-liker set per user and restricts the **output**
+to a feed's pool. We measured the consequence: **34–56% of a user's top-128 co-likers contribute zero
+coverage on any given feed**, and 0% of them were inactive — they are active people who like
+different things.
+
+**Implementation:** seed only from the user's likes that are relevant to *this* feed — e.g. likes on
+posts whose authors appear in the feed's pool, or that match the feed's topical filter. Co-likers then
+arrive feed-relevant by construction.
+
+**Cost:** low-medium algorithmically, but it changes the cache unit from per-user to per-(user, feed),
+multiplying key count by feeds-read-per-user (measured `feeds/user = 1.0` in a one-hour window, which
+suggests the multiplier is small in practice — worth confirming over a longer window).
+**Risk:** users with few in-topic likes get a smaller seed, and we know coverage is not seed-limited,
+so this may be fine — but it is the direct test of that.
+**Why promising:** cheapest fix for the largest measured inefficiency, and faithful to the algorithm
+that demonstrably works in production.
+
+### Approach C — Tuned classical item-item model (EASE / item-kNN) as a second candidate source
+
+**The bet:** before building anything neural, the strongest realistic competitor is a well-tuned
+classical model — and it may simply win.
+
+[Dacrema et al.](https://dl.acm.org/doi/10.1145/3298689.3347058) reproduced 12 neural recommenders and
+found **11 of 12 were outperformed by conceptually simple methods** once baselines were properly
+tuned; with linear models included, **only 1 of 12** was clearly better. Their
+[follow-up](https://arxiv.org/abs/1911.07698) found only 12 of 26 algorithms reproducible at all, and
+named the pattern **"phantom progress."** A
+[2025 study of diffusion recommenders](https://arxiv.org/html/2505.09364v3) reports the same thing
+again.
+
+Given we can run ~4–8 experiments a year, spending one on a neural model that the literature says
+probably loses to a tuned baseline is a poor bet. **Test the baseline first.**
+
+**Fit:** item-item similarity precomputed offline from 141M like edges, served as O(1) lookups;
+restrict to the pool trivially; no per-request graph traversal at all. Directly attacks the sparsity
+wall from the other side — item-item co-occurrence pools evidence across users, so a post with 1 like
+still inherits similarity from that liker's other items.
+**Cost:** low at serve time, moderate offline (a nightly job, like the durable-profile builder).
+**Risk:** item-item recency — our candidates are ≤72h old, so freshly-created posts have no
+co-occurrence yet. Likely needs an author-level or embedding-level backoff for new posts.
+**Why promising:** best evidence-to-effort ratio in the entire literature, and it composes with A and
+B rather than competing operationally.
+
+### Approach D — Two-tower / graph-embedding retrieval, as an additional retrieval source
+
+**The bet:** the only way to escape the sparsity wall entirely is dense scoring where *every*
+candidate gets a score.
+
+This remains the structurally correct answer to our hardest measured fact: **87% of candidates have
+zero likers** and the median pool post has **1 like**. No traversal of a sparse graph fixes that; a
+dense representation does, because similarity is defined for every pair.
+
+Ingredients we already have: 141M like edges for training, plus content embeddings already computed
+and archived by the enrichment pipeline. Two-tower is the standard architecture for exactly this
+retrieval role
+([survey](https://dl.acm.org/doi/pdf/10.1145/3771925),
+[Pinterest multi-embedding retrieval](https://arxiv.org/pdf/2506.23060)).
+
+**Cost:** high — training pipeline, ANN index, embedding refresh, plus much harder debugging and
+auditability (which matters here; the Debug/audit surface exists and users can inspect provenance).
+**Risk:** the Dacrema critique applies directly; and per-feed faceting requires either per-feed ANN
+indexes or post-filtering a global index, which can starve narrow feeds.
+**Why still worth doing eventually:** it is the only candidate that raises the ceiling rather than
+recovering losses, and it composes as an *additional* retrieval source rather than a replacement.
+
+### Honourable mention — use the negative signal we already collect
+
+LinkLonk explicitly uses downvotes: "items you downvoted create a path that detracts from the paths in
+the final sum." We collect `app.bsky.feed.defs#requestLess` (121,419 events) and **do not use it**.
+Adding it as a negative path is faithful to the source algorithm, cheap, and untested.
+
+---
+
+## Part 3 — Suggested sequence
+
+1. **Interleaving harness** (pre-diversity), validated against the running A/B. Converts 48-day tests
+   into ~1-day tests. Everything else depends on this.
+2. **CUPED + always-valid inference** in the analysis layer. Cheap, compounding, and fixes the peeking
+   error I already made.
+3. **Approach B** (facet at Step 1) — smallest change addressing the largest measured waste.
+4. **Approach C** (tuned item-item) — highest evidence-to-effort, and becomes the honest baseline that
+   any future neural work must beat.
+5. **Approach A** (sampled walk) — once measurement is fast, this is the principled fix to the
+   cost/bias dilemma and the path to a latency guarantee.
+6. **Approach D** (two-tower) — only after 1–2 are in place, and only measured against a *tuned* C.
+
+The through-line: we have spent this session discovering that our offline estimates were
+systematically optimistic and our online tests are power-starved. Fixing the second makes the first
+irrelevant, because we can simply try things.
+
+---
+
+## Sources
+
+- [Netflix — Interleaving in Online Experiments](https://netflixtechblog.com/interleaving-in-online-experiments-at-netflix-a04ee392ec55)
+- [Airbnb — Harnessing Interleaving and Counterfactual Evaluation for Search Ranking (2025)](https://arxiv.org/abs/2508.00751)
+- [Airbnb Engineering — Beyond A/B Test](https://medium.com/airbnb-engineering/beyond-a-b-test-speeding-up-airbnb-search-ranking-experimentation-through-interleaving-7087afa09c8e)
+- [Chapelle et al. — Large-Scale Validation and Analysis of Interleaved Search Evaluation](https://www.cs.cornell.edu/people/tj/publications/chapelle_etal_12a.pdf)
+- [Deng et al. — CUPED](https://dl.acm.org/doi/abs/10.1145/2433396.2433413)
+- [KDD 2025 — Variance Reduction in Online Marketplace A/B Testing](https://kdd.org/kdd2025/wp-content/uploads/2025/07/CameraReady-05.pdf)
+- [Johari et al. — Always Valid Inference](https://arxiv.org/abs/1512.04922)
+- [Anytime-Valid Confidence Sequences in an Enterprise A/B Testing Platform](https://arxiv.org/pdf/2302.10108)
+- [Eksombatchai et al. — Pixie (WWW'18)](https://arxiv.org/abs/1711.07601)
+- [Pinterest Engineering — Introducing Pixie](https://medium.com/pinterest-engineering/introducing-pixie-an-advanced-graph-based-recommendation-system-e7b4229b664b)
+- [Dacrema et al. — Are We Really Making Much Progress? (RecSys'19)](https://dl.acm.org/doi/10.1145/3298689.3347058)
+- [Dacrema et al. — A Troubling Analysis of Reproducibility and Progress](https://arxiv.org/abs/1911.07698)
+- [Diffusion Recommender Models and the Illusion of Progress (2025)](https://arxiv.org/html/2505.09364v3)
+- [A Comprehensive Survey on Retrieval Methods in Recommender Systems](https://dl.acm.org/doi/pdf/10.1145/3771925)
+- [Pinterest — Multi-Embedding Retrieval Framework (KDD'25)](https://arxiv.org/pdf/2506.23060)

--- a/docs/BLOG_HOW_IT_WORKS.md
+++ b/docs/BLOG_HOW_IT_WORKS.md
@@ -1,0 +1,124 @@
+# How Graze Personalization Works
+
+*A plain-language walkthrough of the algorithm powering personalized feeds on Bluesky.*
+
+---
+
+## Where the idea came from
+
+Bluesky is an open social network built on the AT Protocol, which means anyone can write a feed algorithm and publish it as a "feed generator" that any user can subscribe to. One of the most interesting community-built algorithms came from [@spacecowboy17.bsky.social](https://bsky.app/profile/spacecowboy17.bsky.social), who published an algorithm called **LinkLonk**.
+
+The insight behind LinkLonk is elegant and social-graph-native: instead of trying to infer what you might like from content features alone — keywords, embeddings, topic tags — it asks a simpler question: *who liked the same things you liked, and what else did they like?*
+
+This is a **three-step random walk on the like graph:**
+
+1. Take your recent likes.
+2. For each post you liked, find other users who also liked it — call them your *co-likers*.
+3. See what posts those co-likers have been liking lately, and surface those to you.
+
+That's the whole thing at its core. No neural networks, no content classifiers, no opaque embeddings. Just: people who have agreed with your taste before are probably good taste signals for what you'd enjoy next.
+
+---
+
+## How we took that idea and inverted it
+
+When we set out to build Graze, we started with the same intuition as LinkLonk, but we ran into a practical wall almost immediately: the original design computes the entire three-step walk *at query time*, inside a Redis Lua script. That works when you have one feed serving a small community. But when you have many feeds each with thousands of users hitting them simultaneously, blocking Redis's single execution thread with heavy Lua computation becomes a serious bottleneck.
+
+Our first change was to **pull the scoring out of Redis and into Rust.** Instead of asking Redis to do the math, we use Redis purely as a fast key-value store for raw data — who liked what and when — and do all the scoring work in our Rust service. This reduces Redis CPU by an order of magnitude on hot feeds and lets us scale the compute side independently.
+
+The second change was more fundamental: we **inverted the direction of the walk.**
+
+In the original formulation, you start from the user and walk *outward* to candidate posts: user → liked posts → co-likers → their liked posts. In our inverted approach, we precompute the expensive middle step. We compute each user's co-liker weights ahead of time and cache them in Redis. Then at scoring time, we iterate over a curated **candidate pool** and ask: "does this post have likers who are in this user's co-liker set?"
+
+This inversion means that adding more candidate posts doesn't require re-traversing the user's entire like history — we only need to look up who liked each candidate and intersect that with the pre-cached co-liker map. The result is a scoring pipeline that runs cleanly in linear time over the candidate set.
+
+---
+
+## The candidate pool: making it steerable
+
+One of the key design decisions was to make the candidate pool **externally configurable**. Every feed has its own pool of eligible posts — stored as a Redis set keyed to the feed's algorithm ID. Those posts can come from ClickHouse (where an upstream data pipeline writes posts matching whatever content rules you care about), or they can be managed directly via an admin API.
+
+This means you can aim the algorithm at whatever content universe you want. A feed for art posts only serves personalization over art posts. A feed for a specific community only considers posts from that community. The graph walk is the same; you're just controlling which posts can even appear in the output.
+
+The candidate pool is kept fresh by a background sync worker that monitors which feeds are actively being used and periodically pulls updated post sets from ClickHouse. The first time a user hits a feed that has no candidate pool yet, the service queues an immediate sync so the pool gets populated before their next scroll.
+
+---
+
+## The scoring formula
+
+Once we have a user's co-liker weights and a candidate pool, scoring a post works like this:
+
+For each post in the candidate pool, we look at everyone who liked it within the last seven days. We intersect that set with the user's co-likers. For each co-liker who liked the post, we add their co-liker weight to the post's score, multiplied by a **recency factor** that decays with a 24-hour half-life. A like from eight hours ago contributes much more than a like from five days ago.
+
+On top of that base score, two corrections are applied:
+
+- **Popularity penalty.** Very viral posts — ones with thousands of likers — get penalized. The intuition is that if everyone is liking something, the signal that *your* co-likers liked it is weaker. We apply an exponent to the raw liker count to discount posts that are mass-appeal rather than taste-matched.
+
+- **Path diversity boost.** If a post was liked by many *different* co-likers — rather than a single super-active user who liked everything — that's a stronger taste signal. We apply a mild exponent to the number of distinct co-liker paths to reward posts with broad agreement across the taste graph.
+
+Posts also need at least some minimum number of overlapping co-likers to appear in your feed at all, as a guard against any single user's behavior contaminating your personalization.
+
+---
+
+## Hard limits: what data we keep and how long
+
+The system has deliberate hard limits on how much history it retains. Likes are stored in date-partitioned Redis sorted sets with a **7-day retention window**. When computing your co-likers, we look at your most recent 500 likes (configurable) from within that 7-day window. We find up to 500 co-likers per liked post and cap the total co-liker set at 10,000 users.
+
+These aren't arbitrary numbers — they reflect a tradeoff between graph richness and latency. A 7-day window keeps the graph fresh and means your co-likers reflect your current interests, not posts you liked two months ago that you've since forgotten about. The per-user and per-post caps mean computation stays bounded and predictable regardless of how active a user is.
+
+When scoring, we check up to 500 candidate posts per request by default (again configurable per preset). Results are cached in Redis for five minutes, so back-to-back scrolls don't recompute from scratch every time.
+
+---
+
+## Cold start and the tiered fallback system
+
+The biggest practical challenge with collaborative filtering is the cold start problem: a brand new user has no likes, so there's nothing to walk. A user with only a handful of likes has a very sparse graph.
+
+We handle this with a **tiered fallback system** based on how many likes a user has accumulated:
+
+- **Cold users (0–5 likes):** The feed is filled primarily with fallback content. There's not enough signal to personalize meaningfully, so we show the best of what the feed has to offer universally.
+
+- **Warm users (6–20 likes):** A partial mix. Some personalization starts to come through, but fallback content takes up a larger portion than it would for an established user.
+
+- **Active users (21+ likes):** Full personalization kicks in. The default configuration targets around 80% personalized content with 20% from fallback tranches.
+
+The fallback content itself is not just one flat list. It's a blend of three distinct tranches:
+
+- **Popular:** Posts with high total engagement, scored with a slow decay (7-day half-life). These are the feed's greatest hits.
+- **Velocity:** Posts gaining engagement *rapidly right now* — measured by rate rather than total count. A post with 200 likes in two hours ranks above a post with 500 likes accumulated over a week.
+- **Discovery:** Cold posts from authors who have demonstrated they produce quality content — newer posts that haven't had time to accumulate likes but are from trusted creators. This deliberately surfaces fresher material.
+
+These three tranches are fetched concurrently and interleaved in a round-robin fashion, then staggered into the personalized posts based on a configurable blend factor. If there isn't enough personalization to fill the feed, an intermediate layer called **author affinity** kicks in first: instead of using exact post co-likers, it matches on authors you've liked, creating a coarser but denser graph that fills gaps before falling all the way back to the universal tranches.
+
+---
+
+## The Thompson Sampling engine
+
+Once you have a working algorithm, the next question is: which configuration of the algorithm is *best*? The LinkLonk parameters aren't magic numbers — how many user likes to consider, how many co-likers per post, how deep to search, how aggressively to penalize popularity — all of these affect the quality of the output differently on different feeds.
+
+We use **Thompson Sampling** to tune these parameters automatically. Thompson Sampling is a Bayesian approach to the classic "multi-armed bandit" problem: you have several choices (different parameter values), and you want to figure out which choice produces the best outcomes without wasting too much time on bad choices.
+
+Each parameter has its own independent bandit. For a parameter like `max_user_likes`, the options might be `[100, 200, 300, 500, 750]`. Each option starts with equal probability. When we observe that a particular combination of settings produced a good result — meaning at least 60% of the feed was personalized, the candidate set was rich enough that scoring had real signal to work with, and the response came back in under 500ms — we update the probability distribution for those options upward. Bad outcomes shift probabilities down.
+
+The key wrinkle is a **10% holdout group.** On one out of ten requests, instead of using the Thompson-sampled parameters, we use the configured defaults. This control group lets us compare the adaptive system against the baseline and measure whether the learning is actually helping. We also have a small 5% exploration rate on top of Thompson — occasionally picking parameter values at random to make sure we don't get stuck in local optima.
+
+This means the system is continuously self-tuning in production. A feed that serves a community with different engagement patterns than the defaults will gradually adapt to what works for that specific audience, without any manual intervention.
+
+---
+
+## What it looks like end to end
+
+When a user opens a Graze-powered feed, here's roughly what happens:
+
+1. The service looks up the user's cached personalization result. If it's fresh (less than five minutes old), the cached ranking is returned immediately.
+2. If the cache is stale or empty, the co-liker map is computed or retrieved from its own cache (which lasts up to six hours, invalidated immediately if you like new posts).
+3. The Rust scorer walks the candidate pool, intersects each post's likers against the co-liker map, applies recency decay, popularity penalty, and path diversity boost, and produces a scored ranking.
+4. If the ranking is thin, author-affinity supplementation fires to fill gaps before fallback tranches are consulted.
+5. The final blended list is assembled, duplicate-deduplicated across sources, and returned to the client — along with a cryptographic proof in the feed context that lets you verify exactly which parameters produced that particular result, what fraction came from personalization versus fallback, and how the scoring was done.
+6. The outcome is recorded by the Thompson Sampling engine, which updates the parameter distributions for the next request.
+
+The whole thing typically completes in well under 200 milliseconds, and the result is something that feels like the feed actually knows you — not because it's been trained on your profile, but because it's been watching what you and people who share your taste have agreed on over the last seven days.
+
+---
+
+*Graze is built on the AT Protocol and is open to any Bluesky feed operator. The core algorithm is written in Rust with Axum and deadpool-redis.*

--- a/kube/configmap.yaml
+++ b/kube/configmap.yaml
@@ -14,7 +14,7 @@ data:
   jetstream-url: "wss://jetstream2.us-west.bsky.network/subscribe"
 
   # Like Graph configuration
-  like-ttl-days: "8"
+  like-ttl-days: "6"
   like-batch-size: "500"
   like-batch-interval-ms: "100"
 

--- a/scripts/clickhouse-init/01-schema.sql
+++ b/scripts/clickhouse-init/01-schema.sql
@@ -1,0 +1,262 @@
+-- =============================================================================
+-- Graze Personalization Service — ClickHouse Schema
+-- =============================================================================
+-- All tables use the Buffer → MergeTree pattern for high-throughput inserts.
+-- Buffer parameters: (num_layers, min_time, max_time, min_rows, max_rows,
+--                     min_bytes, max_bytes)
+--   flush conditions: ANY of (elapsed >= max_time) OR (rows >= max_rows)
+--                               OR (bytes >= max_bytes)
+-- =============================================================================
+
+-- =============================================================================
+-- feed_interactions: raw ATProto sendInteractions events
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS feed_interactions
+(
+    did                        String,
+    impression_id              String,        -- join key with feed_impressions
+    interaction_feed_context   String,        -- raw base64 feedContext blob
+    feed_uri                   String,
+    attribution                LowCardinality(String),
+    interaction_item           String,        -- AT-URI of the post
+    interaction_event          LowCardinality(String),  -- e.g. app.bsky.feed.defs#interactionLike
+    interaction_request_id     String,
+    occurred                   DateTime64(3, 'UTC'),
+
+    INDEX idx_impression_id    impression_id   TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_did              did             TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_event            interaction_event TYPE set(20) GRANULARITY 4
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(occurred)
+ORDER BY (interaction_event, occurred)
+TTL occurred + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS feed_interactions_buffer AS feed_interactions
+ENGINE = Buffer(
+    currentDatabase(), 'feed_interactions',
+    16,         -- num_layers
+    10, 100,    -- min_time, max_time (seconds)
+    10000, 1000000,   -- min_rows, max_rows
+    10485760, 104857600  -- min_bytes (10MB), max_bytes (100MB)
+);
+
+-- =============================================================================
+-- user_action_logs: per-user action aggregates for analytics
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS user_action_logs
+(
+    algo_id          Int32,
+    user_did         String,
+    action_type      LowCardinality(String),
+    action_identifier String,
+    action_time      DateTime64(3, 'UTC'),
+    action_count     UInt32,
+
+    INDEX idx_user_did user_did TYPE bloom_filter(0.01) GRANULARITY 4
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(action_time)
+ORDER BY (algo_id, user_did, action_time)
+TTL action_time + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS user_action_logs_buffer AS user_action_logs
+ENGINE = Buffer(
+    currentDatabase(), 'user_action_logs',
+    8,
+    10, 100,
+    10000, 500000,
+    10485760, 52428800  -- 10MB, 50MB
+);
+
+-- =============================================================================
+-- algorithm_posts_v2: candidate posts per algorithm (read by candidate_sync)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS algorithm_posts_v2
+(
+    algo_id              Int32,
+    uri                  String,
+    bluesky_created_at   DateTime64(3, 'UTC'),
+    created_at           DateTime64(3, 'UTC') DEFAULT now()
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(bluesky_created_at)
+ORDER BY (algo_id, bluesky_created_at DESC)
+TTL bluesky_created_at + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;
+
+-- =============================================================================
+-- hidden_status: per-algorithm hidden posts (read by candidate_sync to exclude)
+--
+-- May be created and maintained by another service. candidate_sync joins to
+-- this table so that hidden posts are not synced into Redis. One row per
+-- (algo_id, uri) with hidden = true when the post is hidden for that feed.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS hidden_status
+(
+    algo_id    UInt32,
+    uri        String,
+    hidden     Bool DEFAULT false,
+    updated_at DateTime DEFAULT now(),
+
+    INDEX idx_uri_bloom uri TYPE bloom_filter(0.01) GRANULARITY 3
+)
+ENGINE = MergeTree()
+ORDER BY (algo_id, uri)
+SETTINGS index_granularity = 8192;
+
+-- =============================================================================
+-- feed_impressions: ML feature vectors logged at feed serve time
+--
+-- One row per (request, post) pair — i.e. every post position in every served
+-- feed. Joined to feed_interactions on impression_id to build training labels.
+--
+-- Scaling: at 100M req/day × 30 posts/req = 3B rows/day → partition by month,
+-- with 90-day TTL gives ~9B rows peak. ClickHouse handles this comfortably with
+-- MergeTree + monthly partitioning.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS feed_impressions
+(
+    -- Identity
+    impression_id          String,        -- 16-char hex, unique per (request, post)
+    user_hash              String,        -- hashed DID (anonymized)
+    post_id                String,        -- internal integer ID as string
+    algo_id                Int32,
+    served_at              DateTime64(3, 'UTC'),
+
+    -- Feed context (from FeedContextProvenance)
+    depth                  UInt8,         -- 0-based position in feed response
+    source                 LowCardinality(String),  -- personalized|fallback|author_affinity|...
+    is_holdout             Bool,
+    is_exploration         Bool,
+    response_time_ms       Float32,
+    is_first_page          Bool,
+
+    -- Scoring features (from scorer hot loop)
+    raw_score              Float32,       -- sum of co-liker weighted contributions
+    final_score            Float32,       -- after paths_boost and popularity_penalty
+    num_paths              UInt16,        -- distinct co-likers who matched this post
+    liker_count            UInt32,        -- global post popularity (total likes)
+    popularity_penalty     Float32,       -- (1/liker_count)^(pop_power*0.5)
+    paths_boost            Float32,       -- num_paths^num_paths_power
+    max_contribution       Float32,       -- largest single co-liker contribution
+    score_concentration    Float32,       -- max_contribution / raw_score
+    newest_like_age_hours  Float32,       -- age of most recent matching co-liker like
+    oldest_like_age_hours  Float32,       -- age of oldest matching co-liker like
+    was_liker_cache_hit    Bool,          -- whether liker data came from in-process cache
+
+    -- Network features (computed from source_weights before scoring loop)
+    coliker_count          UInt16,        -- total co-likers in the user's graph
+    top_coliker_weight     Float32,       -- weight of strongest co-liker
+    top5_weight_sum        Float32,       -- sum of top-5 co-liker weights
+    mean_coliker_weight    Float32,       -- mean co-liker weight
+    weight_concentration   Float32,       -- top1 / mean (Herfindahl-style)
+
+    -- User features (from blending logic)
+    user_like_count        UInt32,        -- total likes by this user in retention window
+    user_segment           LowCardinality(String),  -- cold|warm|active
+
+    -- Request quality (from ScoringResult)
+    richness_ratio         Float32,       -- posts_scored / posts_checked
+
+    -- Time features
+    hour_of_day            UInt8,
+    day_of_week            UInt8,         -- 0=Monday ... 6=Sunday
+
+    INDEX idx_impression_id impression_id TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_user_hash     user_hash     TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_algo_id       algo_id       TYPE minmax GRANULARITY 4
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(served_at)
+ORDER BY (algo_id, user_hash, served_at)
+TTL served_at + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS feed_impressions_buffer AS feed_impressions
+ENGINE = Buffer(
+    currentDatabase(), 'feed_impressions',
+    16,
+    10, 100,
+    10000, 1000000,
+    10485760, 104857600
+);
+
+-- =============================================================================
+-- Training helper view
+--
+-- Joins impressions with interactions to produce labelled training rows.
+-- Use in Python training script as:
+--   SELECT * FROM training_labels WHERE served_at BETWEEN x AND y
+--
+-- Positive examples: any_positive = 1
+-- Explicit negatives: see_less = 1
+-- Implicit negatives: seen_no_engage = 1 (seen but no positive + no see_less)
+-- =============================================================================
+CREATE VIEW IF NOT EXISTS training_labels AS
+SELECT
+    i.impression_id,
+    i.user_hash,
+    i.post_id,
+    i.algo_id,
+    i.served_at,
+    i.depth,
+    i.source,
+    i.is_holdout,
+    i.is_exploration,
+    i.response_time_ms,
+    i.is_first_page,
+    i.raw_score,
+    i.final_score,
+    i.num_paths,
+    i.liker_count,
+    i.popularity_penalty,
+    i.paths_boost,
+    i.max_contribution,
+    i.score_concentration,
+    i.newest_like_age_hours,
+    i.oldest_like_age_hours,
+    i.was_liker_cache_hit,
+    i.coliker_count,
+    i.top_coliker_weight,
+    i.top5_weight_sum,
+    i.mean_coliker_weight,
+    i.weight_concentration,
+    i.user_like_count,
+    i.user_segment,
+    i.richness_ratio,
+    i.hour_of_day,
+    i.day_of_week,
+    -- Outcome counts per interaction type
+    countIf(ie.interaction_event LIKE '%interactionLike')    AS like_count,
+    countIf(ie.interaction_event LIKE '%interactionRepost')  AS repost_count,
+    countIf(ie.interaction_event LIKE '%interactionReply')   AS reply_count,
+    countIf(ie.interaction_event LIKE '%interactionQuote')   AS quote_count,
+    countIf(ie.interaction_event LIKE '%interactionSeeMore') AS see_more_count,
+    countIf(ie.interaction_event LIKE '%interactionSeen')    AS seen_count,
+    countIf(ie.interaction_event LIKE '%seeLess%')           AS see_less_count,
+    -- Binary labels
+    (like_count > 0)     AS liked,
+    (repost_count > 0)   AS reposted,
+    (reply_count > 0)    AS replied,
+    (quote_count > 0)    AS quoted,
+    (see_more_count > 0) AS see_more,
+    (see_less_count > 0) AS see_less,
+    -- Composite positive: any deliberate positive signal
+    (liked OR reposted OR replied OR quoted OR see_more) AS any_positive,
+    -- Implicit negative: seen by client but no positive and no explicit dislike
+    (seen_count > 0 AND NOT any_positive AND NOT see_less)   AS seen_no_engage
+FROM feed_impressions i
+LEFT JOIN feed_interactions ie
+    ON ie.impression_id = i.impression_id
+GROUP BY
+    i.impression_id, i.user_hash, i.post_id, i.algo_id, i.served_at,
+    i.depth, i.source, i.is_holdout, i.is_exploration, i.response_time_ms,
+    i.is_first_page, i.raw_score, i.final_score, i.num_paths, i.liker_count,
+    i.popularity_penalty, i.paths_boost, i.max_contribution, i.score_concentration,
+    i.newest_like_age_hours, i.oldest_like_age_hours, i.was_liker_cache_hit,
+    i.coliker_count, i.top_coliker_weight, i.top5_weight_sum, i.mean_coliker_weight,
+    i.weight_concentration, i.user_like_count, i.user_segment, i.richness_ratio,
+    i.hour_of_day, i.day_of_week;

--- a/scripts/redis_interner_gc.py
+++ b/scripts/redis_interner_gc.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Orphan GC for URI interner tables (legacy global + date-sharded).
+
+Deletes uri2id/id2uri entries whose post IDs are not referenced by live Redis
+data (ap, ul/pl retention window, caches, fallbacks, seen).
+
+Date-sharded keys also get EXPIRE from TTL; this job cleans stale fields and
+legacy global hashes that predate sharding.
+
+Usage:
+  python scripts/redis_interner_gc.py --dry-run
+  python scripts/redis_interner_gc.py --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
+
+import redis
+
+RETENTION_DAYS = int(os.environ.get("RETENTION_DAYS", "6"))
+SCAN_COUNT = int(os.environ.get("SCAN_COUNT", "500"))
+HDEL_BATCH = int(os.environ.get("HDEL_BATCH", "500"))
+PRUNE_SHARD_LOOKBACK_DAYS = int(os.environ.get("PRUNE_SHARD_LOOKBACK_DAYS", "400"))
+
+LEGACY_URI2ID = "uri2id"
+LEGACY_ID2URI = "id2uri"
+
+
+def connect() -> redis.Redis:
+    url = os.environ.get("REDIS_URL")
+    if not url:
+        raise SystemExit("REDIS_URL not set")
+    u = urlparse(url)
+    return redis.Redis(
+        host=u.hostname,
+        port=u.port,
+        password=u.password,
+        username=u.username or None,
+        ssl=url.startswith("rediss"),
+        ssl_cert_reqs=None,
+        socket_timeout=60,
+    )
+
+
+def retention_dates(days: int) -> list[str]:
+    today = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    return [(today - timedelta(days=i)).strftime("%Y%m%d") for i in range(days)]
+
+
+def scan_keys(r: redis.Redis, pattern: str):
+    cursor = 0
+    while True:
+        cursor, keys = r.scan(cursor=cursor, match=pattern, count=SCAN_COUNT)
+        for k in keys:
+            yield k.decode() if isinstance(k, bytes) else k
+        if cursor == 0:
+            break
+
+
+def collect_live_post_ids(r: redis.Redis, dates: list[str]) -> set[str]:
+    live: set[str] = set()
+
+    print("collecting live post IDs from ap:* ...", flush=True)
+    for key in scan_keys(r, "ap:*"):
+        if ":temp" in key:
+            continue
+        for m in r.sscan_iter(key, count=SCAN_COUNT):
+            mid = m.decode() if isinstance(m, bytes) else m
+            live.add(mid)
+
+    print("collecting from apc:* ...", flush=True)
+    for key in scan_keys(r, "apc:*"):
+        if ":temp" in key:
+            continue
+        cursor = 0
+        while True:
+            cursor, data = r.hscan(key, cursor=cursor, count=SCAN_COUNT)
+            for field in data:
+                fid = field.decode() if isinstance(field, bytes) else field
+                live.add(fid)
+            if cursor == 0:
+                break
+
+    for prefix in ("ul:", "pl:", "authl:"):
+        for date in dates:
+            pattern = f"{prefix}*:{date}"
+            n = 0
+            for key in scan_keys(r, pattern):
+                for m in r.zscan_iter(key, count=SCAN_COUNT):
+                    if prefix == "pl:":
+                        continue
+                    mid = m[0].decode() if isinstance(m[0], bytes) else m[0]
+                    live.add(mid)
+                n += 1
+            print(f"  {prefix}*{date} keys_scanned={n}", flush=True)
+
+    for pattern in ("ll:*", "fsc:*", "seen:*"):
+        print(f"collecting from {pattern} ...", flush=True)
+        for key in scan_keys(r, pattern):
+            t = r.type(key)
+            ts = t.decode() if isinstance(t, bytes) else t
+            if ts == "zset":
+                for m in r.zscan_iter(key, count=SCAN_COUNT):
+                    mid = m[0].decode() if isinstance(m[0], bytes) else m[0]
+                    live.add(mid)
+            elif ts == "list":
+                for m in r.lrange(key, 0, -1):
+                    mid = m.decode() if isinstance(m, bytes) else m
+                    live.add(mid)
+
+    for prefix in ("trending:", "popular:", "velocity:", "discovery:"):
+        print(f"collecting from {prefix}* ...", flush=True)
+        for key in scan_keys(r, f"{prefix}*"):
+            if ":meta" in key:
+                continue
+            for m in r.zscan_iter(key, count=SCAN_COUNT):
+                mid = m[0].decode() if isinstance(m[0], bytes) else m[0]
+                live.add(mid)
+
+    print(f"live post IDs collected: {len(live)}", flush=True)
+    return live
+
+
+def gc_hash_orphans(
+    r: redis.Redis,
+    uri2id_key: str,
+    id2uri_key: str,
+    live: set[str],
+    execute: bool,
+) -> tuple[int, int]:
+    """Remove hash fields not in live. Returns (scanned, deleted)."""
+    scanned = deleted = 0
+    uri_del_batch: list[str] = []
+    id_del_batch: list[str] = []
+
+    cursor = 0
+    while True:
+        cursor, items = r.hscan(id2uri_key, cursor=cursor, count=SCAN_COUNT)
+        for post_id, uri in items.items():
+            scanned += 1
+            pid = post_id.decode() if isinstance(post_id, bytes) else post_id
+            if pid in live:
+                continue
+            u = uri.decode() if isinstance(uri, bytes) else uri
+            id_del_batch.append(pid)
+            uri_del_batch.append(u)
+            if len(id_del_batch) >= HDEL_BATCH:
+                if execute:
+                    r.hdel(id2uri_key, *id_del_batch)
+                    r.hdel(uri2id_key, *uri_del_batch)
+                deleted += len(id_del_batch)
+                id_del_batch.clear()
+                uri_del_batch.clear()
+                if deleted and deleted % 50000 == 0:
+                    m = r.info("memory")
+                    print(
+                        f"  progress key={id2uri_key} deleted={deleted} "
+                        f"used={m.get('used_memory_human')}",
+                        flush=True,
+                    )
+        if cursor == 0:
+            break
+
+    if id_del_batch:
+        if execute:
+            r.hdel(id2uri_key, *id_del_batch)
+            r.hdel(uri2id_key, *uri_del_batch)
+        deleted += len(id_del_batch)
+
+    return scanned, deleted
+
+
+def shard_dates_to_gc(dates_retention: list[str]) -> list[str]:
+    """Shard dates to scan: retention window + older shards for orphan cleanup."""
+    cutoff = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    start = cutoff - timedelta(days=PRUNE_SHARD_LOOKBACK_DAYS)
+    out: set[str] = set(dates_retention)
+    d = start
+    while d < cutoff:
+        out.add(d.strftime("%Y%m%d"))
+        d += timedelta(days=1)
+    return sorted(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Orphan GC for URI interner")
+    parser.add_argument("--execute", action="store_true", help="Apply HDEL (default dry-run)")
+    args = parser.parse_args()
+    execute = args.execute
+
+    r = connect()
+    info = r.info("memory")
+    print(f"mode={'EXECUTE' if execute else 'DRY-RUN'} retention_days={RETENTION_DAYS}", flush=True)
+    print(
+        f"used_memory={info.get('used_memory_human')} maxmemory={info.get('maxmemory_human')}",
+        flush=True,
+    )
+
+    dates = retention_dates(RETENTION_DAYS)
+    live = collect_live_post_ids(r, dates)
+
+    total_scanned = 0
+    total_deleted = 0
+
+    if r.exists(LEGACY_ID2URI):
+        print("GC legacy global id2uri/uri2id ...", flush=True)
+        s, d = gc_hash_orphans(r, LEGACY_URI2ID, LEGACY_ID2URI, live, execute)
+        print(f"  legacy scanned={s} orphans={d}", flush=True)
+        total_scanned += s
+        total_deleted += d
+
+    for date in shard_dates_to_gc(dates):
+        id2uri = f"id2uri:{date}"
+        uri2id = f"uri2id:{date}"
+        if not r.exists(id2uri):
+            continue
+        print(f"GC shard {date} ...", flush=True)
+        s, d = gc_hash_orphans(r, uri2id, id2uri, live, execute)
+        print(f"  shard {date} scanned={s} orphans={d}", flush=True)
+        total_scanned += s
+        total_deleted += d
+        time.sleep(0.01)
+
+    info2 = r.info("memory")
+    print(
+        f"done scanned={total_scanned} deleted={total_deleted} "
+        f"used_memory_now={info2.get('used_memory_human')}",
+        flush=True,
+    )
+    if not execute:
+        print("Re-run with --execute to HDEL orphans.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/redis_prune_retention.py
+++ b/scripts/redis_prune_retention.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Prune Redis keys to free memory for personalization layer.
+
+Safe tiers (see --help). Default is dry-run.
+
+Date-partitioned like graph keys older than RETENTION_DAYS are removed;
+legacy ul:/pl:/authl: day-tranche and undated keys are removed (no longer read).
+Caches and queues are optional tiers.
+
+Usage:
+  python scripts/redis_prune_retention.py --dry-run
+  python scripts/redis_prune_retention.py --execute --tier caches --tier legacy --tier old-dates
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
+
+import redis
+
+RETENTION_DAYS = int(os.environ.get("RETENTION_DAYS", "6"))
+SCAN_COUNT = int(os.environ.get("SCAN_COUNT", "500"))
+UNLINK_BATCH = int(os.environ.get("UNLINK_BATCH", "500"))
+
+DATE_SUFFIX = re.compile(r"^(\d{8})$")
+DAY_SUFFIX = re.compile(r"^d[0-7]$")
+
+# Prefixes where the last :segment may be YYYYMMDD
+DATE_PREFIXES = ("ul:", "pl:", "authl:")
+
+# Entire key patterns safe to delete (rebuilt or ephemeral)
+CACHE_PREFIXES = (
+    "fsc:",
+    "ll:",
+    "colikes:",
+    "colikes:meta:",
+    "colikes:ts:",
+    "acolikes:",
+    "acolikes:meta:",
+    "seen:",
+)
+
+CACHE_EXACT = (
+    # co-liker / author-affinity meta keys use prefixes above
+)
+
+QUEUE_EXACT = ("log_tasks", "feed_requests", "pending:syncs", "queue:sync")
+
+LEGACY_SCAN = (
+    "ul:*:d*",
+    "pl:*:d*",
+    "authl:*:d*",
+)
+
+
+def parse_date(s: str) -> datetime | None:
+    try:
+        return datetime.strptime(s, "%Y%m%d").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def cutoff_date() -> datetime:
+    # Keep today and previous (RETENTION_DAYS - 1) full days = RETENTION_DAYS dates
+    today = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    return today - timedelta(days=RETENTION_DAYS)
+
+
+def classify_date_key(key: str) -> str | None:
+    """Return 'keep', 'delete', or None if not a date-partitioned like key."""
+    for prefix in DATE_PREFIXES:
+        if not key.startswith(prefix):
+            continue
+        parts = key.split(":")
+        if len(parts) < 3:
+            return "delete"  # undated legacy ul:hash
+        suffix = parts[-1]
+        if DAY_SUFFIX.match(suffix):
+            return "delete"
+        m = DATE_SUFFIX.match(suffix)
+        if m:
+            d = parse_date(m.group(1))
+            if d is None:
+                return None
+            if d < cutoff_date():
+                return "delete"
+            return "keep"
+        return None
+    return None
+
+
+def connect() -> redis.Redis:
+    url = os.environ.get("REDIS_URL")
+    if not url:
+        raise SystemExit("REDIS_URL not set")
+    u = urlparse(url)
+    return redis.Redis(
+        host=u.hostname,
+        port=u.port,
+        password=u.password,
+        username=u.username or None,
+        ssl=url.startswith("rediss"),
+        ssl_cert_reqs=None,
+        socket_timeout=30,
+        socket_connect_timeout=15,
+    )
+
+
+def scan_keys(r: redis.Redis, pattern: str):
+    cursor = 0
+    while True:
+        cursor, keys = r.scan(cursor=cursor, match=pattern, count=SCAN_COUNT)
+        for k in keys:
+            yield k.decode() if isinstance(k, bytes) else k
+        if cursor == 0:
+            break
+
+
+def unlink_batches(r: redis.Redis, keys: list[str], execute: bool) -> int:
+    if not keys:
+        return 0
+    if not execute:
+        return len(keys)
+    deleted = 0
+    for i in range(0, len(keys), UNLINK_BATCH):
+        batch = keys[i : i + UNLINK_BATCH]
+        try:
+            deleted += r.unlink(*batch)
+        except redis.ResponseError:
+            deleted += r.delete(*batch)
+        time.sleep(0.02)
+    return deleted
+
+
+def scan_and_prune(
+    r: redis.Redis, pattern: str, execute: bool, batch: list[str] | None = None
+) -> int:
+    """Scan keys matching pattern; count or UNLINK in batches (low memory)."""
+    if batch is None:
+        batch = []
+    total = 0
+    for k in scan_keys(r, pattern):
+        total += 1
+        if not execute:
+            continue
+        batch.append(k)
+        if len(batch) >= UNLINK_BATCH:
+            unlink_batches(r, batch, True)
+            batch.clear()
+            if total % 50000 == 0:
+                m = r.info("memory")
+                print(
+                    f"progress pattern={pattern} keys_seen={total} "
+                    f"used={m.get('used_memory_human')}",
+                    flush=True,
+                )
+    if execute and batch:
+        unlink_batches(r, batch, True)
+        batch.clear()
+    return total
+
+
+def scan_and_prune_classified(
+    r: redis.Redis,
+    pattern: str,
+    execute: bool,
+    batch: list[str],
+    should_delete,
+) -> int:
+    """One keyspace pass: only UNLINK keys where should_delete(key) is true."""
+    seen = matched = 0
+    for k in scan_keys(r, pattern):
+        seen += 1
+        if not should_delete(k):
+            continue
+        matched += 1
+        if not execute:
+            continue
+        batch.append(k)
+        if len(batch) >= UNLINK_BATCH:
+            unlink_batches(r, batch, True)
+            batch.clear()
+        if matched % 50000 == 0:
+            m = r.info("memory")
+            print(
+                f"progress pattern={pattern} scanned={seen} matched={matched} "
+                f"used={m.get('used_memory_human')}",
+                flush=True,
+            )
+    if execute and batch:
+        unlink_batches(r, batch, True)
+        batch.clear()
+    print(
+        f"finished pattern={pattern} scanned={seen} matched={matched}",
+        flush=True,
+    )
+    return matched if execute else seen
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Prune personalization Redis keys")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually UNLINK keys (default: dry-run report only)",
+    )
+    parser.add_argument(
+        "--tier",
+        action="append",
+        choices=["old-dates", "legacy", "caches", "queues"],
+        help="Tiers to process (default: all)",
+    )
+    args = parser.parse_args()
+    tiers = set(args.tier or ["old-dates", "legacy", "caches", "queues"])
+    execute = args.execute
+    dry = not execute
+
+    r = connect()
+    info = r.info("memory")
+    print(f"mode={'DRY-RUN' if dry else 'EXECUTE'} retention_days={RETENTION_DAYS}", flush=True)
+    print(f"cutoff_delete_before={cutoff_date().strftime('%Y-%m-%d')} (UTC)", flush=True)
+    print(
+        f"used_memory_human={info.get('used_memory_human')} "
+        f"maxmemory={info.get('maxmemory_human', info.get('maxmemory'))}",
+        flush=True,
+    )
+    print(f"tiers={sorted(tiers)}", flush=True)
+
+    stats: dict[str, int] = {}
+    batch: list[str] = []
+
+    def flush_batch():
+        if batch and execute:
+            unlink_batches(r, batch, True)
+            batch.clear()
+
+    if "queues" in tiers:
+        n = 0
+        for q in QUEUE_EXACT:
+            if r.exists(q):
+                n += 1
+                if execute:
+                    r.delete(q)
+                    print(f"deleted queue key {q}", flush=True)
+        stats["queues"] = n
+        m = r.info("memory")
+        print(f"after queues used={m.get('used_memory_human')}", flush=True)
+
+    if "caches" in tiers:
+        n = 0
+        for p in CACHE_PREFIXES:
+            print(f"scanning {p}*", flush=True)
+            n += scan_and_prune(r, f"{p}*", execute, batch)
+        flush_batch()
+        stats["caches"] = n
+        m = r.info("memory")
+        print(f"after caches used={m.get('used_memory_human')} count={n}", flush=True)
+
+    if "legacy" in tiers:
+        n = 0
+        for pattern in LEGACY_SCAN:
+            n += scan_and_prune(r, pattern, execute, batch)
+        flush_batch()
+        stats["legacy"] = n
+
+    if "old-dates" in tiers:
+        cutoff = cutoff_date()
+        print(
+            f"old-dates single-pass scan, delete before {cutoff.strftime('%Y%m%d')} (UTC)",
+            flush=True,
+        )
+
+        def old_date_delete(key: str) -> bool:
+            return classify_date_key(key) == "delete"
+
+        n = 0
+        for prefix in DATE_PREFIXES:
+            print(f"scanning {prefix}* (classify by suffix)", flush=True)
+            n += scan_and_prune_classified(
+                r, f"{prefix}*", execute, batch, old_date_delete
+            )
+        stats["old-dates"] = n
+        m = r.info("memory")
+        print(f"after old-dates used={m.get('used_memory_human')} matched={n}", flush=True)
+
+    print("categories:", stats, flush=True)
+    if dry:
+        print(f"keys_matched={sum(stats.values())} (dry-run, nothing deleted)", flush=True)
+        return 0
+
+    info2 = r.info("memory")
+    print(
+        f"done keys_processed={sum(stats.values())} "
+        f"used_memory_human_now={info2.get('used_memory_human')}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/redis_quick_stats.py
+++ b/scripts/redis_quick_stats.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import os
+from urllib.parse import urlparse
+
+import redis
+
+u = urlparse(os.environ["REDIS_URL"])
+r = redis.Redis(
+    host=u.hostname,
+    port=u.port,
+    password=u.password,
+    username=u.username or None,
+    ssl=u.scheme == "rediss",
+    ssl_cert_reqs=None,
+    socket_timeout=60,
+)
+m = r.info("memory")
+print("used", m.get("used_memory_human"), "max", m.get("maxmemory_human"))
+print("mem_fragmentation", m.get("mem_fragmentation_ratio"))
+for k in [
+    "log_tasks",
+    "feed_requests",
+    "pending:syncs",
+    "queue:sync",
+    "uri2id",
+    "id2uri",
+    "supported_feeds",
+]:
+    t = r.type(k)
+    ts = t.decode() if isinstance(t, bytes) else t
+    if ts == "none":
+        print(k, "missing")
+    elif ts == "list":
+        print(k, "list", r.llen(k))
+    elif ts == "hash":
+        print(k, "hash", r.hlen(k))
+    else:
+        print(k, ts)
+
+shard_fields = 0
+shard_keys = 0
+for key in r.scan_iter(match="uri2id:*", count=500):
+    shard_keys += 1
+    shard_fields += r.hlen(key)
+print("uri2id:* shards", shard_keys, "fields", shard_fields)

--- a/tests/common/redis_setup.rs
+++ b/tests/common/redis_setup.rs
@@ -89,7 +89,7 @@ fn create_test_config(redis_url: String) -> Config {
         jetstream_stale_timeout_seconds: 60,
 
         // Like Graph
-        like_ttl_days: 8,
+        like_ttl_days: 6,
         like_batch_size: 5000,
         like_batch_interval_ms: 5000,
         like_ttl_refresh_interval_seconds: 3600,
@@ -226,7 +226,7 @@ fn create_test_config(redis_url: String) -> Config {
         default_max_sources_per_post: 100,
         default_max_total_sources: 2000,
         default_min_co_likes: 1,
-        default_time_window_hours: 168.0,
+        default_time_window_hours: 144.0,
         default_recency_half_life_hours: 24.0,
         default_specificity_power: 1.0,
         default_popularity_power: 0.6,


### PR DESCRIPTION
The tail of the same problem #15 addressed: files that exist only on one laptop.

**Most consequential: `Dockerfile.iter`** — the recipe that built the image currently serving production. The full LTO `Dockerfile` takes ~76 minutes under QEMU on an arm64 host; this one builds `graze-api` + `candidate-sync` in ~15. It was not in version control at all, so the build path for the running service was unreproducible by anyone else.

Also lands:

- three Redis ops scripts — interner GC, retention pruning, quick stats
- `DESIGN-durable-coliker-profiles.md` and `RESEARCH-personalization-directions.md`
- `scripts/clickhouse-init/01-schema.sql`
- `DEBUG.md`, `docs/BLOG_HOW_IT_WORKS.md`
- a configmap key, and 154 lines of `CLAUDE.md` covering the date-sharded URI interner and current key patterns

**Secrets:** scanned; all credentials come from environment variables (`os.environ["REDIS_URL"]` etc.). Nothing here carries a literal secret.

With this, the working tree matches `main` and nothing about the running service lives only on local disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)