### PR TITLE
Fix two bugs that made the follow-seed treatment inert

### DIFF
--- a/crates/graze-api/src/algorithm/params.rs
+++ b/crates/graze-api/src/algorithm/params.rs
@@ -222,6 +222,7 @@ pub fn merge_params(
         use_author_affinity: o.use_author_affinity,
         seed_sample_pool: o.seed_sample_pool.unwrap_or(base.seed_sample_pool),
         corater_decay: o.corater_decay.unwrap_or(base.corater_decay),
+        follow_seed_arm: o.follow_seed.or(base.follow_seed_arm),
         ..base
     }
 }
@@ -272,4 +273,50 @@ mod tests {
         assert_eq!(args[15], "0"); // seed_sample_pool (disabled)
         assert_eq!(args[16], "0"); // corater_decay (disabled)
     }
+}
+
+#[cfg(test)]
+mod follow_seed_arm_plumbing_tests {
+    use super::*;
+    use graze_common::models::PersonalizationParams;
+
+    /// The regression this pins: the arm was originally threaded through
+    /// `apply_thompson_params`, which is exported but **never called** on the serving path.
+    /// `merge_params` is the real bridge, so the arm reached the provenance blob and never reached
+    /// the seed step — the treatment was inert for 19 hours while looking correctly randomized.
+    #[test]
+    fn merge_params_carries_the_follow_seed_arm() {
+        let base = LinkLonkParams::default();
+        assert_eq!(base.follow_seed_arm, None, "default must be unenrolled");
+
+        for arm in [Some(true), Some(false)] {
+            let overrides = PersonalizationParams {
+                follow_seed: arm,
+                ..Default::default()
+            };
+            let merged = merge_params(LinkLonkParams::default(), Some(&overrides));
+            assert_eq!(
+                merged.follow_seed_arm, arm,
+                "merge_params dropped the arm: it would never reach the seed step"
+            );
+        }
+    }
+
+    /// An absent override must not clobber an arm already set on the base params.
+    #[test]
+    fn merge_params_does_not_erase_an_existing_arm() {
+        let base = LinkLonkParams {
+            follow_seed_arm: Some(true),
+            ..Default::default()
+        };
+        let overrides = PersonalizationParams::default();
+        assert_eq!(
+            merge_params(base, Some(&overrides)).follow_seed_arm,
+            Some(true)
+        );
+    }
+
+    // Note: `apply_thompson_params` also copies the arm, but it is NOT on the serving path and
+    // SelectedParams has no public constructor, so it is not covered here. If a future caller puts
+    // it on the serving path, this module is where the matching test belongs.
 }

--- a/crates/graze-api/src/algorithm/thompson.rs
+++ b/crates/graze-api/src/algorithm/thompson.rs
@@ -1201,7 +1201,6 @@ mod tests {
             max_sources_per_post: Some(75),
             seed_sample_pool: Some(1000),
             corater_decay_pct: Some(20),
-            follow_seed: None,
         };
         let selected = learner.selected_params_from_provenance(&p);
         assert_eq!(selected.min_post_likes, 10);
@@ -1223,7 +1222,6 @@ mod tests {
             max_sources_per_post: None,
             seed_sample_pool: None,
             corater_decay_pct: None,
-            follow_seed: None,
         };
         let selected2 = learner.selected_params_from_provenance(&p_partial);
         assert_eq!(selected2.min_post_likes, 7);

