### PR TITLE
Allowlist the kubelet probe paths, so probes can actually be added

### DIFF
--- a/crates/graze-api/src/api/auth.rs
+++ b/crates/graze-api/src/api/auth.rs
@@ -15,12 +15,26 @@ use std::sync::Arc;
 
 use crate::AppState;
 
-/// Paths that do not require the admin API key (ATProto and well-known).
+/// Paths that do not require the admin API key (ATProto, well-known, and kubelet probes).
+///
+/// The `/internal/*` probes are here because **a kubelet probe cannot authenticate**. Without this
+/// they return 401, which a probe reads as failure. That is not theoretical: `kube/api-deployment.yaml`
+/// declares a readinessProbe on `/internal/ready`, and applying it would have failed readiness on
+/// every replica at once and emptied the Service — a self-inflicted total outage. The live deployment
+/// consequently ran with no probes at all, so Kubernetes marked pods Ready the instant the container
+/// started and routed traffic to them before the HTTP listener was accepting connections.
+///
+/// Nothing here discloses anything sensitive: `started` and `alive` are static 200s, and `ready`
+/// reports only whether Redis answers a ping — which is precisely the fact a load balancer needs and
+/// no more than an unauthenticated caller learns by observing whether requests succeed.
 const ALLOWLISTED_PATHS: &[&str] = &[
     "/.well-known/did.json",
     "/xrpc/app.bsky.feed.describeFeedGenerator",
     "/xrpc/app.bsky.feed.getFeedSkeleton",
     "/xrpc/app.bsky.feed.sendInteractions",
+    "/internal/started",
+    "/internal/alive",
+    "/internal/ready",
 ];
 
 /// Constant-time equality to reduce timing side channels.
@@ -91,4 +105,40 @@ pub async fn require_admin_api_key(
             .into_response();
     }
     next.run(request).await
+}
+
+#[cfg(test)]
+mod probe_allowlist_tests {
+    use super::ALLOWLISTED_PATHS;
+
+    /// A kubelet probe carries no credentials, so every probe path must be allowlisted or the probe
+    /// fails closed and takes the replica out of the Service. Measured before this change: all
+    /// three returned 401, which is why the live deployment ran with no probes at all.
+    #[test]
+    fn every_kubelet_probe_path_is_allowlisted() {
+        for p in ["/internal/started", "/internal/alive", "/internal/ready"] {
+            assert!(
+                ALLOWLISTED_PATHS.contains(&p),
+                "{p} must not require the admin key: a probe cannot supply one"
+            );
+        }
+    }
+
+    /// The allowlist is exact-match, and must stay that way. This guards against someone later
+    /// replacing the entries with a prefix like "/internal" and exposing admin surfaces with it.
+    #[test]
+    fn admin_and_scoring_paths_are_not_allowlisted() {
+        for p in [
+            "/v1/personalize",
+            "/v1/invalidate",
+            "/v1/thompson/stats",
+            "/metrics",
+            "/internal",
+        ] {
+            assert!(
+                !ALLOWLISTED_PATHS.contains(&p),
+                "{p} must keep requiring the admin key"
+            );
+        }
+    }
 }


### PR DESCRIPTION
`/internal/started`, `/internal/alive` and `/internal/ready` **all returned 401** — they sit behind `require_admin_api_key`, and a kubelet probe carries no credentials.

## This is why the service has no probes

`kube/api-deployment.yaml` declares a `readinessProbe` on `/internal/ready`. Applying it would have failed readiness on **every replica simultaneously and emptied the Service** — a self-inflicted total outage. Someone evidently tried and backed it out.

The consequence of running with no probes: Kubernetes marks a pod Ready the instant the container starts, so traffic is routed to it **before the HTTP listener accepts connections**. Every rollout drops requests.

## Why allowlisting is safe here

Nothing added discloses anything sensitive. `started` and `alive` are static 200s. `ready` reports only whether Redis answers a ping — precisely what a load balancer needs, and no more than an unauthenticated caller learns by observing whether requests succeed.

## Tests

Two: every probe path is allowlisted, and admin/scoring paths are **not**. The second matters because the allowlist is exact-match and must stay that way — a later `"/internal"` prefix would expose admin surfaces through it.

## Deliberately code-only

The probes themselves are a **separate step that must land after this image is serving**, or the outage described above is exactly what happens.

## Adjacent finding, not fixed here

The Prometheus annotation in the repo manifest targets `8080/metrics`, which **also 401s**. The unauthenticated metrics server is on `8081`, and the live deployment carries no scrape annotation at all — consistent with `/metrics` having been recorded as dead.

149 tests passing (2 new), fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)