### PR TITLE
Allow on-demand Docker builds without cutting a release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -3,6 +3,21 @@ name: Release Docker Build
 on:
   release:
     types: [published]
+  # On-demand builds, so shipping a change does not require cutting a release.
+  #
+  # Without this the only way to produce an amd64 image was a local build, and this repo's
+  # Dockerfiles have no cargo cache mounts -- so every iteration was a full cold Rust compile
+  # under QEMU on an arm64 dev host (~15 min, load ~9). These runners are natively amd64, so the
+  # same build needs no emulation at all.
+  #
+  # A dispatch build has no semver tag to derive from, so it publishes `latest` and the short SHA;
+  # deploy by digest rather than by either of those, since both are mutable.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (defaults to the branch this is dispatched on)"
+        required: false
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
@@ -14,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
The only trigger was a **published release**, so shipping any change required either cutting a GitHub release or building locally — and this repo's Dockerfiles have **no cargo cache mounts**, so every local iteration is a full cold Rust compile under QEMU on an arm64 dev host (~15 min, load average ~9).

These runners are natively amd64, so the same build needs **no emulation at all**.

- Adds `workflow_dispatch` with an optional `ref` input
- Checkout honours `inputs.ref || github.ref`

A dispatch build has no semver tag to derive from, so it publishes `latest` and the short SHA. **Deploy by digest** rather than either, since both are mutable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)