### PR TITLE
Set up the randomized follow-seed experiment

### DIFF
--- a/analysis/experiments/follow_seed.yaml
+++ b/analysis/experiments/follow_seed.yaml
@@ -1,0 +1,75 @@
+# Does seeding personalization from the FOLLOW graph reach users the like graph cannot?
+#
+# The engine seeds exclusively from likes. Measured 2026-08-27: `no_user_data` is 98.1% of
+# addressable non-personalization (100.0% in 22 of 24 hours), and 73.6% of the users it turns away
+# have zero likes in 365 days — so nothing built from like history reaches them, which is why
+# durable co-liker profiles cap out at 3.7%. But 86% of them follow 10+ accounts, median 50.
+#
+# This is the randomized test of that idea. It also matters for the holdout: ~39% of the treatment
+# arm currently receives no personalized content at all, so the holdout measures a treatment that is
+# undelivered for two users in five. Raising coverage raises the dose, which raises the effect, and
+# that is the only route to a holdout that resolves — power cannot be bought from a richer outcome
+# table (measured: 82.84x more events exist on our algos but only 0.9% are arm-mappable).
+id: follow_seed
+design: ab
+
+# ⚠️ MUST be set to the moment FOLLOW_SEED_EXPERIMENT_ENABLED goes live, and re-set on any change to
+# traffic_pct or salt — both move the hash boundary and reassign users, which starts a different
+# experiment. The holdout spec has already been reset twice for exactly this reason.
+start: "2026-12-31T00:00:00Z"
+
+unit: user
+primary_metric: like_rate
+
+# Direction: treatment = allowed to seed from follows. `params.follow_seed` is the ARM, assigned by a
+# per-user salted hash before anything is served — deliberately NOT the realised seed kind, which is
+# post-treatment. The dose question (did treated users actually get served) is answered by the
+# `no_user_data` rate in `fallback_reason`, not by conditioning on the outcome.
+arms:
+  control:
+    field: params.follow_seed
+    value: false
+  treatment:
+    field: params.follow_seed
+    value: true
+
+negative_controls:
+  - name: pinned_and_rotating
+    reason: >
+      Pinned and rotating posts are injected by inject_special_posts from a per-feed configuration
+      that never consults the seed graph. Granting a follow seed cannot change which ones are chosen
+      or where they sit, so their like rate must not differ between arms. If it does, the arms differ
+      by something other than the seed source and the primary reading is not attributable.
+    where: "source IN ('pinned', 'rotating')"
+
+# Relevance guardrail. Follow-seeded sources are strangers who liked accounts the user follows, which
+# is a looser affinity signal than a shared like — so this arm could plausibly raise engagement while
+# lowering relevance. requestLess is the only direct relevance signal the client sends.
+# Direction: treatment minus control, so a positive diff means MORE "show me less".
+guardrails:
+  - metric: request_less_rate
+    max: 0.0
+
+cuped_covariate: pre_period_like_rate
+
+# REQUIRED, and not merely for the usual foreign-traffic reason. An absent JSON field extracts as
+# false, so without this every row written before the flag went live — and every unenrolled row —
+# lands in the CONTROL arm and silently dilutes the comparison to nothing. Requiring the nested key
+# to exist restricts the population to genuinely enrolled requests.
+population: >
+  JSONHas(tryBase64Decode(interaction_feed_context), 'algo_id')
+  AND JSONHas(tryBase64Decode(interaction_feed_context), 'params', 'follow_seed')
+
+min_observations: 2000
+
+notes: >
+  Expect this to accrue faster than the holdout: enrolment is 100% of non-holdout users by default
+  rather than 20%, and both arms are the same size.
+
+  Read the ABSOLUTE difference as well as the relative one. The base rate here is low and a large
+  relative lift on a small base is a small change in what users actually do.
+
+  Before believing any result, check the dose. The engine can only follow-seed a user who has a
+  `uf:{hash}` key, written by the personalization-follow-seeds CronJob. If that job has stalled the
+  treatment arm is under-delivered and the estimate is attenuated toward zero — the same failure that
+  made the holdout unconvergeable. `no_user_data` share by arm is the check.

