### PR TITLE
Let an alternative seed get a user past the personalization gate

### DIFF
--- a/crates/graze-api/src/api/feed.rs
+++ b/crates/graze-api/src/api/feed.rs
@@ -687,6 +687,18 @@ pub async fn get_feed_skeleton(
     // enrolled population excluded precisely the responses follow-seeding exists to change --
     // coverage could never move in the readout, regardless of whether the treatment worked.
     let mut follow_seed_arm: Option<bool> = None;
+    // Resolved before the seed gate below, which now depends on it. The assignment needs only the
+    // DID and config, so it can be computed this early; it is copied onto thompson_params later.
+    if state.config.follow_seed_experiment_enabled {
+        let fs_exp = crate::algorithm::FollowSeedExperiment {
+            enabled: true,
+            traffic_pct: state.config.follow_seed_experiment_traffic_pct,
+            salt: state.config.follow_seed_experiment_salt.clone(),
+        };
+        follow_seed_arm = fs_exp.assign(user_did.as_deref().unwrap_or(""));
+    }
+    let allow_follow_seed_for_gate =
+        follow_seed_arm.unwrap_or(state.config.follow_seed_read_enabled);
     let mut feed_cache_hit = false;
     let mut response_thompson_meta: Option<ResponseThompsonMeta> = None;
     // The arm is a pure function of the DID, so compute it once for EVERY request — first page or
@@ -848,11 +860,37 @@ pub async fn get_feed_skeleton(
             // a rebuild.
             let check_days = state.config.user_data_check_days;
             let user_likes_keys = Keys::user_likes_retention(&user_hash, check_days);
-            let user_has_data = state
+            let has_like_seed = state
                 .redis
                 .exists_any(&user_likes_keys)
                 .await
                 .unwrap_or(false);
+
+            // A like seed is no longer the only way in.
+            //
+            // This gate is why every alternative-seed mechanism built so far has served nothing.
+            // It runs BEFORE personalization is attempted, so a user without `ul:` never reaches
+            // compute_personalization at all -- and both the durable co-liker profile hook and the
+            // follow-seed hook live inside it, at the `coliker_weights.is_empty()` branch. The
+            // durable-profile Phase B has been deployed since 2026-08-11 and has never fired for
+            // this reason ("0 shadow firings in 40 min"), and the follow-seed read path produced
+            // zero `follow_seed_fallback_engaged` lines across two deploys until this changed.
+            //
+            // Cost is one EXISTS, and only on the path where the like-seed check already failed --
+            // roughly 14% of requests.
+            let has_follow_seed = if has_like_seed || !allow_follow_seed_for_gate {
+                false
+            } else {
+                state
+                    .redis
+                    .exists(&Keys::user_follows(&user_hash))
+                    .await
+                    .unwrap_or(false)
+            };
+            let user_has_data = has_like_seed || has_follow_seed;
+            if has_follow_seed {
+                debug!(algo_id, "follow_seed_admitted_user_without_like_seed");
+            }
 
             if user_has_data {
                 // Load feed-specific Thompson config (holdout override, etc.)
@@ -927,16 +965,12 @@ pub async fn get_feed_skeleton(
                 //
                 // The holdout is never enrolled -- holdout users receive no personalization at all,
                 // so granting them a seed capability would be meaningless and would blur two arms.
-                if state.config.follow_seed_experiment_enabled && !thompson_params.is_holdout {
-                    let fs_exp = crate::algorithm::FollowSeedExperiment {
-                        enabled: true,
-                        traffic_pct: state.config.follow_seed_experiment_traffic_pct,
-                        salt: state.config.follow_seed_experiment_salt.clone(),
-                    };
-                    thompson_params.follow_seed_arm =
-                        fs_exp.assign(user_did.as_deref().unwrap_or(""));
-                    follow_seed_arm = thompson_params.follow_seed_arm;
-                    if let Some(arm) = thompson_params.follow_seed_arm {
+                // Assigned above the seed gate; here it only rides onto thompson_params so it
+                // reaches merge_params and the provenance blob. The holdout is never enrolled --
+                // those users receive no personalization at all, so a seed capability is moot.
+                if !thompson_params.is_holdout {
+                    thompson_params.follow_seed_arm = follow_seed_arm;
+                    if let Some(arm) = follow_seed_arm {
                         debug!(algo_id, arm, "follow_seed_experiment_assigned");
                     }
                 }


### PR DESCRIPTION
**Fourth blocker, and the actual entry point.** The three earlier fixes were all necessary and all insufficient.

`feed.rs` gates on `exists_any(user_likes_retention(...))` **before personalization is attempted**. A user without a `ul:` like seed never reaches `compute_personalization` at all — and every alternative-seed mechanism built so far lives **inside** it, at the `coliker_weights.is_empty()` branch.

## That is why nothing has ever fired there

- **Durable co-liker profiles**: Phase B deployed since 2026-08-11, has served nothing (*"0 shadow firings in 40 min"*)
- **Follow-seed read path**: zero `follow_seed_fallback_engaged` lines across two deploys, with 14 arm assignments and zero errors each time

The hook was correct. It was unreachable.

## The fix

The gate now admits a user with a **follow** seed as well as one with a **like** seed. Cost is a single `EXISTS`, and only on the path where the like-seed check already failed — roughly 14% of requests.

The arm assignment moves above the gate, since the gate now depends on it. It needs only the DID and config, so it can be computed that early; the later block just copies it onto `thompson_params` so it still reaches `merge_params` and the provenance blob. The holdout remains unenrolled.

## Method note

I verified this class of thing three times by reading code and was wrong three times. The gate was found by asking **why a log line was absent**, not why the code looked right.

180 tests passing, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)