### PR TITLE
Drop the vestigial SSH deploy key from the Docker build

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -46,11 +46,6 @@ jobs:
       - name: Log in to DigitalOcean Container Registry
         run: doctl registry login --expiry-seconds 600
 
-      - name: Set up SSH agent for deploy key
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY_STUDIOUS_GUIDE }}
-
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -72,6 +67,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_HASH=${{ github.sha }}
-          ssh: default
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
The workflow set up an ssh-agent from `DEPLOY_KEY_STUDIOUS_GUIDE` and passed `ssh: default` to the build, but **nothing needs it** — neither the workspace `Cargo.toml` nor any crate manifest declares a git or ssh dependency, so the build never resolves anything over SSH.

It is not merely dead, it is **blocking**: `webfactory/ssh-agent` fails on an empty key, and this repo currently has no secrets at all, so the step aborts every dispatch build before it reaches the actual build.

Removing it reduces the workflow's requirement to exactly one secret: `DIGITALOCEAN_ACCESS_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)