### PR TITLE
Build follow-graph seeds for users the co-liker engine cannot reach

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY --from=builder /app/target/release/graze-like-streamer /app/graze-like-stre
 COPY --from=builder /app/target/release/graze-candidate-sync /app/graze-candidate-sync
 # Phase A of the durable co-liker profile design; built by -p graze-candidate-sync.
 COPY --from=builder /app/target/release/graze-build-coliker-profiles /app/graze-build-coliker-profiles
+COPY --from=builder /app/target/release/graze-build-follow-seeds /app/graze-build-follow-seeds
 COPY --from=builder /app/target/release/graze-backfill-ula /app/graze-backfill-ula
 COPY --from=builder /app/target/release/graze-backfill /app/graze-backfill
 COPY --from=builder /app/target/release/graze-frontdoor /app/graze-frontdoor

--- a/Dockerfile.iter
+++ b/Dockerfile.iter
@@ -45,6 +45,7 @@ WORKDIR /app
 COPY --from=builder /app/target/release/graze-api /app/graze-api
 COPY --from=builder /app/target/release/graze-candidate-sync /app/graze-candidate-sync
 COPY --from=builder /app/target/release/graze-build-coliker-profiles /app/graze-build-coliker-profiles
+COPY --from=builder /app/target/release/graze-build-follow-seeds /app/graze-build-follow-seeds
 
 COPY lua ./lua
 

--- a/crates/graze-candidate-sync/Cargo.toml
+++ b/crates/graze-candidate-sync/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/main.rs"
 name = "graze-build-coliker-profiles"
 path = "src/bin/build_coliker_profiles.rs"
 
+[[bin]]
+name = "graze-build-follow-seeds"
+path = "src/bin/build_follow_seeds.rs"
+
 [lib]
 name = "graze_candidate_sync"
 path = "src/lib.rs"

--- a/crates/graze-candidate-sync/src/bin/build_follow_seeds.rs
+++ b/crates/graze-candidate-sync/src/bin/build_follow_seeds.rs
@@ -1,0 +1,86 @@
+//! Build follow-graph seeds (`uf:{hash}`) for users the co-liker engine cannot reach.
+//!
+//! Phase A of the follow-seeding plan in `DESIGN-coverage-next-lever-2026-08.md`: this writes `uf:`
+//! keys and nothing else. No read path consumes them, so it cannot change what any user is served.
+//!
+//! Targets are selected from ClickHouse as the DIDs actually turned away with
+//! `fallback_reason='no_user_data'` — which is only selectable because that reason now reaches the
+//! provenance blob rather than living in a log line.
+//!
+//! Usage — always rehearse first:
+//!   FOLLOW_SEED_DRY_RUN=1 FOLLOW_SEED_MAX_USERS=50 \
+//!     cargo run --release --bin graze-build-follow-seeds
+//!
+//! Environment variables:
+//!   REDIS_URL                        Redis connection URL (required)
+//!   CLICKHOUSE_HOST/_PORT/...        ClickHouse connection (graze-candidate-sync config)
+//!   FOLLOW_SEED_DRY_RUN              Report only, write nothing (default: false)
+//!   FOLLOW_SEED_APPVIEW_BASE         AppView base (default: https://public.api.bsky.app)
+//!   FOLLOW_SEED_MAX_FOLLOWS          Follows stored per user (default: 100)
+//!   FOLLOW_SEED_MIN_FOLLOWS          Below this, store a miss marker instead (default: 10)
+//!   FOLLOW_SEED_TTL_DAYS             TTL on uf: keys (default: 30)
+//!   FOLLOW_SEED_MISS_TTL_HOURS       Retry cadence for unusable accounts (default: 24)
+//!   FOLLOW_SEED_MAX_USERS            Per-run target cap (default: 5000)
+//!   FOLLOW_SEED_REQUEST_DELAY_MS     Delay between AppView calls (default: 150)
+//!   FOLLOW_SEED_LOOKBACK_DAYS        How far back to select targets (default: 7)
+//!   FOLLOW_SEED_QUERY_TIMEOUT_SECS   ClickHouse timeout (default: 300)
+
+use std::sync::Arc;
+
+use tracing::{info, Level};
+use tracing_subscriber::EnvFilter;
+
+use graze_candidate_sync::config::Config;
+use graze_candidate_sync::follow_seeds::{FollowSeedBuilder, FollowSeedConfig};
+use graze_common::clickhouse::ClickHouseConfig;
+use graze_common::RedisClient;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(Level::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let config = Config::from_env();
+    let seed_config = FollowSeedConfig::from_env();
+
+    // Constructed exactly as build_coliker_profiles does, so both binaries read the same
+    // graze-candidate-sync config rather than diverging on connection details.
+    let clickhouse = Arc::new(ClickHouseConfig {
+        host: config.clickhouse_host.clone(),
+        port: config.clickhouse_port,
+        database: config.clickhouse_database.clone(),
+        user: config.clickhouse_user.clone(),
+        password: config.clickhouse_password.clone(),
+        secure: config.clickhouse_secure,
+    });
+    let redis = Arc::new(RedisClient::new(&config.redis_config()).await?);
+
+    info!(
+        dry_run = seed_config.dry_run,
+        max_users = seed_config.max_users,
+        min_follows = seed_config.min_follows,
+        ttl_days = seed_config.ttl_days,
+        lookback_days = seed_config.lookback_days,
+        "build_follow_seeds_starting"
+    );
+
+    let builder = FollowSeedBuilder::new(clickhouse, redis, seed_config)?;
+    let stats = builder.run().await?;
+
+    info!(
+        targets = stats.targets,
+        written = stats.written,
+        mean_follows = stats.mean_follows(),
+        already_seeded = stats.already_seeded,
+        already_missed = stats.already_missed,
+        too_few_follows = stats.too_few_follows,
+        fetch_errors = stats.fetch_errors,
+        "build_follow_seeds_done"
+    );
+    Ok(())
+}

