### PR TITLE
Cache the per-algorithm candidate pool; bound candidate allocation

### DIFF
--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -8,6 +8,7 @@ mod diversity;
 mod feed_cache;
 mod liker_cache;
 mod params;
+mod pool_cache;
 mod proof;
 mod scorer;
 mod scoring_core;
@@ -21,6 +22,7 @@ pub use feed_cache::{FeedCache, FeedCacheStats};
 pub use graze_common::models::FeedSuccessConfig;
 pub use liker_cache::{CacheStats, LikerCache};
 pub use params::{apply_thompson_params, get_preset, merge_params, LinkLonkParams};
+pub use pool_cache::{PoolCache, PoolCacheStats};
 pub use proof::{compute_proof, LinkLonkProof, ProofCollector};
 pub use scorer::{Scorer, ScoringResult};
 pub use scoring_core::{
@@ -72,7 +74,19 @@ impl LinkLonkAlgorithm {
             config.liker_cache_max_size,
             config.liker_cache_ttl_seconds,
         ));
-        let scorer = Scorer::new(redis.clone(), liker_cache.clone(), config.clone());
+        // One pool cache, shared by both scorers. Unlike LikerCache -- which is deliberately
+        // per-arm because liker lists depend on max_likers_per_post -- a candidate pool is the
+        // same Redis set whatever the params, so sharing is correct rather than a leak.
+        let pool_cache = Arc::new(pool_cache::PoolCache::new(
+            config.pool_cache_ttl_seconds,
+            config.pool_cache_max_members,
+        ));
+        let scorer = Scorer::new(
+            redis.clone(),
+            liker_cache.clone(),
+            config.clone(),
+            pool_cache.clone(),
+        );
 
         // The durable arm gets its own scorer with relaxed candidate filters. Cloning the
         // config and overriding just those fields keeps every other knob in lockstep with
@@ -92,7 +106,12 @@ impl LinkLonkAlgorithm {
                 config.liker_cache_max_size,
                 config.liker_cache_ttl_seconds,
             ));