--- a/crates/graze-api/src/algorithm/author_affinity.rs
+++ b/crates/graze-api/src/algorithm/author_affinity.rs
@@ -114,10 +114,13 @@ impl AuthorColikerWorker {
     ///
     /// Checks if pre-computed author co-likers exist and are fresh.
     /// If not, it triggers computation.
-    pub async fn get_or_compute_author_colikes(
+    /// `allow_follow_seed` is the per-user experiment arm resolved by the caller, not a config
+    /// read: follow-seeding is randomized per user, so the seed step cannot decide it locally.
+    pub async fn get_or_compute_author_colikes_with_seed(
         &self,
         user_hash: &str,
         force_refresh: bool,
+        allow_follow_seed: bool,
     ) -> Result<HashMap<String, f64>> {
         if !self.config.author_affinity_enabled {
             debug!(user_hash = %&user_hash[..8.min(user_hash.len())], "early_exit: author affinity disabled");
@@ -143,11 +146,16 @@ impl AuthorColikerWorker {
         }
 
         // Cache miss or force refresh - compute now
-        self.compute_author_colikes(user_hash).await
+        self.compute_author_colikes(user_hash, allow_follow_seed)
+            .await
     }
 
     /// Compute author-level co-liker aggregation for a user.
-    pub async fn compute_author_colikes(&self, user_hash: &str) -> Result<HashMap<String, f64>> {
+    pub async fn compute_author_colikes(
+        &self,
+        user_hash: &str,
+        allow_follow_seed: bool,
+    ) -> Result<HashMap<String, f64>> {
         let start_time = Instant::now();
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -185,7 +193,7 @@ impl AuthorColikerWorker {
         // have zero likes in 365 days, and 86% of them follow 10+ accounts (median 50).
         let seed = if !liked_authors.is_empty() {
             Seed::Likes(liked_authors)
-        } else if self.config.follow_seed_read_enabled {
+        } else if allow_follow_seed {
             let follows = self
                 .redis
                 .zrevrange(

--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -31,8 +31,8 @@ pub use scoring_core::{
     score_posts_parallel, score_posts_topk, to_fx_hashmap, ScoredPostResult,
 };
 pub use thompson::{
-    FeedOutcome, FeedOutcomeDetails, HashExperiment, SelectedParams, ThompsonConfig,
-    ThompsonLearner,
+    FeedOutcome, FeedOutcomeDetails, FollowSeedExperiment, HashExperiment, SelectedParams,
+    ThompsonConfig, ThompsonLearner,
 };
 
 use rustc_hash::FxHashMap;
@@ -603,9 +603,15 @@ impl LinkLonkAlgorithm {
         // Step 1: Get or compute co-likers (post-level or author-level)
         let coliker_weights = if params.use_author_affinity {
             debug!("step1_author_coliker_start");
+            // The arm decides when the experiment is running; otherwise the plain config flag
+            // applies. Resolved here because this is where `params` lives -- the seed step is too
+            // deep to know a per-user assignment.
+            let allow_follow_seed = params
+                .follow_seed_arm
+                .unwrap_or(self.config.follow_seed_read_enabled);
             let weights = self
                 .author_coliker
-                .get_or_compute_author_colikes(user_hash, false)
+                .get_or_compute_author_colikes_with_seed(user_hash, false, allow_follow_seed)
                 .await?;
             debug!(
                 coliker_count = weights.len(),

--- a/crates/graze-api/src/algorithm/params.rs
+++ b/crates/graze-api/src/algorithm/params.rs
@@ -52,6 +52,13 @@ pub struct LinkLonkParams {
     // Corater decay: per-rank decay factor for co-liker contributions (0.0 to 1.0).
     // 0.0 = disabled (current behavior). 0.2 = each successive co-liker like gets 20% less weight.
     pub corater_decay: f64,
+
+    /// Follow-seed experiment arm for this user. `None` = not enrolled, so the
+    /// `FOLLOW_SEED_READ_ENABLED` config applies instead.
+    ///
+    /// Threaded on the params struct because the seed step runs too deep to know a per-user
+    /// randomized assignment, and because it must be the ARM rather than the realised seed kind.
+    pub follow_seed_arm: Option<bool>,
 }
 
 impl Default for LinkLonkParams {
@@ -72,6 +79,7 @@ impl Default for LinkLonkParams {
             use_author_affinity: false,
             seed_sample_pool: 0,
             corater_decay: 0.0,
+            follow_seed_arm: None,
         }
     }
 }
@@ -186,6 +194,7 @@ pub fn apply_thompson_params(
         max_algo_checks: thompson.max_algo_checks,
         seed_sample_pool: thompson.seed_sample_pool,
         corater_decay: thompson.corater_decay_pct as f64 / 100.0,
+        follow_seed_arm: thompson.follow_seed_arm,
         // Keep other params from base preset
         ..base
     }

--- a/crates/graze-api/src/algorithm/thompson.rs
+++ b/crates/graze-api/src/algorithm/thompson.rs
@@ -111,6 +111,51 @@ pub struct SelectedParams {
     /// True = one dimension was forced by a user-hash randomized experiment. Excluded from
     /// bandit learning, since the value was not chosen by the bandit.
     pub is_hash_experiment: bool,
+    /// Whether this user may be seeded from the follow graph (`uf:`) when the like seed is empty.
+    ///
+    /// Carried here rather than read from config in the seed step because it is a **per-user
+    /// randomized assignment**, and because `SelectedParams` already flows into the provenance blob
+    /// — so the arm reaches ClickHouse with no new analysis plumbing, the same property that made
+    /// the `max_sources` hash experiment analysable.
+    ///
+    /// This is the ARM (pre-treatment), deliberately not the realised seed kind. Conditioning an
+    /// analysis on which seed actually got used would be post-treatment conditioning; the dose
+    /// question is answered instead by the `no_user_data` rate, which `fallback_reason` already
+    /// carries.
+    ///
+    /// `None` = not enrolled, so the plain `follow_seed_read_enabled` config applies.
+    pub follow_seed_arm: Option<bool>,
+}
+
+/// Per-user randomized on/off assignment for follow-graph seeding.
+///
+/// Separate from `HashExperiment` because follow-seeding is not a Thompson dimension — there is no
+/// parameter value to force, only a capability to grant. Uses its own salt so the split is
+/// orthogonal to both the bandit experiment and the holdout.
+#[derive(Debug, Clone)]
+pub struct FollowSeedExperiment {
+    pub enabled: bool,
+    /// Percentage of users enrolled. The remainder keep the current behaviour.
+    pub traffic_pct: u32,
+    pub salt: String,
+}
+
+impl FollowSeedExperiment {
+    /// `Some(true)` = follow-seeding allowed, `Some(false)` = withheld, `None` = not enrolled.
+    ///
+    /// Membership and arm are taken from different parts of the hash, so ramping `traffic_pct` adds
+    /// users without reshuffling the arms of those already enrolled.
+    pub fn assign(&self, user_did: &str) -> Option<bool> {
+        if !self.enabled || self.traffic_pct == 0 {
+            return None;
+        }
+        let h = graze_common::hash_did(&format!("{}|{}", self.salt, user_did));
+        let v = u64::from_str_radix(&h, 16).unwrap_or(0);
+        if (v % 100) >= self.traffic_pct as u64 {
+            return None;
+        }
+        Some(((v / 100) % 2) == 1)
+    }
 }
 
 /// A randomized A/B assignment keyed on the user DID, deliberately independent of the bandit.
@@ -445,6 +490,7 @@ impl ThompsonLearner {
                     is_exploration: false,
                     is_treatment_override: false,
                     is_hash_experiment: false,
+                    follow_seed_arm: None,
                 }
             } else {
                 SelectedParams {
@@ -461,6 +507,7 @@ impl ThompsonLearner {
                     is_exploration: false,
                     is_treatment_override: false,
                     is_hash_experiment: false,
+                    follow_seed_arm: None,
                 }
             };
         }
@@ -482,6 +529,7 @@ impl ThompsonLearner {
                 is_exploration: false,
                 is_treatment_override: true,
                 is_hash_experiment: false,
+                follow_seed_arm: None,
             };
         }
 
@@ -545,6 +593,7 @@ impl ThompsonLearner {
             is_exploration,
             is_treatment_override: false,
             is_hash_experiment: false,
+            follow_seed_arm: None,
         }
     }
 
@@ -585,6 +634,7 @@ impl ThompsonLearner {
             is_exploration: false,
             is_treatment_override: false,
             is_hash_experiment: false,
+            follow_seed_arm: None,
         }
     }
 
@@ -1151,6 +1201,7 @@ mod tests {
             max_sources_per_post: Some(75),
             seed_sample_pool: Some(1000),
             corater_decay_pct: Some(20),
+            follow_seed: None,
         };
         let selected = learner.selected_params_from_provenance(&p);
         assert_eq!(selected.min_post_likes, 10);
@@ -1172,6 +1223,7 @@ mod tests {
             max_sources_per_post: None,
             seed_sample_pool: None,
             corater_decay_pct: None,
+            follow_seed: None,
         };
         let selected2 = learner.selected_params_from_provenance(&p_partial);
         assert_eq!(selected2.min_post_likes, 7);
@@ -1197,6 +1249,7 @@ mod tests {
             is_exploration: false,
             is_treatment_override: false,
             is_hash_experiment: false,
+            follow_seed_arm: None,
         };
 
         assert_eq!(params.min_post_likes, 5);
@@ -1329,5 +1382,114 @@ mod hash_experiment_tests {
             None
         );
         assert!(!p.is_hash_experiment);
+    }
+}
+
+#[cfg(test)]
+mod follow_seed_experiment_tests {
+    use super::FollowSeedExperiment;
+
+    fn exp(pct: u32) -> FollowSeedExperiment {
+        FollowSeedExperiment {
+            enabled: true,
+            traffic_pct: pct,
+            salt: "v1".to_string(),
+        }
+    }
+
+    #[test]
+    fn disabled_or_zero_traffic_enrols_nobody() {
+        let mut e = exp(100);
+        e.enabled = false;
+        assert_eq!(e.assign("did:plc:aaa"), None);
+        assert_eq!(exp(0).assign("did:plc:aaa"), None);
+    }
+
+    /// Assignment must be stable per user, or the same person drifts between arms and the
+    /// comparison is attenuated toward zero. That is exactly what the per-request holdout coin flip
+    /// did: 18% of users were in both arms at once.
+    #[test]
+    fn assignment_is_deterministic_per_user() {
+        let e = exp(100);
+        for did in ["did:plc:aaa", "did:plc:bbb", "did:plc:ccc"] {
+            let first = e.assign(did);
+            for _ in 0..20 {
+                assert_eq!(e.assign(did), first, "assignment drifted for {did}");
+            }
+        }
+    }
+
+    #[test]
+    fn both_arms_are_populated_at_full_traffic() {
+        let e = exp(100);
+        let mut t = 0;
+        let mut c = 0;
+        for i in 0..4000 {
+            match e.assign(&format!("did:plc:user{i}")) {
+                Some(true) => t += 1,
+                Some(false) => c += 1,
+                None => panic!("nobody should be unenrolled at 100% traffic"),
+            }
+        }
+        let frac = t as f64 / (t + c) as f64;
+        assert!(
+            (0.45..0.55).contains(&frac),
+            "expected a roughly even split, got {frac:.3} ({t} vs {c})"
+        );
+    }
+
+    /// Membership and arm are drawn from different parts of the hash, so ramping traffic must add
+    /// users without flipping the arm of anyone already enrolled — otherwise a ramp silently
+    /// invalidates the data collected before it.
+    #[test]
+    fn ramping_traffic_does_not_reshuffle_existing_arms() {
+        let small = exp(20);
+        let large = exp(60);
+        let mut checked = 0;
+        for i in 0..4000 {
+            let did = format!("did:plc:user{i}");
+            if let Some(arm) = small.assign(&did) {
+                assert_eq!(
+                    large.assign(&did),
+                    Some(arm),
+                    "arm flipped for {did} when traffic was ramped"
+                );
+                checked += 1;
+            }
+        }
+        assert!(checked > 100, "test did not actually enrol anyone");
+    }
+
+    #[test]
+    fn traffic_pct_bounds_enrolment() {
+        let e = exp(25);
+        let enrolled = (0..4000)
+            .filter(|i| e.assign(&format!("did:plc:user{i}")).is_some())
+            .count();
+        let frac = enrolled as f64 / 4000.0;
+        assert!(
+            (0.20..0.30).contains(&frac),
+            "expected ~25% enrolled, got {frac:.3}"
+        );
+    }
+
+    /// A different salt must give an independent split, so this experiment cannot correlate with
+    /// the holdout or the bandit experiment.
+    #[test]
+    fn a_different_salt_gives_an_independent_split() {
+        let a = exp(100);
+        let mut b = exp(100);
+        b.salt = "v2".to_string();
+        let disagreements = (0..2000)
+            .filter(|i| {
+                let did = format!("did:plc:user{i}");
+                a.assign(&did) != b.assign(&did)
+            })
+            .count();
+        // Independent splits disagree about half the time; identical ones never would.
+        assert!(
+            (700..1300).contains(&disagreements),
+            "salts look correlated: {disagreements} disagreements of 2000"
+        );
     }
 }

--- a/crates/graze-api/src/api/feed.rs
+++ b/crates/graze-api/src/api/feed.rs
@@ -160,17 +160,20 @@ fn encode_feed_context(
     };
     let (params, response_time_ms, is_holdout) = match thompson_meta {
         Some(meta) => (
-            Some(ProvenanceParams::from_selected(
-                meta.params.min_post_likes,
-                meta.params.max_likers_per_post,
-                meta.params.max_total_sources,
-                meta.params.max_algo_checks,
-                meta.params.min_co_likes,
-                meta.params.max_user_likes,
-                meta.params.max_sources_per_post,
-                meta.params.seed_sample_pool,
-                meta.params.corater_decay_pct,
-            )),
+            Some(
+                ProvenanceParams::from_selected(
+                    meta.params.min_post_likes,
+                    meta.params.max_likers_per_post,
+                    meta.params.max_total_sources,
+                    meta.params.max_algo_checks,
+                    meta.params.min_co_likes,
+                    meta.params.max_user_likes,
+                    meta.params.max_sources_per_post,
+                    meta.params.seed_sample_pool,
+                    meta.params.corater_decay_pct,
+                )
+                .with_follow_seed(meta.params.follow_seed_arm),
+            ),
             Some(meta.response_time_ms),
             Some(meta.is_holdout),
         ),
@@ -908,6 +911,24 @@ pub async fn get_feed_skeleton(
                             value = v,
                             "ab_experiment_assigned"
                         );
+                    }
+                }
+
+                // Follow-seed experiment: a per-user on/off assignment, orthogonal to both the
+                // bandit experiment above and the holdout (its own salt).
+                //
+                // The holdout is never enrolled -- holdout users receive no personalization at all,
+                // so granting them a seed capability would be meaningless and would blur two arms.
+                if state.config.follow_seed_experiment_enabled && !thompson_params.is_holdout {
+                    let fs_exp = crate::algorithm::FollowSeedExperiment {
+                        enabled: true,
+                        traffic_pct: state.config.follow_seed_experiment_traffic_pct,
+                        salt: state.config.follow_seed_experiment_salt.clone(),
+                    };
+                    thompson_params.follow_seed_arm =
+                        fs_exp.assign(user_did.as_deref().unwrap_or(""));
+                    if let Some(arm) = thompson_params.follow_seed_arm {
+                        debug!(algo_id, arm, "follow_seed_experiment_assigned");
                     }
                 }
 

--- a/crates/graze-api/src/config.rs
+++ b/crates/graze-api/src/config.rs
@@ -358,6 +358,13 @@ pub struct Config {
     /// Defaults OFF: this is the read path for follow seeds, and it changes what users are served.
     /// Turning it on is a treatment change and therefore resets the holdout experiment window.
     pub follow_seed_read_enabled: bool,
+    /// Randomize follow-seeding per user instead of applying `follow_seed_read_enabled` to everyone.
+    ///
+    /// When on, the arm decides and `follow_seed_read_enabled` is ignored. This is what makes the
+    /// change measurable rather than merely shipped.
+    pub follow_seed_experiment_enabled: bool,
+    pub follow_seed_experiment_traffic_pct: u32,
+    pub follow_seed_experiment_salt: String,
     /// How a followed author is weighted: `uniform` or `inverse_popularity`.
     ///
     /// A follow carries no strength signal the way a like count does, so unlike the like path there
@@ -673,6 +680,13 @@ impl Config {
             pool_cache_ttl_seconds: parse_u64_env("POOL_CACHE_TTL_SECONDS", 30),
             pool_cache_max_members: parse_usize_env("POOL_CACHE_MAX_MEMBERS", 600_000),
             follow_seed_read_enabled: parse_bool_env("FOLLOW_SEED_READ_ENABLED", false),
+            follow_seed_experiment_enabled: parse_bool_env("FOLLOW_SEED_EXPERIMENT_ENABLED", false),
+            follow_seed_experiment_traffic_pct: parse_u32_env(
+                "FOLLOW_SEED_EXPERIMENT_TRAFFIC_PCT",
+                100,
+            ),
+            follow_seed_experiment_salt: std::env::var("FOLLOW_SEED_EXPERIMENT_SALT")
+                .unwrap_or_else(|_| "v1".to_string()),
             follow_seed_weight_mode: std::env::var("FOLLOW_SEED_WEIGHT_MODE")
                 .unwrap_or_else(|_| "uniform".to_string()),
             author_affinity_enabled: parse_bool_env("AUTHOR_AFFINITY_ENABLED", true),

--- a/crates/graze-common/src/models/feed_context.rs
+++ b/crates/graze-common/src/models/feed_context.rs
@@ -132,6 +132,14 @@ pub struct ProvenanceParams {
     pub seed_sample_pool: Option<usize>,
     #[serde(rename = "corater_decay_pct", skip_serializing_if = "Option::is_none")]
     pub corater_decay_pct: Option<usize>,
+    /// Follow-seed experiment arm: `true` = allowed to seed from the follow graph.
+    ///
+    /// The ARM, not the realised seed kind. Analysis must be intention-to-treat; conditioning on
+    /// which seed actually got used would be post-treatment conditioning. The dose question — did
+    /// treated users actually get served — is answered by the `no_user_data` rate in
+    /// `fallback_reason`, which needs no new field.
+    #[serde(rename = "follow_seed", skip_serializing_if = "Option::is_none")]
+    pub follow_seed: Option<bool>,
 }
 
 impl ProvenanceParams {
@@ -158,7 +166,18 @@ impl ProvenanceParams {
             max_sources_per_post: Some(max_sources_per_post),
             seed_sample_pool: Some(seed_sample_pool),
             corater_decay_pct: Some(corater_decay_pct),
+            follow_seed: None,
         }
+    }
+
+    /// Attach the follow-seed experiment arm.
+    ///
+    /// A builder rather than a tenth positional argument: `from_selected` already carries nine and
+    /// is called from several places, so extending it would churn every caller for a field most do
+    /// not set.
+    pub fn with_follow_seed(mut self, arm: Option<bool>) -> Self {
+        self.follow_seed = arm;
+        self
     }
 }
 


### PR DESCRIPTION
Adds the per-user arm, carries it into the provenance blob, and adds the spec the analysis layer reads. **`FOLLOW_SEED_EXPERIMENT_ENABLED` defaults FALSE**, so deploying this changes nothing.

## 🔴 Correction to the plan

I said I would put `seed_kind` in provenance. **That is the wrong field.** The realised seed kind is *post-treatment*, and conditioning an analysis on it would be the same error this project keeps catching — the `source` slicing and the impressions-per-user bucketing both went that way.

What the experiment needs is the **ARM**, assigned before anything is served. And the dose question the realised kind would have answered is already answered by the `no_user_data` rate in `fallback_reason` — no new field required.

## Design

`FollowSeedExperiment` is its own struct rather than a `HashExperiment`: follow-seeding is not a Thompson dimension, there is no parameter value to force, only a capability to grant. Its own salt keeps the split orthogonal to both the bandit experiment and the holdout, and **a test asserts that independence**. The holdout is never enrolled — those users receive no personalization at all, so granting them a seed capability would blur two arms.

Membership and arm come from **different parts of the hash**, so ramping `traffic_pct` adds users without flipping the arm of anyone already enrolled. A test pins that too: without it, a ramp silently invalidates everything collected before it.

The arm rides `SelectedParams → LinkLonkParams → ProvenanceParams`, chosen because `SelectedParams` already flows into the provenance blob — so the arm reaches ClickHouse with **no new analysis plumbing**, the same property that made the `max_sources` hash experiment analysable. It also means the seed step receives the resolved capability as an argument rather than reading config, which it must, since a per-user assignment cannot be decided that deep.

## The population clause is load-bearing

It requires the nested key to **exist**. Without it, every pre-flip and unenrolled row lands in the **control** arm, because an absent JSON field extracts as false — the exact trap `data.py` documents.

Verified against the real spec loader:

```
JSONExtractBool(tryBase64Decode(interaction_feed_context), params, follow_seed) AS arm_value
WHERE arm_value IN (0, 1)
ALL ASSERTIONS PASSED
```

## Two things left for flip time, deliberately not now

1. Set this spec's `start` to the flip moment
2. **Reset the holdout spec's `start`** as well — granting follow seeds changes what its treatment arm receives

178 tests passing (6 new), fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)