### PR TITLE
Correct the probes in the manifest to what is actually deployed

### DIFF
--- a/kube/api-deployment.yaml
+++ b/kube/api-deployment.yaml
@@ -107,21 +107,34 @@ spec:
                 configMapKeyRef:
                   name: graze-personalization-config
                   key: default-max-likers-per-post
-          livenessProbe:
-            httpGet:
-              path: /internal/alive
-              port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
+          # startupProbe, NOT readinessProbe, for the Redis-dependent check.
+          #
+          # /internal/ready returns 503 when a Redis ping fails. All replicas share one Valkey, so
+          # as a readinessProbe a single blip fails readiness on every pod simultaneously and empties
+          # the Service -- a correlated total outage, strictly worse than serving degraded responses.
+          # This repo already has that failure mode on record elsewhere: a readiness check tied to an
+          # upstream dependency is what wedged network-cache on grazer-prod2 for hours.
+          #
+          # As a startupProbe it gates initial traffic until Redis is connected and is then never
+          # evaluated again, so a later blip cannot take pods out of rotation. 3s x 40 = up to 120s
+          # to connect before the pod is failed.
+          startupProbe:
             httpGet:
               path: /internal/ready
               port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            periodSeconds: 3
             timeoutSeconds: 3
+            failureThreshold: 40
+          # /internal/alive is a static 200, so it cannot correlate-fail on a dependency. This is
+          # what actually fixes the rollout gap: without any readinessProbe, Kubernetes marks a pod
+          # Ready the instant the container starts and routes traffic to it before the HTTP listener
+          # is accepting connections.
+          readinessProbe:
+            httpGet:
+              path: /internal/alive
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
This file declared a `readinessProbe` on `/internal/ready`, which was a **landmine**.

That endpoint returns 503 when a Redis ping fails, and all replicas share one Valkey — so as a `readinessProbe` a single blip fails readiness on **every pod at once and empties the Service**. A correlated total outage, strictly worse than serving degraded responses. This repo has the failure mode on record elsewhere: a readiness check tied to an upstream dependency is what wedged network-cache on grazer-prod2 for hours.

And until #26 it could not have fired at all, because every `/internal/*` path returned **401** behind `require_admin_api_key`. Applying this manifest would have failed readiness on all three pods instantly — the most likely reason the live deployment ran with no probes.

## Replaced with what was actually deployed and verified

- **`startupProbe` on `/internal/ready`** — gates initial traffic until Redis is connected, then is never evaluated again, so a later blip cannot remove pods from rotation. `3s × 40` = up to 120s to connect.
- **`readinessProbe` on `/internal/alive`** — a static 200, so it cannot correlate-fail on a dependency. This is what fixes the rollout gap.

## Why the livenessProbe is dropped rather than ported

Nothing measured indicated a wedged listener, and a liveness probe sharing the same tokio runtime as requests can restart pods during a latency spike — and this service had **40% of personalized responses over 500ms** until an hour ago.

## Verified live

3/3 pods ready, **3 Service endpoints**, no `Unhealthy` events, zero errors.

## Not fixed here, still drifted

This manifest declares `image: dgaff/graze-personalization:latest` while the live deployment runs a DOCR digest. Patch the live deployment rather than applying this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)