### PR TITLE
Flip the follow-seed experiment on, and reset the holdout window

### DIFF
--- a/analysis/experiments/follow_seed.yaml
+++ b/analysis/experiments/follow_seed.yaml
@@ -16,7 +16,7 @@ design: ab
 # ⚠️ MUST be set to the moment FOLLOW_SEED_EXPERIMENT_ENABLED goes live, and re-set on any change to
 # traffic_pct or salt — both move the hash boundary and reassign users, which starts a different
 # experiment. The holdout spec has already been reset twice for exactly this reason.
-start: "2026-12-31T00:00:00Z"
+start: "2026-08-27T17:29:54Z"
 
 unit: user
 primary_metric: like_rate

--- a/analysis/experiments/personalization_holdout.yaml
+++ b/analysis/experiments/personalization_holdout.yaml
@@ -24,7 +24,18 @@ design: ab
 #
 # The rate also changed here (0.05 -> 0.20). A rate change moves the hash boundary, which reassigns
 # some users, so it starts a new experiment for the same reason.
-start: "2026-08-14T18:47:00Z"
+# ⚠️ RESET #3, 2026-08-27T17:29:54Z: FOLLOW_SEED_EXPERIMENT_ENABLED went to 1, so half of the non-holdout
+# population may now be seeded from the follow graph. That changes what the TREATED arm receives, so
+# pooling across the flip would make this a time-weighted blend of two different treatments rather
+# than one comparison. Same reasoning as the two earlier resets (the per-request-to-per-user
+# assignment fix, and the 0.05 -> 0.20 rate change, both of which moved who was in which arm).
+#
+# What was discarded: the window from 2026-08-14T18:47:00Z, which had reached ~4,600 units at
+# diff=+0.0307 (+287.9%) and p=0.1087 -- positive, large, and NOT converging. p had risen from 0.0952
+# while the sample grew, so this reset costs nothing that was going to resolve. The reason it could
+# not converge is the reason for the flip: ~39% of the treated arm received no personalized content
+# at all, so the treatment was undelivered for two users in five.
+start: "2026-08-27T17:29:54Z"
 unit: user
 primary_metric: like_rate
 

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:eae619d9a5917f394e41a77415a5b1285164b9fe1bc9d7089aa3041c738e9c54
+              image: dgaff/graze-analysis@sha256:a590d81cd2045bf680e4b2c3b61ddfa861a30ddbf5f49f8aa1a822761b261bc2
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job
@@ -35,9 +35,9 @@ spec:
                 - |
                   set -o pipefail
                   python -m graze_analysis.runner \
-                    experiments/max_sources_250_vs_10000.yaml \
-                    experiments/interleave_self_check.yaml \
-                    experiments/personalization_holdout.yaml
+                    experiments/personalization_holdout.yaml \
+                    experiments/follow_seed.yaml \
+                    experiments/max_sources_250_vs_10000.yaml
                   readout=$?
                   python -m graze_analysis.drift
                   drift=$?


### PR DESCRIPTION
`FOLLOW_SEED_EXPERIMENT_ENABLED=1` live at **2026-08-27T17:29:54Z**, traffic 100%, salt `v1`, weight mode `uniform`. 3/3 pods, zero errors.

## The holdout reset (its third)

Granting follow seeds changes what the holdout's **treated** arm receives, so pooling across the flip would make it a time-weighted blend of two treatments rather than one comparison — same reasoning as the per-request→per-user assignment fix and the 0.05→0.20 rate change.

**What was discarded:** ~4,600 units at `diff=+0.0307 (+287.9%), p=0.1087`. Positive, large, and **not converging** — p had *risen* from 0.0952 while the sample grew. So the reset costs nothing that was going to resolve. And the reason it couldn't resolve is the reason for the flip: ~39% of the treated arm received no personalized content at all, so the treatment was undelivered for two users in five.

## ⚠️ Read coverage first, not like_rate

Only **322 users currently have a `uf:` seed**, so ~161 land in treatment — against a holdout that has 4,600 units and still sits at p=0.11. **A `like_rate` readout at this size will not resolve.**

The mechanism question — *does `no_user_data` fall in the treated arm* — is a large effect on an event **every impression carries**, and it is answerable now. `like_rate` becomes readable as seeds accrue at ~290/day via the follow-seeds CronJob.

## Also

Drops `interleave_self_check` from the hourly readout: 7 tagged impressions against a 100 minimum, so it printed a WITHHELD line every hour and nothing else. The harness stays for when interleaving is actually exposed.

**Verified after the flip:** `follow_seed` already reports 4 observations, so rows matching `JSONHas(params, follow_seed)` exist and the arm reaches ClickHouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)