--- a/crates/graze-api/src/api/feed.rs
+++ b/crates/graze-api/src/api/feed.rs
@@ -125,6 +125,9 @@ fn encode_feed_context(
     // Why this response was not personalized, when it was not. Carried into provenance so coverage
     // failures are decomposable in ClickHouse instead of only in log lines.
     fallback_reason: Option<String>,
+    // Follow-seed experiment arm. Passed alongside fallback_reason rather than inside
+    // thompson_meta, so it is recorded on responses where personalization never ran.
+    follow_seed: Option<bool>,
 ) -> Option<String> {
     let (source, personalization_type, fallback_tranche, attribution, personalized) = match prov {
         ItemProvenance::Base(BlendedSource::PostLevelPersonalization) => (
@@ -160,20 +163,17 @@ fn encode_feed_context(
     };
     let (params, response_time_ms, is_holdout) = match thompson_meta {
         Some(meta) => (
-            Some(
-                ProvenanceParams::from_selected(
-                    meta.params.min_post_likes,
-                    meta.params.max_likers_per_post,
-                    meta.params.max_total_sources,
-                    meta.params.max_algo_checks,
-                    meta.params.min_co_likes,
-                    meta.params.max_user_likes,
-                    meta.params.max_sources_per_post,
-                    meta.params.seed_sample_pool,
-                    meta.params.corater_decay_pct,
-                )
-                .with_follow_seed(meta.params.follow_seed_arm),
-            ),
+            Some(ProvenanceParams::from_selected(
+                meta.params.min_post_likes,
+                meta.params.max_likers_per_post,
+                meta.params.max_total_sources,
+                meta.params.max_algo_checks,
+                meta.params.min_co_likes,
+                meta.params.max_user_likes,
+                meta.params.max_sources_per_post,
+                meta.params.seed_sample_pool,
+                meta.params.corater_decay_pct,
+            )),
             Some(meta.response_time_ms),
             Some(meta.is_holdout),
         ),
@@ -197,6 +197,7 @@ fn encode_feed_context(
         is_personalization_holdout,
         ranker,
         fallback_reason,
+        follow_seed,
     };
     ctx.encode()
 }
@@ -596,6 +597,7 @@ pub async fn get_feed_skeleton(
                         // This whole branch is the empty-candidate-pool path; `emit_skip_log`
                         // above records the same reason.
                         Some("no_algo_posts".to_string()),
+                        None,
                     );
                     SkeletonFeedPost {
                         post: uri,
@@ -659,6 +661,7 @@ pub async fn get_feed_skeleton(
             ranker: None,
             // Same reason the debug! above records: no candidate pool and no fallback either.
             fallback_reason: Some("no_algo_posts".to_string()),
+            follow_seed: None,
         }
         .encode();
         let response = FeedSkeletonResponse {
@@ -679,6 +682,11 @@ pub async fn get_feed_skeleton(
         std::collections::HashMap::new();
     let mut was_personalized = false;
     let mut fallback_reason: Option<&str> = None;
+    // Recorded independently of response_thompson_meta, which is only set on the personalization
+    // SUCCESS branch. Measured 2026-08-28: 2,129 no_user_data rows carried no arm at all, so the
+    // enrolled population excluded precisely the responses follow-seeding exists to change --
+    // coverage could never move in the readout, regardless of whether the treatment worked.
+    let mut follow_seed_arm: Option<bool> = None;
     let mut feed_cache_hit = false;
     let mut response_thompson_meta: Option<ResponseThompsonMeta> = None;
     // The arm is a pure function of the DID, so compute it once for EVERY request — first page or
@@ -927,6 +935,7 @@ pub async fn get_feed_skeleton(
                     };
                     thompson_params.follow_seed_arm =
                         fs_exp.assign(user_did.as_deref().unwrap_or(""));
+                    follow_seed_arm = thompson_params.follow_seed_arm;
                     if let Some(arm) = thompson_params.follow_seed_arm {
                         debug!(algo_id, arm, "follow_seed_experiment_assigned");
                     }
@@ -940,6 +949,9 @@ pub async fn get_feed_skeleton(
                     min_co_likes: Some(thompson_params.min_co_likes),
                     seed_sample_pool: Some(thompson_params.seed_sample_pool),
                     corater_decay: Some(thompson_params.corater_decay_pct as f64 / 100.0),
+                    // Without this the arm never reaches the seed step: merge_params is the bridge
+                    // that actually builds LinkLonkParams, and it reads this struct.
+                    follow_seed: thompson_params.follow_seed_arm,
                     ..Default::default()
                 };
 
@@ -1329,6 +1341,7 @@ pub async fn get_feed_skeleton(
                 },
                 ranker_by_uri.get(uri).cloned(),
                 fallback_reason.map(str::to_string),
+                follow_seed_arm,
             );
             SkeletonFeedPost {
                 post: uri.clone(),

--- a/crates/graze-common/src/models/feed_context.rs
+++ b/crates/graze-common/src/models/feed_context.rs
@@ -103,6 +103,18 @@ pub struct FeedContextProvenance {
     /// only two fields.
     #[serde(rename = "fallback_reason", skip_serializing_if = "Option::is_none")]
     pub fallback_reason: Option<String>,
+
+    /// Follow-seed experiment arm: `true` = allowed to seed from the follow graph.
+    ///
+    /// TOP LEVEL, not under `params`, and set independently of `params`. It was originally nested
+    /// there, but `params` is only written on the personalization-SUCCESS path — so `no_user_data`
+    /// responses carried no arm, and those are exactly the responses this treatment exists to
+    /// change. Measured 2026-08-28: 2,129 such rows, zero with an arm.
+    ///
+    /// The ARM (pre-treatment), never the realised seed kind: conditioning on which seed actually
+    /// got used would be post-treatment conditioning.
+    #[serde(rename = "follow_seed", skip_serializing_if = "Option::is_none")]
+    pub follow_seed: Option<bool>,
 }
 
 /// Compact personalization params for provenance.
@@ -132,14 +144,6 @@ pub struct ProvenanceParams {
     pub seed_sample_pool: Option<usize>,
     #[serde(rename = "corater_decay_pct", skip_serializing_if = "Option::is_none")]
     pub corater_decay_pct: Option<usize>,
-    /// Follow-seed experiment arm: `true` = allowed to seed from the follow graph.
-    ///
-    /// The ARM, not the realised seed kind. Analysis must be intention-to-treat; conditioning on
-    /// which seed actually got used would be post-treatment conditioning. The dose question — did
-    /// treated users actually get served — is answered by the `no_user_data` rate in
-    /// `fallback_reason`, which needs no new field.
-    #[serde(rename = "follow_seed", skip_serializing_if = "Option::is_none")]
-    pub follow_seed: Option<bool>,
 }
 
 impl ProvenanceParams {
@@ -166,18 +170,7 @@ impl ProvenanceParams {
             max_sources_per_post: Some(max_sources_per_post),
             seed_sample_pool: Some(seed_sample_pool),
             corater_decay_pct: Some(corater_decay_pct),
-            follow_seed: None,
         }
-    }
-
-    /// Attach the follow-seed experiment arm.
-    ///
-    /// A builder rather than a tenth positional argument: `from_selected` already carries nine and
-    /// is called from several places, so extending it would churn every caller for a field most do
-    /// not set.
-    pub fn with_follow_seed(mut self, arm: Option<bool>) -> Self {
-        self.follow_seed = arm;
-        self
     }
 }
 
@@ -224,6 +217,7 @@ mod tests {
             is_personalization_holdout: None,
             ranker: None,
             fallback_reason: None,
+            follow_seed: None,
         };
         let encoded = ctx.encode().expect("encode");
         let decoded = FeedContextProvenance::decode(&encoded).expect("decode");
@@ -268,6 +262,7 @@ mod tests {
             is_personalization_holdout: None,
             ranker: None,
             fallback_reason: None,
+            follow_seed: None,
         };
         let json_absent = serde_json::to_string(&ctx).expect("serialize");
         assert!(
@@ -315,6 +310,7 @@ mod tests {
             is_personalization_holdout: None,
             ranker: None,
             fallback_reason: None,
+            follow_seed: None,
         };
         let json_absent = serde_json::to_string(&ctx).expect("serialize");
         assert!(

--- a/crates/graze-common/src/models/requests.rs
+++ b/crates/graze-common/src/models/requests.rs
@@ -8,6 +8,14 @@ pub struct PersonalizationParams {
     /// Preset name (default, discovery, stable, fast).
     pub preset: Option<String>,
 
+    /// Follow-seed experiment arm. `None` = not enrolled, so config applies.
+    ///
+    /// Lives here because `merge_params` is what actually builds `LinkLonkParams` on the serving
+    /// path. An earlier attempt threaded this through `apply_thompson_params` instead, which is
+    /// exported but never called -- so the arm reached the provenance blob and never reached the
+    /// seed step, and the treatment was inert while looking correctly randomized.
+    pub follow_seed: Option<bool>,
+
     /// Maximum user likes to consider.
     pub max_user_likes: Option<usize>,
 


### PR DESCRIPTION
The dose check found it at 19 hours: **NOT DELIVERED**, with a textbook-clean 50/50 split (244 users per arm) and both arms identical. Two independent bugs, compounding.

## 1. The arm never reached the seed step

I threaded it through `apply_thompson_params` — which is exported and **never called**. The serving path builds `LinkLonkParams` via `merge_params`, which reads `PersonalizationParams`, and that struct had no such field. So `params.follow_seed_arm` was always `None` at the seed step, resolving to `false` for everyone.

**The treatment was inert for 19 hours while looking perfectly randomized**, because the arm *did* reach the provenance blob by a different route.

Fixed by adding `follow_seed` to `PersonalizationParams` and carrying it through `merge_params` — the bridge that is actually used.

## 2. The readout could not have seen it anyway

The arm was nested under `params`, which is only written on the personalization-**success** branch. Measured: **all 2,129 `no_user_data` rows** since the flip carried no arm at all.

So the enrolled population structurally excluded precisely the responses follow-seeding exists to change. Coverage could never have moved, even with bug 1 fixed.

Fixed by hoisting `follow_seed` to the provenance **top level**, recorded alongside `fallback_reason` — which already works this way — so it is written on every response regardless of outcome.

## What I actually got wrong

I tested the assignment logic thoroughly: determinism, split balance, salt independence, ramp stability. Six tests. And **never tested that the assignment reached the code it was supposed to affect.**

The new regression tests pin exactly that: `merge_params` must carry the arm, and must not erase one already set.

## The dose check earned its keep

Leading with `like_rate` would have produced a null in about two weeks that was indistinguishable from *"follows do not help"*.

One real cost: the holdout window reset on 8/27 discarded ~4,600 units for a treatment change **that never happened**. It was not converging anyway, so the practical loss is small — but it was an unnecessary reset caused by this bug.

180 tests passing (2 new), fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)