### PR TITLE
Attach follow-seeding where it can actually run

### DIFF
--- a/crates/graze-api/src/algorithm/author_affinity.rs
+++ b/crates/graze-api/src/algorithm/author_affinity.rs
@@ -126,7 +126,32 @@ impl AuthorColikerWorker {
             debug!(user_hash = %&user_hash[..8.min(user_hash.len())], "early_exit: author affinity disabled");
             return Ok(HashMap::new());
         }
+        self.cached_or_compute(user_hash, force_refresh, allow_follow_seed)
+            .await
+    }
 
+    /// Follow-seeded author affinity, used ONLY as a fallback for users the post-level path serves
+    /// nothing.
+    ///
+    /// Deliberately NOT gated on `author_affinity_enabled`. That flag controls whether author
+    /// affinity replaces the post-level co-liker path as the PRIMARY seed for everyone, and it is
+    /// `false` in production — which is why the follow-seed read path was unreachable even after the
+    /// arm plumbing was fixed. This entry point only ever runs where the live path already produced
+    /// no co-likers, so it cannot regress anyone it does not currently serve.
+    pub async fn get_or_compute_follow_seeded(
+        &self,
+        user_hash: &str,
+        force_refresh: bool,
+    ) -> Result<HashMap<String, f64>> {
+        self.cached_or_compute(user_hash, force_refresh, true).await
+    }
+
+    async fn cached_or_compute(
+        &self,
+        user_hash: &str,
+        force_refresh: bool,
+        allow_follow_seed: bool,
+    ) -> Result<HashMap<String, f64>> {
         let author_colikes_key = Keys::author_colikes(user_hash);
 
         if !force_refresh {

--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -509,7 +509,7 @@ impl LinkLonkAlgorithm {
         user_hash: &str,
         algo_id: i32,
         params: &LinkLonkParams,
-        audit: Option<&mut AuditCollector>,
+        mut audit: Option<&mut AuditCollector>,
     ) -> Result<ScoringResult> {
         let compute_start = Instant::now();
         info!(
@@ -600,15 +600,17 @@ impl LinkLonkAlgorithm {
             }
         }
 
+        // The arm decides when the experiment is running; otherwise the plain config flag applies.
+        // Resolved here because this is where `params` lives -- the seed step runs too deep to know
+        // a per-user assignment. Hoisted above the seed selection so the empty-coliker fallback
+        // below can see it, not just the author-affinity branch.
+        let allow_follow_seed = params
+            .follow_seed_arm
+            .unwrap_or(self.config.follow_seed_read_enabled);
+
         // Step 1: Get or compute co-likers (post-level or author-level)
         let coliker_weights = if params.use_author_affinity {
             debug!("step1_author_coliker_start");
-            // The arm decides when the experiment is running; otherwise the plain config flag
-            // applies. Resolved here because this is where `params` lives -- the seed step is too
-            // deep to know a per-user assignment.
-            let allow_follow_seed = params
-                .follow_seed_arm
-                .unwrap_or(self.config.follow_seed_read_enabled);
             let weights = self
                 .author_coliker
                 .get_or_compute_author_colikes_with_seed(user_hash, false, allow_follow_seed)
@@ -647,10 +649,44 @@ impl LinkLonkAlgorithm {
             // already serve never reaches this code, so there is no regression surface.
             if self.config.durable_profile_shadow_mode || self.config.durable_profile_enabled {
                 if let Some(result) = self
-                    .try_durable_profile(user_hash, algo_id, params, audit)
+                    .try_durable_profile(user_hash, algo_id, params, audit.as_deref_mut())
                     .await?
                 {
                     return Ok(result);
+                }
+            }
+
+            // Follow-graph seeding attaches at the same point, for the same reason: these users
+            // currently receive nothing from the live path, so there is no regression surface.
+            //
+            // It has to be HERE rather than in the primary seed selection above. That branch is
+            // gated on `params.use_author_affinity`, which is false in production
+            // (AUTHOR_AFFINITY_ENABLED=false), so a follow-seed read wired there was unreachable --
+            // the arm was assigned, recorded, and then consulted by code that never ran.
+            //
+            // Measured: no_user_data is 98.1% of addressable non-personalization, 73.6% of those
+            // users have zero likes in 365 days, and 86% of them follow 10+ accounts (median 50).
+            if allow_follow_seed {
+                let follow_weights = self
+                    .author_coliker
+                    .get_or_compute_follow_seeded(user_hash, false)
+                    .await?;
+                if !follow_weights.is_empty() {
+                    debug!(
+                        user_hash = %&user_hash[..8.min(user_hash.len())],
+                        algo_id,
+                        sources = follow_weights.len(),
+                        "follow_seed_fallback_engaged"
+                    );
+                    return self
+                        .score_with_lookup_comparison(
+                            user_hash,
+                            algo_id,
+                            &follow_weights,
+                            params,
+                            audit,
+                        )
+                        .await;
                 }
             }
 


### PR DESCRIPTION
Third blocker, and the architectural one. The two bugs fixed in #34 were real but **insufficient**: even with the arm reaching the seed step and recorded on every response, the read path still could not execute.

## The problem

`AUTHOR_AFFINITY_ENABLED=false` in production, and `use_author_affinity` defaults to `false`. The primary seed branch is **either/or** — author-level OR post-level — and production uses post-level.

So a follow-seed read wired into the author-affinity branch was **unreachable**: the arm was assigned, recorded in provenance, and then consulted by code that never ran. That is why no `seed_kind` line ever appeared after the #34 deploy, in either arm.

My design doc claimed follow-seeding *"substitutes the seed set and leaves the fan-out, aggregation and scorer untouched — smallest change, largest population."* That was the smallest change **within** author affinity, and I never checked that author affinity itself was on.

## The fix

Attached at the `coliker_weights.is_empty()` hook, which exists for precisely this and says so:

> *"Attaching here makes the change strictly additive — anyone the live path can already serve never reaches this code, so there is no regression surface."*

The durable-profile work attaches at the same point. This also means the feature no longer requires enabling author affinity globally, which would have changed the co-liker source for **every** user and needed its own experiment.

`get_or_compute_follow_seeded` is deliberately **not** gated on `author_affinity_enabled` — that flag controls whether author affinity replaces the post-level path as the primary seed for everyone; this entry point only runs where the live path already produced nothing.

`allow_follow_seed` is hoisted above the seed selection so the fallback can see it, and the audit collector is reborrowed rather than moved.

180 tests passing, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)