### PR TITLE
Start the follow-seed experiment for real, and reset the holdout to match

### DIFF
--- a/analysis/experiments/follow_seed.yaml
+++ b/analysis/experiments/follow_seed.yaml
@@ -16,7 +16,17 @@ design: ab
 # ⚠️ MUST be set to the moment FOLLOW_SEED_EXPERIMENT_ENABLED goes live, and re-set on any change to
 # traffic_pct or salt — both move the hash boundary and reassign users, which starts a different
 # experiment. The holdout spec has already been reset twice for exactly this reason.
-start: "2026-08-27T17:29:54Z"
+# START. This is the FOURTH start for this experiment and the first that measures anything.
+# Three earlier windows contained no valid contrast because the treatment was inert:
+#   - the arm was threaded through `apply_thompson_params`, which is never called
+#   - the arm was nested under `params`, written only on the personalization-success path
+#   - the read path hung off the author-affinity branch, and AUTHOR_AFFINITY_ENABLED=false
+#   - the seed gate turned these users away BEFORE personalization was attempted, so no hook
+#     inside compute_personalization could reach them
+#
+# Set to the moment the gate fix finished rolling out. First confirmed engagement was 13:46:23Z:
+# follow_seed_fallback_engaged, algo 2323, 300 sources, seed_kind=follows.
+start: "2026-08-28T13:41:26Z"
 
 unit: user
 primary_metric: like_rate
@@ -27,10 +37,10 @@ primary_metric: like_rate
 # `no_user_data` rate in `fallback_reason`, not by conditioning on the outcome.
 arms:
   control:
-    field: params.follow_seed
+    field: follow_seed
     value: false
   treatment:
-    field: params.follow_seed
+    field: follow_seed
     value: true
 
 negative_controls:
@@ -58,7 +68,7 @@ cuped_covariate: pre_period_like_rate
 # to exist restricts the population to genuinely enrolled requests.
 population: >
   JSONHas(tryBase64Decode(interaction_feed_context), 'algo_id')
-  AND JSONHas(tryBase64Decode(interaction_feed_context), 'params', 'follow_seed')
+  AND JSONHas(tryBase64Decode(interaction_feed_context), 'follow_seed')
 
 min_observations: 2000
 

--- a/analysis/experiments/personalization_holdout.yaml
+++ b/analysis/experiments/personalization_holdout.yaml
@@ -24,18 +24,16 @@ design: ab
 #
 # The rate also changed here (0.05 -> 0.20). A rate change moves the hash boundary, which reassigns
 # some users, so it starts a new experiment for the same reason.
-# ⚠️ RESET #3, 2026-08-27T17:29:54Z: FOLLOW_SEED_EXPERIMENT_ENABLED went to 1, so half of the non-holdout
-# population may now be seeded from the follow graph. That changes what the TREATED arm receives, so
-# pooling across the flip would make this a time-weighted blend of two different treatments rather
-# than one comparison. Same reasoning as the two earlier resets (the per-request-to-per-user
-# assignment fix, and the 0.05 -> 0.20 rate change, both of which moved who was in which arm).
+# ⚠️ RESET, 2026-08-28T13:41:26Z. The 2026-08-27 reset was premature: it was made for a
+# treatment change that did not actually happen, because follow-seeding was inert (see
+# follow_seed.yaml for the four reasons). This is the moment the treated arm's treatment really
+# changed -- half of the non-holdout population can now be seeded from the follow graph.
 #
-# What was discarded: the window from 2026-08-14T18:47:00Z, which had reached ~4,600 units at
-# diff=+0.0307 (+287.9%) and p=0.1087 -- positive, large, and NOT converging. p had risen from 0.0952
-# while the sample grew, so this reset costs nothing that was going to resolve. The reason it could
-# not converge is the reason for the flip: ~39% of the treated arm received no personalized content
-# at all, so the treatment was undelivered for two users in five.
-start: "2026-08-27T17:29:54Z"
+# Discarded across both resets: ~4,600 units at diff=+0.0307 (+287.9%), p=0.1087. Positive, large,
+# and NOT converging -- p had risen from 0.0952 as the sample grew -- so nothing that was going to
+# resolve was lost. The reason it could not resolve is the reason for the flip: ~39% of the treated
+# arm received no personalized content at all.
+start: "2026-08-28T13:41:26Z"
 unit: user
 primary_metric: like_rate
 

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:a590d81cd2045bf680e4b2c3b61ddfa861a30ddbf5f49f8aa1a822761b261bc2
+              image: dgaff/graze-analysis@sha256:304409b35ea970b57a3790c40928347f5367606af4b200d04985e6ba877c0696
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job

--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -123,7 +123,7 @@ spec:
                 name: personalization-dose-check-src
           containers:
             - name: dose
-              image: dgaff/graze-analysis@sha256:a590d81cd2045bf680e4b2c3b61ddfa861a30ddbf5f49f8aa1a822761b261bc2
+              image: dgaff/graze-analysis@sha256:304409b35ea970b57a3790c40928347f5367606af4b200d04985e6ba877c0696
               command: ["python", "/src/dose.py"]
               volumeMounts:
                 - name: src
@@ -132,7 +132,7 @@ spec:
                 # Must match the moment FOLLOW_SEED_EXPERIMENT_ENABLED went to 1. Re-set it if the
                 # experiment is ever restarted, or pre-flip rows silently join the control arm.
                 - name: FOLLOW_SEED_FLIP_AT
-                  value: "2026-08-27 17:29:54"
+                  value: "2026-08-28 13:41:26"
               envFrom:
                 - configMapRef:
                     name: personalization-env


### PR DESCRIPTION
Verified live at **2026-08-28T13:41:26Z**, after the fourth blocker was cleared. The full chain fired for the first time:

```
follow_seed_admitted_user_without_like_seed        (the widened gate)
follow_seed_fallback_engaged  algo_id=2323  sources=300
"seed_kind":"follows"                              (the seed step took the branch)
```

27 arm assignments, zero errors. The `user_hash` matches one written by the follow-seeds CronJob, so a genuinely seeded user was served from the follow graph.

## Fourth start, first one that measures anything

Three earlier windows held no valid contrast because the treatment was inert:

| # | why |
|---|---|
| 1 | arm threaded through `apply_thompson_params`, which is never called |
| 2 | arm nested under `params`, written only on the personalization-success path |
| 3 | read path hung off the author-affinity branch, and `AUTHOR_AFFINITY_ENABLED=false` |
| 4 | the seed gate turned these users away **before** personalization was attempted |

## The holdout reset on 8/27 was premature

It was made for a treatment change that **did not actually happen**. Reset again to the moment it really changed.

Across both resets ~4,600 units were discarded at `diff=+0.0307 (+287.9%), p=0.1087` — positive, large, and **not converging**, with p having risen from 0.0952 as the sample grew. Nothing that was going to resolve was lost.

The dose check's `FOLLOW_SEED_FLIP_AT` is updated to match; without that bound, pre-flip rows join the control arm since an absent JSON field extracts as false. Analysis image rebuilt, both CronJobs bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)