--- a/crates/graze-candidate-sync/src/follow_seeds.rs
+++ b/crates/graze-candidate-sync/src/follow_seeds.rs
@@ -1,0 +1,391 @@
+//! Follow-graph seeds (`uf:{hash}`) for users the co-liker engine structurally cannot reach.
+//!
+//! **Phase A: this writes `uf:` keys and nothing else.** No read path consumes them, so it cannot
+//! change what any user is served. Same shape as Phase A of the durable co-liker profiles, and for
+//! the same reason — the write side can be validated on production data at zero serving risk.
+//!
+//! Why follows. Measured 2026-08-27 (`DESIGN-coverage-next-lever-2026-08.md`): `no_user_data` is
+//! **98.1% of addressable non-personalization**, 100.0% in 22 of 24 hours. Of the users it turns
+//! away, **73.6% have zero likes in 365 days** — and the engine seeds exclusively from likes, so
+//! nothing built from like history reaches them (durable profiles cap out at 3.7% for exactly this
+//! reason). But **86% of them follow 10+ accounts, median 50**. Follows are the one available seed
+//! that does not require a like history.
+//!
+//! Cost is already measured and acceptable: 59 followed authors fan out to ~2,530 unique sources at
+//! 354 Redis ops and 90 ms, against 6 authors / 410 sources / 40 ops for the like path. That runs
+//! roughly once per user per hour behind `AUTHOR_AFFINITY_TTL_SECONDS`, not per request, and the
+//! downstream scoring cost is bounded by the 500-post `total_scored` cap.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+
+use graze_common::clickhouse::ClickHouseConfig;
+use graze_common::{hash_did, Keys, RedisClient};
+
+/// Users turned away with `no_user_data` — the exact cohort follows are meant to reach.
+///
+/// This query is only possible because `fallback_reason` reaches the provenance blob; before that
+/// the reason existed solely in a log line and the cohort could not be selected at all.
+const TARGET_QUERY: &str = r#"
+SELECT DISTINCT did
+FROM {database:Identifier}.feed_interactions
+WHERE occurred >= {from:DateTime}
+  AND interaction_feed_context != ''
+  AND JSONHas(tryBase64Decode(interaction_feed_context), 'algo_id')
+  AND JSONExtractString(tryBase64Decode(interaction_feed_context), 'fallback_reason') = 'no_user_data'
+LIMIT {limit:UInt32}
+FORMAT JSON
+"#;
+
+#[derive(Debug, Clone)]
+pub struct FollowSeedConfig {
+    /// Report what would be written, write nothing.
+    pub dry_run: bool,
+    pub appview_base: String,
+    /// Follows kept per user. Matches `AUTHOR_AFFINITY_MAX_AUTHORS`, since the seed step caps
+    /// there anyway — storing more would be dead weight.
+    pub max_follows: usize,
+    /// Below this a seed is not worth storing. 10 is the threshold the 86% figure was measured at.
+    pub min_follows: usize,
+    /// TTL on `uf:` keys. Deliberately long: follows are far more stable than likes, and the
+    /// durable-profile post-mortem is the specification for getting this wrong — a 7-day TTL there
+    /// expired silently and would have produced a null read as "the idea does not work".
+    pub ttl_days: u32,
+    /// Retry cadence for users whose fetch produced nothing usable.
+    pub miss_ttl_hours: u32,
+    pub max_users: usize,
+    /// Politeness delay between AppView calls.
+    pub request_delay_ms: u64,
+    pub lookback_days: u32,
+    pub query_timeout_secs: u64,
+}
+
+impl Default for FollowSeedConfig {
+    fn default() -> Self {
+        Self {
+            dry_run: false,
+            appview_base: "https://public.api.bsky.app".to_string(),
+            max_follows: 100,
+            min_follows: 10,
+            ttl_days: 30,
+            miss_ttl_hours: 24,
+            max_users: 5_000,
+            request_delay_ms: 150,
+            lookback_days: 7,
+            query_timeout_secs: 300,
+        }
+    }
+}
+
+fn env_u32(key: &str, default: u32) -> u32 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+impl FollowSeedConfig {
+    pub fn from_env() -> Self {
+        let d = Self::default();
+        Self {
+            dry_run: std::env::var("FOLLOW_SEED_DRY_RUN")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(d.dry_run),
+            appview_base: std::env::var("FOLLOW_SEED_APPVIEW_BASE").unwrap_or(d.appview_base),
+            max_follows: env_u32("FOLLOW_SEED_MAX_FOLLOWS", d.max_follows as u32) as usize,
+            min_follows: env_u32("FOLLOW_SEED_MIN_FOLLOWS", d.min_follows as u32) as usize,
+            ttl_days: env_u32("FOLLOW_SEED_TTL_DAYS", d.ttl_days),
+            miss_ttl_hours: env_u32("FOLLOW_SEED_MISS_TTL_HOURS", d.miss_ttl_hours),
+            max_users: env_u32("FOLLOW_SEED_MAX_USERS", d.max_users as u32) as usize,
+            request_delay_ms: env_u32("FOLLOW_SEED_REQUEST_DELAY_MS", d.request_delay_ms as u32)
+                as u64,
+            lookback_days: env_u32("FOLLOW_SEED_LOOKBACK_DAYS", d.lookback_days),
+            query_timeout_secs: env_u32(
+                "FOLLOW_SEED_QUERY_TIMEOUT_SECS",
+                d.query_timeout_secs as u32,
+            ) as u64,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FollowSeedStats {
+    pub targets: usize,
+    pub already_seeded: usize,
+    pub already_missed: usize,
+    pub fetched: usize,
+    pub written: usize,
+    pub too_few_follows: usize,
+    pub fetch_errors: usize,
+    pub follows_total: usize,
+}
+
+impl FollowSeedStats {
+    pub fn mean_follows(&self) -> f64 {
+        if self.written == 0 {
+            0.0
+        } else {
+            self.follows_total as f64 / self.written as f64
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct TargetRow {
+    did: String,
+}
+
+#[derive(Deserialize)]
+struct ChResponse {
+    data: Vec<TargetRow>,
+}
+
+#[derive(Deserialize)]
+struct FollowEntry {
+    did: String,
+}
+
+#[derive(Deserialize)]
+struct FollowsResponse {
+    #[serde(default)]
+    follows: Vec<FollowEntry>,
+}
+
+pub struct FollowSeedBuilder {
+    clickhouse: Arc<ClickHouseConfig>,
+    redis: Arc<RedisClient>,
+    http: reqwest::Client,
+    config: FollowSeedConfig,
+}
+
+impl FollowSeedBuilder {
+    pub fn new(
+        clickhouse: Arc<ClickHouseConfig>,
+        redis: Arc<RedisClient>,
+        config: FollowSeedConfig,
+    ) -> anyhow::Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(20))
+            .user_agent("graze-personalization/follow-seeds")
+            .build()?;
+        Ok(Self {
+            clickhouse,
+            redis,
+            http,
+            config,
+        })
+    }
+
+    /// DIDs turned away with `no_user_data` in the lookback window.
+    pub async fn target_dids(&self) -> anyhow::Result<Vec<String>> {
+        let from = (chrono::Utc::now()
+            - chrono::Duration::days(self.config.lookback_days.max(1) as i64))
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string();
+
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(Duration::from_secs(self.config.query_timeout_secs))
+            .query(&[
+                (
+                    "max_execution_time",
+                    self.config.query_timeout_secs.to_string().as_str(),
+                ),
+                ("param_database", self.clickhouse.database.as_str()),
+                ("param_from", from.as_str()),
+                ("param_limit", &self.config.max_users.to_string()),
+            ])
+            .body(TARGET_QUERY)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "target query failed ({}): {}",
+                status,
+                &body[..body.len().min(600)]
+            );
+        }
+        let parsed: ChResponse = response.json().await?;
+        Ok(parsed.data.into_iter().map(|r| r.did).collect())
+    }
+
+    /// Followed DIDs for one actor, capped at `max_follows`.
+    ///
+    /// One page is enough by construction: the cap equals `AUTHOR_AFFINITY_MAX_AUTHORS`, which is
+    /// also the AppView's page limit, so pagination would fetch authors the seed step discards.
+    async fn fetch_follows(&self, did: &str) -> anyhow::Result<Vec<String>> {
+        let url = format!(
+            "{}/xrpc/app.bsky.graph.getFollows",
+            self.config.appview_base.trim_end_matches('/')
+        );
+        let response = self
+            .http
+            .get(&url)
+            .query(&[
+                ("actor", did),
+                ("limit", &self.config.max_follows.min(100).to_string()),
+            ])
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            anyhow::bail!("getFollows {} -> {}", did, response.status());
+        }
+        let parsed: FollowsResponse = response.json().await?;
+        Ok(parsed
+            .follows
+            .into_iter()
+            .map(|f| f.did)
+            .take(self.config.max_follows)
+            .collect())
+    }
+
+    pub async fn run(&self) -> anyhow::Result<FollowSeedStats> {
+        let targets = self.target_dids().await?;
+        let mut stats = FollowSeedStats {
+            targets: targets.len(),
+            ..Default::default()
+        };
+        info!(
+            targets = stats.targets,
+            dry_run = self.config.dry_run,
+            "follow_seed_run_starting"
+        );
+
+        for did in targets {
+            let hash = hash_did(&did);
+            // Skip work we have already done. Checked per user rather than in bulk because the
+            // AppView call dominates by orders of magnitude, so two Redis EXISTS are free here.
+            if self.redis.exists(&Keys::user_follows(&hash)).await? {
+                stats.already_seeded += 1;
+                continue;
+            }
+            if self.redis.exists(&Keys::user_follows_miss(&hash)).await? {
+                stats.already_missed += 1;
+                continue;
+            }
+
+            let follows = match self.fetch_follows(&did).await {
+                Ok(f) => {
+                    stats.fetched += 1;
+                    f
+                }
+                Err(e) => {
+                    stats.fetch_errors += 1;
+                    warn!(error = %e, "follow_seed_fetch_failed");
+                    // Mark as a miss so a permanently broken account is not retried every run.
+                    if !self.config.dry_run {
+                        let _ = self
+                            .redis
+                            .set_ex(
+                                &Keys::user_follows_miss(&hash),
+                                "error",
+                                self.config.miss_ttl_hours as u64 * 3600,
+                            )
+                            .await;
+                    }
+                    tokio::time::sleep(Duration::from_millis(self.config.request_delay_ms)).await;
+                    continue;
+                }
+            };
+
+            if follows.len() < self.config.min_follows {
+                stats.too_few_follows += 1;
+                if !self.config.dry_run {
+                    self.redis
+                        .set_ex(
+                            &Keys::user_follows_miss(&hash),
+                            "too_few",
+                            self.config.miss_ttl_hours as u64 * 3600,
+                        )
+                        .await?;
+                }
+            } else {
+                let author_hashes: Vec<String> = follows.iter().map(|d| hash_did(d)).collect();
+                stats.written += 1;
+                stats.follows_total += author_hashes.len();
+                if !self.config.dry_run {
+                    let items: Vec<(f64, &str)> =
+                        author_hashes.iter().map(|h| (1.0, h.as_str())).collect();
+                    let key = Keys::user_follows(&hash);
+                    self.redis.zadd(&key, &items).await?;
+                    self.redis
+                        .expire(&key, self.config.ttl_days as i64 * 86_400)
+                        .await?;
+                }
+                debug!(follows = author_hashes.len(), "follow_seed_written");
+            }
+
+            tokio::time::sleep(Duration::from_millis(self.config.request_delay_ms)).await;
+        }
+
+        info!(
+            targets = stats.targets,
+            written = stats.written,
+            mean_follows = stats.mean_follows(),
+            already_seeded = stats.already_seeded,
+            already_missed = stats.already_missed,
+            too_few_follows = stats.too_few_follows,
+            fetch_errors = stats.fetch_errors,
+            dry_run = self.config.dry_run,
+            "follow_seed_run_complete"
+        );
+        Ok(stats)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mean_follows_is_zero_rather_than_nan_when_nothing_was_written() {
+        let s = FollowSeedStats::default();
+        assert_eq!(s.mean_follows(), 0.0);
+    }
+
+    #[test]
+    fn mean_follows_averages_over_written_users_only() {
+        let s = FollowSeedStats {
+            written: 4,
+            follows_total: 200,
+            too_few_follows: 99,
+            ..Default::default()
+        };
+        assert_eq!(s.mean_follows(), 50.0);
+    }
+
+    /// The default TTL must outlive an experiment horizon. A 7-day TTL is what silently expired the
+    /// durable co-liker profiles between 8/18 and 8/27, leaving a flag that would have served
+    /// nothing and read as a refutation.
+    #[test]
+    fn default_ttl_outlives_an_experiment() {
+        let d = FollowSeedConfig::default();
+        assert!(
+            d.ttl_days >= 30,
+            "TTL {} days is too short to survive an experiment",
+            d.ttl_days
+        );
+        assert!(d.miss_ttl_hours <= 48, "misses must be retried promptly");
+    }
+
+    /// Storing more follows than the seed step reads would be dead weight.
+    #[test]
+    fn max_follows_matches_the_author_affinity_cap() {
+        assert_eq!(FollowSeedConfig::default().max_follows, 100);
+    }
+
+    #[test]
+    fn min_follows_matches_the_measured_threshold() {
+        // 86% of the unreachable cohort has >=10 follows; that is the threshold measured.
+        assert_eq!(FollowSeedConfig::default().min_follows, 10);
+    }
+}

--- a/crates/graze-candidate-sync/src/lib.rs
+++ b/crates/graze-candidate-sync/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod coliker_profiles;
 pub mod config;
+pub mod follow_seeds;
 pub mod metrics;
 pub mod sync;
 

--- a/crates/graze-common/src/redis/keys.rs
+++ b/crates/graze-common/src/redis/keys.rs
@@ -547,6 +547,33 @@ impl Keys {
         format!("ucl:{}", user_did_hash)
     }
 
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Follow-graph seed keys
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    /// Hashed authors this user FOLLOWS, as a seed for users with no like history.
+    ///
+    /// Measured 2026-08-27: `no_user_data` is 98.1% of addressable non-personalization, and 73.6%
+    /// of those users have zero likes in 365 days. The engine seeds exclusively from likes, so they
+    /// are structurally unreachable by it — but 86% of them follow 10+ accounts (median 50).
+    /// Follows are the one seed that does not require a like history.
+    ///
+    /// Scores are a uniform placeholder: a follow carries no strength signal the way a like count
+    /// does, and picking the real weight is a separate decision (see
+    /// `DESIGN-coverage-next-lever-2026-08.md`).
+    pub fn user_follows(user_did_hash: &str) -> String {
+        format!("uf:{}", user_did_hash)
+    }
+
+    /// Marker that a follow fetch was attempted and produced nothing usable.
+    ///
+    /// Exists because an empty ZSET cannot persist in Redis, so the absence of `uf:` cannot
+    /// distinguish "never tried" from "tried, no follows". Without it every run would re-fetch the
+    /// same unusable accounts forever. Carries a short TTL so genuine new follows are picked up.
+    pub fn user_follows_miss(user_did_hash: &str) -> String {
+        format!("uf:miss:{}", user_did_hash)
+    }
+
     /// DEPRECATED: Use author_likers_date() for new writes.
     #[inline]
     pub fn author_likers_day(author_did_hash: &str, day: u8) -> String {


### PR DESCRIPTION
**Phase A: writes `uf:{hash}` keys and nothing else.** No read path consumes them, so this cannot change what any user is served — same shape and reasoning as Phase A of the durable co-liker profiles.

## Why follows

`no_user_data` is **98.1% of addressable non-personalization**, 100.0% in 22 of 24 hours. Of the users it turns away, **73.6% have zero likes in 365 days** — and the engine seeds exclusively from likes, so nothing built from like history reaches them (which is why durable profiles cap out at 3.7%).

But **86% of them follow 10+ accounts, median 50.** Follows are the one available seed that does not require a like history.

Targets come from ClickHouse as the DIDs actually turned away with `fallback_reason=no_user_data` — a selection only possible because that reason now reaches the provenance blob instead of living in a log line.

## Cost, already measured

59 followed authors fan out to ~2,530 unique sources at 354 Redis ops and 90 ms, versus 6 authors / 410 sources / 40 ops for the like path. That runs about **once per user per hour** behind `AUTHOR_AFFINITY_TTL_SECONDS`, not per request, and downstream scoring is bounded by the 500-post `total_scored` cap.

## Design points

- **Default TTL is 30 days, and a test asserts ≥30.** A 7-day TTL is exactly what silently expired the durable profiles between 8/18 and 8/27, leaving a flag that would have served nothing and read as a refutation.
- **`uf:miss:{hash}`** exists because an empty ZSET cannot persist in Redis, so the absence of `uf:` cannot distinguish *never tried* from *tried, no follows*. Without it every run re-fetches the same unusable accounts forever.
- **One AppView page suffices by construction**: the follow cap equals `AUTHOR_AFFINITY_MAX_AUTHORS`, which is also the page limit, so paginating would fetch authors the seed step discards.
- **No HTTP on the request path.** `reqwest` is deliberately absent from `graze-api`; this lives in `graze-candidate-sync`, which already has it.
- **Scores are a uniform 1.0 placeholder.** A follow carries no strength signal the way a like count does. Both the `min_author_likes >= 2` filter and the `user_like_count.sqrt()` weight need follow-specific replacements before any read path works — that is the next step, not this one.

## Testing

171 passing (5 new), `cargo fmt --check` and `cargo clippy -D warnings` clean. Both Dockerfiles ship the new binary.

Rehearse before writing anything:
```
FOLLOW_SEED_DRY_RUN=1 FOLLOW_SEED_MAX_USERS=50 graze-build-follow-seeds
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)