-            Scorer::new(redis.clone(), profile_liker_cache, Arc::new(profile_config))
+            Scorer::new(
+                redis.clone(),
+                profile_liker_cache,
+                Arc::new(profile_config),
+                pool_cache.clone(),
+            )
         };
 
         Self {

--- a/crates/graze-api/src/algorithm/pool_cache.rs
+++ b/crates/graze-api/src/algorithm/pool_cache.rs
@@ -1,0 +1,222 @@
+//! Per-algorithm candidate-pool cache.
+//!
+//! `Scorer::score` fetched the entire `ap:{algo_id}` set with `SMEMBERS` on **every request**.
+//! Measured on prod 2026-08-27: 56 live pools, median 4,554 members, max 39,959, and `SMEMBERS`
+//! costs **71–107 ms** on the large ones. The same identical set was refetched for every user of
+//! that feed, and `SCARD` on the five largest pools drifted by **exactly zero** over 20 s — the
+//! data is effectively static between candidate-sync runs.
+//!
+//! That work showed up as `posts_checked` being pinned at 23,734 regardless of `max_total_sources`,
+//! and as 40.1% of personalized responses breaching the 500 ms Thompson speed gate (which marks
+//! them as failures for bandit learning even when they personalized perfectly well).
+//!
+//! Deliberately **shared between the live and durable-profile scorers**, unlike `LikerCache`. That
+//! separation exists because liker lists depend on `max_likers_per_post`, so sharing them would
+//! leak one arm's longer lists into the other. A candidate pool has no such dependency — it is the
+//! same Redis set whatever the params — so sharing is correct here rather than a hazard.
+//!
+//! Bounded on total members rather than entry count: pools range from 1 to ~40,000 members, so an
+//! entry cap would bound almost nothing. This service has a 2 GiB limit against ~400 MiB in use,
+//! and the whole live set is ~485k members (~25–40 MB), so the default fits with wide margin.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+struct PoolEntry {
+    fetched_at: Instant,
+    posts: Arc<Vec<String>>,
+}
+
+/// Hit/miss accounting, so a cache that silently stops working is visible.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PoolCacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub evictions: u64,
+    pub entries: usize,
+    pub members: usize,
+}
+
+/// TTL cache of `ap:{algo_id}` membership, keyed by algo.
+pub struct PoolCache {
+    entries: DashMap<i32, PoolEntry>,
+    ttl: Duration,
+    max_members: usize,
+    members: AtomicU64,
+    hits: AtomicU64,
+    misses: AtomicU64,
+    evictions: AtomicU64,
+}
+
+impl PoolCache {
+    /// `ttl_seconds == 0` disables the cache entirely.
+    ///
+    /// That is the rollback path: `POOL_CACHE_TTL_SECONDS=0` restores the previous
+    /// fetch-every-request behaviour with an env edit and no rebuild.
+    pub fn new(ttl_seconds: u64, max_members: usize) -> Self {
+        Self {
+            entries: DashMap::new(),
+            ttl: Duration::from_secs(ttl_seconds),
+            max_members,
+            members: AtomicU64::new(0),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
+        }
+    }
+
+    #[inline]
+    pub fn enabled(&self) -> bool {
+        !self.ttl.is_zero()
+    }
+
+    /// Fresh pool for `algo_id`, or `None` when disabled, absent, or expired.
+    pub fn get(&self, algo_id: i32) -> Option<Arc<Vec<String>>> {
+        if !self.enabled() {
+            return None;
+        }
+        // Read the entry, then drop the guard before any mutation. Holding a DashMap reference
+        // across a `remove` on the same shard deadlocks, which is exactly the class of bug the
+        // network-cache port hit with its handle dedup.
+        let expired_len = {
+            match self.entries.get(&algo_id) {
+                Some(e) if e.fetched_at.elapsed() < self.ttl => {
+                    self.hits.fetch_add(1, Ordering::Relaxed);
+                    return Some(e.posts.clone());
+                }
+                Some(e) => Some(e.posts.len()),
+                None => None,
+            }
+        };
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        if let Some(len) = expired_len {
+            if self.entries.remove(&algo_id).is_some() {
+                self.members.fetch_sub(len as u64, Ordering::Relaxed);
+            }
+        }
+        None
+    }
+
+    /// Store a freshly fetched pool. No-op when disabled or when the pool alone exceeds the bound.
+    pub fn put(&self, algo_id: i32, posts: Arc<Vec<String>>) {
+        if !self.enabled() {
+            return;
+        }
+        let len = posts.len();
+        if len > self.max_members {
+            // A single pool larger than the whole budget is never cached; caching it would evict
+            // everything else on every request and turn the cache into pure overhead.
+            return;
+        }
+        // Evict arbitrary entries until the new pool fits. Arbitrary is acceptable: entries are
+        // interchangeable, cheap to refetch, and expire on their own within the TTL anyway.
+        while self.members.load(Ordering::Relaxed) as usize + len > self.max_members {
+            let victim = self.entries.iter().next().map(|e| *e.key());
+            match victim {
+                Some(k) => {
+                    if let Some((_, e)) = self.entries.remove(&k) {
+                        self.members
+                            .fetch_sub(e.posts.len() as u64, Ordering::Relaxed);
+                        self.evictions.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                None => break,
+            }
+        }
+        if let Some(old) = self.entries.insert(
+            algo_id,
+            PoolEntry {
+                fetched_at: Instant::now(),
+                posts,
+            },
+        ) {
+            self.members
+                .fetch_sub(old.posts.len() as u64, Ordering::Relaxed);
+        }
+        self.members.fetch_add(len as u64, Ordering::Relaxed);
+    }
+
+    pub fn stats(&self) -> PoolCacheStats {
+        PoolCacheStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            evictions: self.evictions.load(Ordering::Relaxed),
+            entries: self.entries.len(),
+            members: self.members.load(Ordering::Relaxed) as usize,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pool(n: usize) -> Arc<Vec<String>> {
+        Arc::new((0..n).map(|i| format!("post{i}")).collect())
+    }
+
+    #[test]
+    fn hit_within_ttl_and_miss_after_it() {
+        let c = PoolCache::new(1, 10_000);
+        c.put(1, pool(5));
+        assert_eq!(c.get(1).map(|p| p.len()), Some(5));
+        std::thread::sleep(Duration::from_millis(1100));
+        assert!(c.get(1).is_none(), "entry must expire after its TTL");
+        // The expired entry is dropped rather than left to occupy the member budget.
+        assert_eq!(c.stats().members, 0);
+    }
+
+    #[test]
+    fn ttl_zero_disables_entirely() {
+        let c = PoolCache::new(0, 10_000);
+        assert!(!c.enabled());
+        c.put(1, pool(5));
+        assert!(c.get(1).is_none());
+        // Nothing is retained, so the rollback path cannot leak memory either.
+        assert_eq!(c.stats().entries, 0);
+    }
+
+    #[test]
+    fn member_bound_is_enforced_by_eviction() {
+        let c = PoolCache::new(60, 100);
+        c.put(1, pool(60));
+        c.put(2, pool(60)); // does not fit alongside 1, so 1 is evicted
+        assert!(c.stats().members <= 100, "member bound must hold");
+        assert_eq!(c.stats().entries, 1);
+        assert!(c.stats().evictions >= 1);
+    }
+
+    #[test]
+    fn a_pool_bigger_than_the_budget_is_never_cached() {
+        let c = PoolCache::new(60, 100);
+        c.put(1, pool(500));
+        assert_eq!(
+            c.stats().entries,
+            0,
+            "oversized pool must not evict everything each request"
+        );
+        assert_eq!(c.stats().members, 0);
+    }
+
+    #[test]
+    fn replacing_an_entry_does_not_double_count_members() {
+        let c = PoolCache::new(60, 10_000);
+        c.put(7, pool(100));
+        c.put(7, pool(30));
+        assert_eq!(c.stats().members, 30);
+        assert_eq!(c.stats().entries, 1);
+    }
+
+    #[test]
+    fn stats_track_hits_and_misses() {
+        let c = PoolCache::new(60, 10_000);
+        assert!(c.get(42).is_none());
+        c.put(42, pool(3));
+        assert!(c.get(42).is_some());
+        let s = c.stats();
+        assert_eq!((s.hits, s.misses), (1, 1));
+    }
+}

--- a/crates/graze-api/src/algorithm/scorer.rs
+++ b/crates/graze-api/src/algorithm/scorer.rs
@@ -131,6 +131,10 @@ impl ScoringResult {
 pub struct Scorer {
     redis: Arc<RedisClient>,
     liker_cache: Arc<LikerCache>,
+    /// Per-algorithm candidate pool, cached because `SMEMBERS ap:{algo_id}` was costing 71-107 ms
+    /// per request for data that is identical across every user of the feed and static between
+    /// candidate-sync runs.
+    pool_cache: Arc<crate::algorithm::PoolCache>,
     min_post_likes: usize,
     max_likers_per_post: usize,
     max_posts_to_score: usize,
@@ -153,10 +157,16 @@ pub struct Scorer {
 
 impl Scorer {
     /// Create a new scorer.
-    pub fn new(redis: Arc<RedisClient>, liker_cache: Arc<LikerCache>, config: Arc<Config>) -> Self {
+    pub fn new(
+        redis: Arc<RedisClient>,
+        liker_cache: Arc<LikerCache>,
+        config: Arc<Config>,
+        pool_cache: Arc<crate::algorithm::PoolCache>,
+    ) -> Self {
         Self {
             redis,
             liker_cache,
+            pool_cache,
             min_post_likes: config.inverted_min_post_likes,
             max_likers_per_post: config.inverted_max_likers_per_post,
             max_posts_to_score: config.inverted_max_posts_to_score,
@@ -960,14 +970,41 @@ impl Scorer {
         } else {
             -1
         };
-        let (algo_posts_result, user_likes_result, seen_posts_result) = tokio::join!(
-            self.redis.smembers(&algo_posts_key),
-            self.redis
-                .zrevrangebyscore_merged(&user_likes_keys, now, min_time, fetch_limit),
-            self.redis.zrevrange(&user_seen_key, 0, seen_limit)
-        );
+        // The pool is the one fetch here that is shared across every user of this feed, so it is
+        // served from cache when fresh and only the two user-specific reads stay on the hot path.
+        let cached_pool = self.pool_cache.get(algo_id);
+        let (algo_posts, user_likes_result, seen_posts_result) = match cached_pool {
+            Some(pool) => {
+                let (user_likes_result, seen_posts_result) = tokio::join!(
+                    self.redis.zrevrangebyscore_merged(
+                        &user_likes_keys,
+                        now,
+                        min_time,
+                        fetch_limit
+                    ),
+                    self.redis.zrevrange(&user_seen_key, 0, seen_limit)
+                );
+                (pool, user_likes_result, seen_posts_result)
+            }
+            None => {
+                let (algo_posts_result, user_likes_result, seen_posts_result) = tokio::join!(
+                    self.redis.smembers(&algo_posts_key),
+                    self.redis.zrevrangebyscore_merged(
+                        &user_likes_keys,
+                        now,
+                        min_time,
+                        fetch_limit
+                    ),
+                    self.redis.zrevrange(&user_seen_key, 0, seen_limit)
+                );
+                let fetched: Arc<Vec<String>> = Arc::new(algo_posts_result?);
+                // Cache even an empty pool: a feed mid-sync would otherwise re-issue the full
+                // SMEMBERS on every request precisely while it is least able to answer it.
+                self.pool_cache.put(algo_id, fetched.clone());
+                (fetched, user_likes_result, seen_posts_result)
+            }
+        };
 
-        let algo_posts: Vec<String> = algo_posts_result?;
         let mut user_likes = user_likes_result?;
         let seen_posts: Vec<String> = seen_posts_result.unwrap_or_default();
 
@@ -1003,14 +1040,23 @@ impl Scorer {
         excluded_posts.extend(seen_posts);
 
         // Step 2: Filter posts (remove already liked or seen)
-        let mut candidates: Vec<String> = algo_posts
-            .into_iter()
-            .filter(|p| !excluded_posts.contains(p))
+        //
+        // `take` rather than collect-then-truncate. The previous form allocated a Vec of every
+        // non-excluded post -- up to ~39,000 for the largest pools -- and then discarded all but
+        // `max_posts_to_score` of it. Short-circuiting keeps the identical result (the first N
+        // non-excluded posts in iteration order) while allocating only N, which more than pays for
+        // cloning out of the shared pool rather than consuming it.
+        let take_n = if self.max_posts_to_score > 0 {
+            self.max_posts_to_score
+        } else {
+            usize::MAX
+        };
+        let candidates: Vec<String> = algo_posts
+            .iter()
+            .filter(|p| !excluded_posts.contains(p.as_str()))
+            .take(take_n)
+            .cloned()
             .collect();
-
-        if self.max_posts_to_score > 0 && candidates.len() > self.max_posts_to_score {
-            candidates.truncate(self.max_posts_to_score);
-        }
 
         if candidates.is_empty() {
             return Ok(ScoringResult {

--- a/crates/graze-api/src/config.rs
+++ b/crates/graze-api/src/config.rs
@@ -347,6 +347,12 @@ pub struct Config {
     // ═══════════════════════════════════════════════════════════════════════════════
     // Author-Affinity Configuration
     // ═══════════════════════════════════════════════════════════════════════════════
+    /// TTL for the per-algorithm candidate-pool cache. `0` disables it, which is the rollback
+    /// path: it restores fetching `ap:{algo_id}` on every request without a rebuild.
+    pub pool_cache_ttl_seconds: u64,
+    /// Total cached pool members across all algos. Bounded on members rather than entries because
+    /// pools range from 1 to ~40,000, so an entry cap would bound almost nothing.
+    pub pool_cache_max_members: usize,
     pub author_affinity_enabled: bool,
     pub max_liked_authors_per_user: usize,
     pub max_likers_per_author: usize,
@@ -654,6 +660,8 @@ impl Config {
             linklonk_normalization_enabled: parse_bool_env("LINKLONK_NORMALIZATION_ENABLED", true),
 
             // Author-Affinity
+            pool_cache_ttl_seconds: parse_u64_env("POOL_CACHE_TTL_SECONDS", 30),
+            pool_cache_max_members: parse_usize_env("POOL_CACHE_MAX_MEMBERS", 600_000),
             author_affinity_enabled: parse_bool_env("AUTHOR_AFFINITY_ENABLED", true),
             max_liked_authors_per_user: parse_usize_env("MAX_LIKED_AUTHORS_PER_USER", 500),
             max_likers_per_author: parse_usize_env("MAX_LIKERS_PER_AUTHOR", 1000),


### PR DESCRIPTION
`Scorer::score` fetched the **entire `ap:{algo_id}` set with `SMEMBERS` on every request**.

Measured on prod: 56 live pools, median 4,554 members, max 39,959, and `SMEMBERS` costs **71–107 ms** on the large ones — for data that is identical across every user of the feed and static between candidate-sync runs (`SCARD` on the five largest pools drifted by **exactly zero** over 20 s). No pool cache existed anywhere.

## Why it matters beyond latency

That cost is why **40.1% of personalized responses breach the 500 ms Thompson speed gate** — which marks them as bandit **failures** even when they personalized perfectly well, since `success = personalization && richness && speed` requires all three.

Production over 24h:

| | p50 | p95 | over gate |
|---|---:|---:|---:|
| personalized | 389 ms | 1,642 ms | **40.1%** |
| non-personalized | 74 ms | 550 ms | 6.7% |

Simulating a 100 ms saving moves the breach from **40.0% → 32.6%**. Partial, not total — see below.

## Two causes ruled out first rather than assumed

- **CPU throttling:** 3,402 of 95,267 CFS periods throttled (**3.6%**) at the 500m limit. Real but far too small to explain a 40% breach.
- **Source count:** `total_scored` saturates at a hard cap of 500, so latency does not scale with `max_total_sources` (#22).

## Design notes

**Shared between the live and durable-profile scorers, deliberately unlike `LikerCache`.** That separation exists because liker lists depend on `max_likers_per_post`, so sharing would leak one arm's longer lists into the other. A candidate pool is the same Redis set whatever the params.

**Bounded on total members, not entry count** — pools range from 1 to ~40,000, so an entry cap would bound almost nothing. Default 600k members ≈ 25–40 MB against a 2 GiB limit with ~400 MiB in use.

**`POOL_CACHE_TTL_SECONDS=0` disables it entirely**, restoring the previous behaviour with an env edit and no rebuild.

**Deadlock note:** `get()` drops its DashMap guard before removing an expired entry. Holding a reference across a `remove` on the same shard is the class of bug the network-cache port hit with its handle dedup.

## Bonus: candidate allocation was unbounded

The `Arc` change surfaced this. The old form collected **every** non-excluded post into a `Vec` — up to ~39,000 for the largest pools — then truncated to `max_posts_to_score`. It now short-circuits with `take()`, allocating only N. Identical result, and it more than pays for cloning out of the shared pool rather than consuming it.

> Worth noting separately: only the first ~500 of up to 39,000 candidates are ever scored, selected in **arbitrary Redis-set order** with no quality ordering. That is pre-existing and out of scope here, but it looks like a real quality lever.

## Testing

204 tests passing (6 new covering TTL expiry, the disable path, the member bound, oversized pools, replacement accounting, and hit/miss stats). `cargo fmt --check` and `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)