### PR TITLE
Phase B: read follow seeds, with a chosen weight rather than an inherited one

### DIFF
--- a/crates/graze-api/src/algorithm/author_affinity.rs
+++ b/crates/graze-api/src/algorithm/author_affinity.rs
@@ -25,6 +25,79 @@ use crate::config::Config;
 use crate::error::Result;
 use graze_common::{Keys, RedisClient, DEFAULT_RETENTION_DAYS};
 
+/// How a followed author is weighted when the seed came from follows rather than likes.
+///
+/// The like path weights each seed author by `sqrt(like_count)` -- more likes to an author is a
+/// stronger signal. A follow has no such count, so a weight has to be *chosen*. This is the whole
+/// reason follow-seeding is not a drop-in seed swap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FollowWeightMode {
+    /// Every followed author counts the same. Loses the affinity signal, but assumes nothing.
+    Uniform,
+    /// Weight `1/sqrt(|likers|)`: following a niche account says more about a user than following a
+    /// huge one. Same intuition as LinkLonk's fairness term, which production already relies on to
+    /// stop prolific likers dominating.
+    ///
+    /// ⚠️ The popularity proxy is the author's liker list as returned by the fan-out, which is
+    /// LIMITed to `AUTHOR_AFFINITY_MAX_LIKERS_PER_AUTHOR` (default 100). So every author at or above
+    /// that cap gets an identical weight, and the mode only discriminates below it -- precisely
+    /// where discrimination matters least. Reading true cardinality would cost another ZCARD per
+    /// author per date shard, roughly doubling the fan-out. Anyone evaluating this mode needs to
+    /// know the signal is compressed, rather than concluding from a null that the idea is wrong.
+    InversePopularity,
+}
+
+impl FollowWeightMode {
+    pub fn from_config(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "inverse_popularity" | "inverse" => Self::InversePopularity,
+            _ => Self::Uniform,
+        }
+    }
+}
+
+/// Which store the seed authors came from.
+enum Seed {
+    /// `(author_hash, like_count)` from `ula:`.
+    Likes(Vec<(String, f64)>),
+    /// `author_hash` from `uf:` -- no strength signal attached.
+    Follows(Vec<String>),
+}
+
+impl Seed {
+    fn author_hashes(&self) -> Vec<&str> {
+        match self {
+            Self::Likes(v) => v.iter().map(|(h, _)| h.as_str()).collect(),
+            Self::Follows(v) => v.iter().map(|h| h.as_str()).collect(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Likes(v) => v.len(),
+            Self::Follows(v) => v.len(),
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Likes(_) => "likes",
+            Self::Follows(_) => "follows",
+        }
+    }
+
+    /// Weight contributed by seed author `idx` to each of its likers.
+    fn weight_for(&self, idx: usize, liker_count: usize, mode: FollowWeightMode) -> f64 {
+        match self {
+            Self::Likes(v) => v[idx].1.sqrt(),
+            Self::Follows(_) => match mode {
+                FollowWeightMode::Uniform => 1.0,
+                FollowWeightMode::InversePopularity => 1.0 / (liker_count.max(1) as f64).sqrt(),
+            },
+        }
+    }
+}
+
 /// Computes and caches author-level co-liker aggregations for users.
 pub struct AuthorColikerWorker {
     redis: Arc<RedisClient>,
@@ -96,37 +169,56 @@ impl AuthorColikerWorker {
             .zrevrange_with_scores(&user_liked_authors_key, 0, (max_authors - 1) as isize)
             .await?;
 
-        if liked_authors.is_empty() {
-            debug!(
-                user_hash = %&user_hash[..8.min(user_hash.len())],
-                max_authors,
-                "early_exit: user has no liked authors"
-            );
-            return Ok(HashMap::new());
-        }
-
         // Filter authors with insufficient likes
         let liked_authors: Vec<(String, f64)> = liked_authors
             .into_iter()
             .filter(|(_, like_count)| *like_count >= min_author_likes as f64)
             .collect();
 
-        if liked_authors.is_empty() {
+        // Fall back to the follow graph when the like-based seed yields nothing usable.
+        //
+        // Note this covers BOTH previous early exits -- no liked authors at all, and none meeting
+        // min_author_likes. The filter is also why follows cannot reuse this path directly: a
+        // follow has no like count, so it would be rejected here and then weighted sqrt(0)=0.
+        //
+        // Measured: no_user_data is 98.1% of addressable non-personalization, 73.6% of those users
+        // have zero likes in 365 days, and 86% of them follow 10+ accounts (median 50).
+        let seed = if !liked_authors.is_empty() {
+            Seed::Likes(liked_authors)
+        } else if self.config.follow_seed_read_enabled {
+            let follows = self
+                .redis
+                .zrevrange(
+                    &Keys::user_follows(user_hash),
+                    0,
+                    (max_authors - 1) as isize,
+                )
+                .await?;
+            if follows.is_empty() {
+                debug!(
+                    user_hash = %&user_hash[..8.min(user_hash.len())],
+                    min_author_likes,
+                    "early_exit: no usable like seed and no follow seed"
+                );
+                return Ok(HashMap::new());
+            }
+            Seed::Follows(follows)
+        } else {
             debug!(
                 user_hash = %&user_hash[..8.min(user_hash.len())],
                 min_author_likes,
                 "early_exit: no authors meet min_author_likes threshold"
             );
             return Ok(HashMap::new());
-        }
+        };
+        let weight_mode = FollowWeightMode::from_config(&self.config.follow_seed_weight_mode);
 
         // Step 2: For each liked author, get other users who liked them (pipelined)
         // Build date-based key groups for each author
-        let author_key_groups: Vec<Vec<String>> = liked_authors
-            .iter()
-            .map(|(author_hash, _)| {
-                Keys::author_likers_retention(author_hash, DEFAULT_RETENTION_DAYS)
-            })
+        let author_key_groups: Vec<Vec<String>> = seed
+            .author_hashes()
+            .into_iter()
+            .map(|author_hash| Keys::author_likers_retention(author_hash, DEFAULT_RETENTION_DAYS))
             .collect();
 
         // Fetch from all date-based keys and merge results per author
@@ -138,16 +230,16 @@ impl AuthorColikerWorker {
         // Aggregate weights from all results
         let mut source_weights: HashMap<String, f64> = HashMap::new();
 
-        for ((_, user_like_count), likers) in liked_authors.iter().zip(all_likers.iter()) {
+        for (idx, likers) in all_likers.iter().enumerate() {
+            // Computed once per seed author rather than per liker: for the like path it is a sqrt of
+            // a constant, and for inverse_popularity it depends on the liker-list length, not the
+            // individual liker.
+            let weight = seed.weight_for(idx, likers.len(), weight_mode);
             for (source_hash, _like_time) in likers {
                 // Skip self
                 if source_hash == user_hash {
                     continue;
                 }
-
-                // Weight by user's affinity for this author
-                // More likes to this author = stronger signal
-                let weight = user_like_count.sqrt(); // Sqrt to dampen extreme values
                 *source_weights.entry(source_hash.clone()).or_insert(0.0) += weight;
             }
         }
@@ -155,7 +247,8 @@ impl AuthorColikerWorker {
         if source_weights.is_empty() {
             debug!(
                 user_hash = %&user_hash[..8.min(user_hash.len())],
-                authors_checked = liked_authors.len(),
+                authors_checked = seed.len(),
+            seed_kind = seed.kind(),
                 "early_exit: no co-likers after self-exclusion"
             );
             return Ok(HashMap::new());
@@ -187,7 +280,8 @@ impl AuthorColikerWorker {
         debug!(
             user_hash = %&user_hash[..8.min(user_hash.len())],
             sources = sorted_sources.len(),
-            authors_checked = liked_authors.len(),
+            authors_checked = seed.len(),
+            seed_kind = seed.kind(),
             compute_time_ms = compute_time.as_millis(),
             "author_colikes_computed"
         );
@@ -210,5 +304,86 @@ impl AuthorColikerWorker {
         let author_colikes_key = Keys::author_colikes(user_hash);
         self.redis.del(&author_colikes_key).await?;
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod follow_seed_tests {
+    use super::*;
+
+    #[test]
+    fn weight_mode_parses_and_defaults_to_uniform() {
+        assert_eq!(
+            FollowWeightMode::from_config("inverse_popularity"),
+            FollowWeightMode::InversePopularity
+        );
+        assert_eq!(
+            FollowWeightMode::from_config("  INVERSE  "),
+            FollowWeightMode::InversePopularity
+        );
+        assert_eq!(
+            FollowWeightMode::from_config("uniform"),
+            FollowWeightMode::Uniform
+        );
+        // Anything unrecognised must fall back to the assumption-free mode rather than panicking or
+        // silently selecting the unvalidated one.
+        assert_eq!(
+            FollowWeightMode::from_config("typo"),
+            FollowWeightMode::Uniform
+        );
+        assert_eq!(FollowWeightMode::from_config(""), FollowWeightMode::Uniform);
+    }
+
+    #[test]
+    fn like_seed_keeps_the_sqrt_like_count_weight() {
+        let seed = Seed::Likes(vec![("a".into(), 9.0), ("b".into(), 4.0)]);
+        // Liker count and mode are irrelevant on the like path.
+        assert_eq!(seed.weight_for(0, 50, FollowWeightMode::Uniform), 3.0);
+        assert_eq!(
+            seed.weight_for(1, 50, FollowWeightMode::InversePopularity),
+            2.0
+        );
+    }
+
+    /// The bug this whole design exists to avoid: a follow has no like count, so reusing the like
+    /// weight would give every source sqrt(0) = 0 and the seed would silently do nothing.
+    #[test]
+    fn follow_seed_never_produces_a_zero_weight() {
+        let seed = Seed::Follows(vec!["a".into(), "b".into()]);
+        assert_eq!(seed.weight_for(0, 100, FollowWeightMode::Uniform), 1.0);
+        let w = seed.weight_for(0, 100, FollowWeightMode::InversePopularity);
+        assert!(
+            w > 0.0,
+            "inverse popularity weight must be positive, got {w}"
+        );
+    }
+
+    #[test]
+    fn inverse_popularity_prefers_niche_authors() {
+        let seed = Seed::Follows(vec!["a".into()]);
+        let niche = seed.weight_for(0, 4, FollowWeightMode::InversePopularity);
+        let popular = seed.weight_for(0, 100, FollowWeightMode::InversePopularity);
+        assert!(
+            niche > popular,
+            "following a niche author should count for more: {niche} vs {popular}"
+        );
+        assert_eq!(niche, 0.5); // 1/sqrt(4)
+    }
+
+    /// A zero-length liker list must not divide by zero.
+    #[test]
+    fn inverse_popularity_survives_an_empty_liker_list() {
+        let seed = Seed::Follows(vec!["a".into()]);
+        let w = seed.weight_for(0, 0, FollowWeightMode::InversePopularity);
+        assert!(w.is_finite() && w > 0.0, "got {w}");
+    }
+
+    #[test]
+    fn seed_reports_its_kind_and_size() {
+        let likes = Seed::Likes(vec![("a".into(), 1.0)]);
+        let follows = Seed::Follows(vec!["a".into(), "b".into()]);
+        assert_eq!((likes.kind(), likes.len()), ("likes", 1));
+        assert_eq!((follows.kind(), follows.len()), ("follows", 2));
+        assert_eq!(follows.author_hashes(), vec!["a", "b"]);
     }
 }

--- a/crates/graze-api/src/config.rs
+++ b/crates/graze-api/src/config.rs
@@ -353,6 +353,16 @@ pub struct Config {
     /// Total cached pool members across all algos. Bounded on members rather than entries because
     /// pools range from 1 to ~40,000, so an entry cap would bound almost nothing.
     pub pool_cache_max_members: usize,
+    /// Seed author-affinity from `uf:{hash}` (followed authors) when the like-based seed is empty.
+    ///
+    /// Defaults OFF: this is the read path for follow seeds, and it changes what users are served.
+    /// Turning it on is a treatment change and therefore resets the holdout experiment window.
+    pub follow_seed_read_enabled: bool,
+    /// How a followed author is weighted: `uniform` or `inverse_popularity`.
+    ///
+    /// A follow carries no strength signal the way a like count does, so unlike the like path there
+    /// is no weight to inherit -- one has to be chosen, and the choice needs its own validation.
+    pub follow_seed_weight_mode: String,
     pub author_affinity_enabled: bool,
     pub max_liked_authors_per_user: usize,
     pub max_likers_per_author: usize,
@@ -662,6 +672,9 @@ impl Config {
             // Author-Affinity
             pool_cache_ttl_seconds: parse_u64_env("POOL_CACHE_TTL_SECONDS", 30),
             pool_cache_max_members: parse_usize_env("POOL_CACHE_MAX_MEMBERS", 600_000),
+            follow_seed_read_enabled: parse_bool_env("FOLLOW_SEED_READ_ENABLED", false),
+            follow_seed_weight_mode: std::env::var("FOLLOW_SEED_WEIGHT_MODE")
+                .unwrap_or_else(|_| "uniform".to_string()),
             author_affinity_enabled: parse_bool_env("AUTHOR_AFFINITY_ENABLED", true),
             max_liked_authors_per_user: parse_usize_env("MAX_LIKED_AUTHORS_PER_USER", 500),
             max_likers_per_author: parse_usize_env("MAX_LIKERS_PER_AUTHOR", 1000),


### PR DESCRIPTION
Wires `uf:{hash}` into the author-affinity seed step, behind **`FOLLOW_SEED_READ_ENABLED`, which defaults to FALSE**. Deploying this changes nothing; turning it on is the treatment change that resets the holdout window.

## Why this is not a seed swap

Two things in `compute_author_colikes` are like-count-dependent:

```rust
.filter(|(_, like_count)| *like_count >= min_author_likes as f64)   // rejects a follow outright
let weight = user_like_count.sqrt();                                // sqrt(0) = 0 for a follow
```

A naive swap filters out **every** followed author and weights any survivor at **zero**. It would have shipped as a silent no-op, indistinguishable from *"follows do not help"* — the same shape as the durable profiles whose keys had already expired.

A `Seed` enum now carries whether authors came from likes or follows, and the weight is computed per seed author from that. The fallback covers **both** previous early exits: no liked authors at all, and none meeting the threshold.

## Two weight modes, because there is nothing to inherit

- **`uniform`** (default) — every followed author counts the same. Assumes nothing.
- **`inverse_popularity`** — `1/sqrt(|likers|)`, on the intuition that following a niche account says more than following a huge one. Same reasoning as LinkLonk's fairness term that production already relies on.

### Stated limitation of `inverse_popularity`

The popularity proxy is the liker list returned by the fan-out, which is **LIMITed to `AUTHOR_AFFINITY_MAX_LIKERS_PER_AUTHOR` (default 100)**. Every author at or above that cap gets an **identical** weight, so the mode only discriminates below it — where discrimination matters least. True cardinality would cost another `ZCARD` per author per date shard, roughly doubling the fan-out.

Documented in the enum itself so nobody evaluates a compressed signal and concludes the idea is wrong.

An unrecognised `FOLLOW_SEED_WEIGHT_MODE` falls back to `uniform` rather than panicking or silently selecting the unvalidated mode.

## Known gap, next step

`seed_kind` is logged on `author_colikes_computed` but is **not yet in the provenance blob**. The experiment will need it to separate follow-seeded from like-seeded author-affinity impressions.

172 tests passing (6 new), fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)