### PR TITLE
graze-lens: follow-graph store, lens builder, and live set maintenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ members = [
     "crates/graze-candidate-sync",
     "crates/graze-frontdoor",
     "crates/graze-feed-stats",
+    "crates/graze-lens-builder",
+    "crates/graze-lens-fold",
+    "crates/graze-lens-bootstrap",
 ]
 
 [workspace.package]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,10 @@ RUN --mount=type=ssh \
     -p graze-like-streamer \
     -p graze-candidate-sync \
     -p graze-frontdoor \
-    -p graze-feed-stats
+    -p graze-feed-stats \
+    -p graze-lens-builder \
+    -p graze-lens-fold \
+    -p graze-lens-bootstrap
 
 # Stage 2: Final runtime image
 FROM --platform=linux/amd64 gcr.io/distroless/cc-debian12
@@ -46,6 +49,12 @@ COPY --from=builder /app/target/release/graze-backfill-ula /app/graze-backfill-u
 COPY --from=builder /app/target/release/graze-backfill /app/graze-backfill
 COPY --from=builder /app/target/release/graze-frontdoor /app/graze-frontdoor
 COPY --from=builder /app/target/release/graze-feed-stats /app/graze-feed-stats
+# Viewer-graph lenses; selected by `command:` in kube/lens-builder-deployment.yaml.
+COPY --from=builder /app/target/release/graze-lens-builder /app/graze-lens-builder
+COPY --from=builder /app/target/release/graze-lens-fold /app/graze-lens-fold
+COPY --from=builder /app/target/release/graze-lens-bootstrap /app/graze-lens-bootstrap
+# Built by -p graze-lens-fold; selected by `command:` in the CronJob.
+COPY --from=builder /app/target/release/graze-lens-rev-rebuild /app/graze-lens-rev-rebuild
 COPY --from=builder /app/target/release/graze-migrate-tranches /app/graze-migrate-tranches
 COPY --from=builder /app/target/release/graze-migrate-dates /app/graze-migrate-dates
 COPY --from=builder /app/target/release/graze-verify-migration /app/graze-verify-migration

--- a/cohorts/beta.txt
+++ b/cohorts/beta.txt
@@ -1,0 +1,56 @@
+# Graze beta cohort
+#
+# The people who get new, risky, or half-finished features first. This list is
+# deliberately NOT lens-specific: any feature that wants a small trusted audience
+# should read this cohort rather than inventing its own allowlist, so that
+# "who is in the beta" is one decision recorded in one place.
+#
+# Established 2026-08-28 for the graze-lens (viewer-graph feeds) beta.
+#
+# ## Keyed on DID, not handle
+#
+# Handles are mutable — someone moving from alice.bsky.social to alice.com would
+# silently drop out of a handle-keyed cohort, and worse, the old handle could
+# later be claimed by someone else who would silently drop *in*. DIDs never
+# change. The handle beside each DID is a comment for humans; it may go stale and
+# that is fine. Re-resolve with:
+#
+#   curl -s "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=<handle>"
+#
+# ## Consumers
+#
+#   * ConfigMap `graze-beta-cohort` (key `dids.txt`) — the runtime artifact any
+#     job or service can mount. Regenerate after editing this file:
+#
+#       grep -v '^#' cohorts/beta.txt | grep -v '^$' > /tmp/dids.txt
+#       kubectl create configmap graze-beta-cohort --from-file=dids.txt=/tmp/dids.txt \
+#         --dry-run=client -o yaml | kubectl apply -f -
+#
+#   * `kube/lens-bootstrap-job.yaml` mounts that ConfigMap to pick which accounts
+#     to backfill follow history for.
+#
+#   * feeder-rs reads `LENS_ALLOWLIST_DIDS` (comma-separated) from `app-secrets`.
+#     Build it from this file:
+#
+#       grep -v '^#' cohorts/beta.txt | grep -v '^$' | paste -sd, -
+#
+# Anyone added here gains early access to unfinished features; that is the point,
+# but it is also worth their knowing. Adding someone is a product decision, not a
+# config change.
+
+# richferro.com
+did:plc:an5cb3ab3cjswxhb3czqqjov
+# fema.monster
+did:plc:lptjvw6ut224kwrj7ub3sqbe
+# aendra.com
+did:plc:kkf4naxqmweop7dv4l2iqqf5
+# byarielm.fyi
+did:plc:6i6n57nrkq6xavqbdo6bvkqr
+# zombiegomoan.on.bike
+did:plc:zmxjf4b7tzmuvtanyqjzslcn
+# clarabelle.xyz
+did:plc:geoqe3qls5mwezckxxsewys2
+# devingaffney.com
+did:plc:jijwtzgroy76samnivlqrpec
+# hipstersmoothie.com
+did:plc:m2sjv3wncvsasdapla35hzwj

--- a/crates/graze-lens-bootstrap/Cargo.toml
+++ b/crates/graze-lens-bootstrap/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "graze-lens-bootstrap"
+version = "0.2.0"
+edition = "2021"
+description = "Backfills historical follow edges into ClickHouse follow_edges"
+license = "MIT"
+
+[[bin]]
+name = "graze-lens-bootstrap"
+path = "src/main.rs"
+
+[lib]
+name = "graze_lens_bootstrap"
+path = "src/lib.rs"
+
+[dependencies]
+graze-common = { path = "../graze-common" }
+# Shares the row type and the ClickHouse sink with the live fold, so a
+# backfilled row and a streamed row are the same thing by construction.
+graze-lens-fold = { path = "../graze-lens-fold" }
+
+tokio = { version = "1.43", features = ["full", "signal"] }
+reqwest = { version = "0.12", features = ["json", "gzip", "rustls-tls"], default-features = false }
+
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = "0.4"
+atproto-record = { version = "0.14", default-features = false }
+
+anyhow = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/crates/graze-lens-bootstrap/src/backfill.rs
+++ b/crates/graze-lens-bootstrap/src/backfill.rs
@@ -1,0 +1,295 @@
+//! Paginate one repo's follow records into `follow_edges` rows.
+//!
+//! Uses `com.atproto.repo.listRecords` rather than a repo CAR fetch. The CAR is
+//! one request instead of N, but the record key lives in the MST, not in the
+//! record — and the rkey is exactly what this table is keyed on, so a CAR path
+//! would mean walking the MST correctly to recover it. listRecords hands back
+//! `uri` (rkey included) and the decoded record as JSON, which is the same data
+//! with none of the binary parsing risk. Backfill is a one-time, background
+//! operation per viewer, so the extra round trips are affordable.
+
+use std::time::Duration;
+
+use graze_lens_fold::FollowEdge;
+use serde::Deserialize;
+use tracing::{debug, warn};
+
+use crate::resolve::Resolver;
+
+const COLLECTION: &str = "app.bsky.graph.follow";
+/// listRecords caps at 100.
+const PAGE_LIMIT: u32 = 100;
+
+#[derive(Deserialize)]
+struct ListRecordsResponse {
+    records: Vec<Record>,
+    cursor: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Record {
+    uri: String,
+    value: FollowValue,
+}
+
+#[derive(Deserialize)]
+struct FollowValue {
+    subject: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+}
+
+pub struct Backfiller {
+    http: reqwest::Client,
+    resolver: Resolver,
+    request_timeout: Duration,
+    /// Politeness delay between pages against one PDS.
+    page_delay: Duration,
+    max_pages: usize,
+}
+
+impl Backfiller {
+    pub fn new(
+        http: reqwest::Client,
+        resolver: Resolver,
+        request_timeout: Duration,
+        page_delay: Duration,
+        max_pages: usize,
+    ) -> Self {
+        Self {
+            http,
+            resolver,
+            request_timeout,
+            page_delay,
+            max_pages,
+        }
+    }
+
+    /// Every current follow edge for one account.
+    ///
+    /// Only creates are produced: listRecords reflects present state, so a
+    /// record that is absent was either never created or already deleted, and
+    /// in both cases there is nothing to write. Live deletes come from the fold.
+    pub async fn edges_for(&self, did: &str) -> anyhow::Result<Vec<FollowEdge>> {
+        let pds = self.resolver.pds_for(did).await?;
+        let url = format!("{pds}/xrpc/com.atproto.repo.listRecords");
+
+        let mut edges = Vec::new();
+        let mut cursor: Option<String> = None;
+        let mut pages = 0usize;
+
+        loop {
+            let mut query: Vec<(&str, String)> = vec![
+                ("repo", did.to_string()),
+                ("collection", COLLECTION.to_string()),
+                ("limit", PAGE_LIMIT.to_string()),
+            ];
+            if let Some(ref c) = cursor {
+                query.push(("cursor", c.clone()));
+            }
+
+            let response = self
+                .http
+                .get(&url)
+                .query(&query)
+                .timeout(self.request_timeout)
+                .send()
+                .await?;
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                anyhow::bail!(
+                    "listRecords failed for {did} ({}): {}",
+                    status,
+                    &body[..body.len().min(300)]
+                );
+            }
+
+            let page: ListRecordsResponse = response.json().await?;
+            let returned = page.records.len();
+            for record in page.records {
+                match edge_from_record(did, &record) {
+                    Some(edge) => edges.push(edge),
+                    None => debug!(uri = %record.uri, "skipping unusable follow record"),
+                }
+            }
+
+            pages += 1;
+            cursor = page.cursor;
+
+            // An empty page still carries a cursor on some PDS versions, so
+            // stop on "no cursor" OR "nothing returned" — trusting the cursor
+            // alone can spin forever on an account whose records were deleted
+            // mid-pagination.
+            if cursor.is_none() || returned == 0 {
+                break;
+            }
+            if pages >= self.max_pages {
+                warn!(
+                    did,
+                    pages,
+                    edges = edges.len(),
+                    "hit max_pages; backfill truncated for this account"
+                );
+                break;
+            }
+            if !self.page_delay.is_zero() {
+                tokio::time::sleep(self.page_delay).await;
+            }
+        }
+
+        Ok(edges)
+    }
+}
+
+/// Build a row from one listRecords entry.
+fn edge_from_record(did: &str, record: &Record) -> Option<FollowEdge> {
+    let rkey = rkey_from_uri(&record.uri)?;
+    let followee = record.value.subject.clone()?;
+    if !followee.starts_with("did:") {
+        return None;
+    }
+
+    // The rkey is a TID, which encodes the record's creation time in
+    // microseconds. That is the right version column: it is monotonic, it comes
+    // from the repo rather than the record body, and it cannot be forged by a
+    // bogus `createdAt`. A live unfollow always carries a much larger
+    // jetstream `time_us`, so it reliably supersedes a backfilled create.
+    let seq = atproto_record::tid::Tid::decode(rkey)
+        .map(|tid| tid.timestamp_micros())
+        .unwrap_or(0);
+
+    let created_at = record
+        .value
+        .created_at
+        .as_deref()
+        .and_then(normalize_timestamp)
+        .unwrap_or_else(|| graze_lens_fold::event::micros_to_clickhouse(seq));
+
+    Some(FollowEdge {
+        follower: did.to_string(),
+        rkey: rkey.to_string(),
+        followee,
+        op: "create",
+        seq,
+        created_at,
+    })
+}
+
+/// `at://did/app.bsky.graph.follow/<rkey>` → `<rkey>`.
+fn rkey_from_uri(uri: &str) -> Option<&str> {
+    let rkey = uri.rsplit('/').next()?;
+    if rkey.is_empty() || rkey == uri {
+        return None;
+    }
+    Some(rkey)
+}
+
+/// Same normalization the fold applies, kept in step deliberately: a record
+/// backfilled here and the same record seen live must produce the same row.
+fn normalize_timestamp(raw: &str) -> Option<String> {
+    let parsed = chrono::DateTime::parse_from_rfc3339(raw).ok()?;
+    let utc = parsed.with_timezone(&chrono::Utc);
+    let year = chrono::Datelike::year(&utc);
+    if !(2020..=2100).contains(&year) {
+        return None;
+    }
+    Some(utc.format("%Y-%m-%d %H:%M:%S%.3f").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(uri: &str, subject: Option<&str>, created: Option<&str>) -> Record {
+        Record {
+            uri: uri.to_string(),
+            value: FollowValue {
+                subject: subject.map(str::to_string),
+                created_at: created.map(str::to_string),
+            },
+        }
+    }
+
+    /// Captured from a real listRecords response, for the same account and rkey
+    /// observed on the firehose — the two paths must agree.
+    #[test]
+    fn builds_an_edge_matching_the_firehose_row() {
+        let r = record(
+            "at://did:plc:ppe4rzpiatethnqkvxf32xzj/app.bsky.graph.follow/3mu5p6crk3w23",
+            Some("did:plc:5mwlxn5ktysxvd3w5kgbbuv6"),
+            Some("2026-08-28T15:41:17.774Z"),
+        );
+        let edge = edge_from_record("did:plc:ppe4rzpiatethnqkvxf32xzj", &r).expect("edge");
+        assert_eq!(edge.rkey, "3mu5p6crk3w23");
+        assert_eq!(edge.followee, "did:plc:5mwlxn5ktysxvd3w5kgbbuv6");
+        assert_eq!(edge.op, "create");
+        assert_eq!(edge.created_at, "2026-08-28 15:41:17.774");
+    }
+
+    /// The seq must come from the rkey's TID, not the record body — otherwise a
+    /// forged `createdAt` far in the future would outrank a real unfollow and
+    /// the edge could never be retracted.
+    #[test]
+    fn seq_comes_from_the_rkey_not_the_record() {
+        let honest = record(
+            "at://did:plc:a/app.bsky.graph.follow/3mu5p6crk3w23",
+            Some("did:plc:b"),
+            Some("2026-08-28T15:41:17.774Z"),
+        );
+        let forged = record(
+            "at://did:plc:a/app.bsky.graph.follow/3mu5p6crk3w23",
+            Some("did:plc:b"),
+            Some("2099-01-01T00:00:00.000Z"),
+        );
+        let a = edge_from_record("did:plc:a", &honest).unwrap();
+        let b = edge_from_record("did:plc:a", &forged).unwrap();
+        assert_eq!(a.seq, b.seq, "seq must not depend on createdAt");
+        assert!(a.seq > 0, "a valid TID must yield a timestamp");
+    }
+
+    /// A backfilled create must lose to any later live event for the same edge.
+    #[test]
+    fn backfilled_seq_is_below_present_day_event_time() {
+        let r = record(
+            "at://did:plc:a/app.bsky.graph.follow/3mu5p6crk3w23",
+            Some("did:plc:b"),
+            None,
+        );
+        let edge = edge_from_record("did:plc:a", &r).unwrap();
+        let now_us = 1_787_931_684_518_756u64; // the captured live event time
+        assert!(
+            edge.seq <= now_us,
+            "backfill seq {} must not exceed live event time",
+            edge.seq
+        );
+    }
+
+    #[test]
+    fn records_without_a_subject_are_skipped() {
+        let r = record("at://did:plc:a/app.bsky.graph.follow/3mu5", None, None);
+        assert!(edge_from_record("did:plc:a", &r).is_none());
+    }
+
+    /// A subject that is a handle rather than a DID would never match an author
+    /// DID at serve time; drop it rather than publish an unmatchable member.
+    #[test]
+    fn non_did_subjects_are_skipped() {
+        let r = record(
+            "at://did:plc:a/app.bsky.graph.follow/3mu5",
+            Some("alice.bsky.social"),
+            None,
+        );
+        assert!(edge_from_record("did:plc:a", &r).is_none());
+    }
+
+    #[test]
+    fn rkey_is_the_last_uri_segment() {
+        assert_eq!(
+            rkey_from_uri("at://did:plc:a/app.bsky.graph.follow/3mu5p6crk3w23"),
+            Some("3mu5p6crk3w23")
+        );
+        assert!(rkey_from_uri("nonsense").is_none());
+    }
+}

--- a/crates/graze-lens-bootstrap/src/config.rs
+++ b/crates/graze-lens-bootstrap/src/config.rs
@@ -1,0 +1,84 @@
+//! Configuration for the backfill job.
+
+use std::time::Duration;
+
+use graze_common::ClickHouseConfig;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub clickhouse: ClickHouseConfig,
+    pub insert_timeout: Duration,
+    /// Rows per ClickHouse insert. Backfill is bulk, so this is far larger than
+    /// the fold's live batch.
+    pub insert_batch: usize,
+
+    /// Accounts backfilled concurrently. Kept low by default: this fans out to
+    /// other people's PDS hosts, and a backfill is never urgent.
+    pub concurrency: usize,
+    pub request_timeout: Duration,
+    /// Delay between pages against one PDS.
+    pub page_delay: Duration,
+    /// Cap on pages per account (100 records each). 500 pages covers a 50k-follow
+    /// account; beyond that the account is logged and truncated rather than
+    /// paging indefinitely.
+    pub max_pages: usize,
+
+    pub plc_directory: Option<String>,
+    /// Resolve and fetch, but write nothing.
+    pub dry_run: bool,
+}
+
+impl Config {
+    pub fn from_env() -> anyhow::Result<Self> {
+        let clickhouse = ClickHouseConfig {
+            host: require("CLICKHOUSE_HOST")?,
+            port: parse("CLICKHOUSE_PORT", 443)?,
+            database: default("CLICKHOUSE_DATABASE", "default"),
+            user: require("CLICKHOUSE_USER")?,
+            password: require("CLICKHOUSE_PASSWORD")?,
+            secure: parse("CLICKHOUSE_SECURE", true)?,
+        };
+
+        Ok(Self {
+            clickhouse,
+            insert_timeout: Duration::from_secs(parse(
+                "LENS_BOOTSTRAP_INSERT_TIMEOUT_SECONDS",
+                60,
+            )?),
+            insert_batch: parse("LENS_BOOTSTRAP_INSERT_BATCH", 20_000)?,
+
+            concurrency: parse("LENS_BOOTSTRAP_CONCURRENCY", 4)?,
+            request_timeout: Duration::from_secs(parse("LENS_BOOTSTRAP_REQUEST_TIMEOUT", 20)?),
+            page_delay: Duration::from_millis(parse("LENS_BOOTSTRAP_PAGE_DELAY_MS", 150)?),
+            max_pages: parse("LENS_BOOTSTRAP_MAX_PAGES", 600)?,
+
+            plc_directory: optional("LENS_BOOTSTRAP_PLC_DIRECTORY"),
+            dry_run: parse("LENS_BOOTSTRAP_DRY_RUN", false)?,
+        })
+    }
+}
+
+fn optional(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+fn default(name: &str, fallback: &str) -> String {
+    optional(name).unwrap_or_else(|| fallback.to_string())
+}
+
+fn require(name: &str) -> anyhow::Result<String> {
+    optional(name).ok_or_else(|| anyhow::anyhow!("{name} is required but unset"))
+}
+
+fn parse<T>(name: &str, fallback: T) -> anyhow::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match optional(name) {
+        None => Ok(fallback),
+        Some(raw) => raw
+            .parse()
+            .map_err(|e| anyhow::anyhow!("{name} is not a valid value ({raw}): {e}")),
+    }
+}

--- a/crates/graze-lens-bootstrap/src/lib.rs
+++ b/crates/graze-lens-bootstrap/src/lib.rs
@@ -1,0 +1,32 @@
+//! Backfills `follow_edges` for a set of accounts.
+//!
+//! `graze-lens-fold` only sees follows from the moment it connects. This job
+//! fills in history, by reading each account's follow records straight from its
+//! PDS and writing them as `create` rows versioned by the record's own TID.
+//!
+//! # Why this rather than the Jetstream v2 archive
+//!
+//! The design brief calls for bootstrapping from Jetstream v2's Network Replay:
+//! one filtered bulk download of the whole network's follow history. That is
+//! still the right move for warming the *global* graph, and it remains blocked
+//! on an archive API token plus a decoder for the `.jss` columnar segment format
+//! (256-byte header, length-prefixed zstd blocks, raw CBOR payloads) — which is
+//! not something to write blind against a format we cannot yet fetch and verify.
+//!
+//! This job needs neither. It is per-account, uses only public unauthenticated
+//! endpoints, and covers exactly the accounts that actually asked for a lens —
+//! which is all M0 requires, and matches the lazy-build shape of the rest of the
+//! system. When the archive path lands it supersedes this for bulk warming;
+//! this remains the repair path for an account whose history predates whatever
+//! the archive holds.
+//!
+//! Idempotent: rows are versioned by TID, so re-running writes the same
+//! (follower, rkey, seq) tuples and ReplacingMergeTree collapses them.
+
+pub mod backfill;
+pub mod config;
+pub mod resolve;
+
+pub use backfill::Backfiller;
+pub use config::Config;
+pub use resolve::Resolver;

--- a/crates/graze-lens-bootstrap/src/main.rs
+++ b/crates/graze-lens-bootstrap/src/main.rs
@@ -1,0 +1,172 @@
+//! graze-lens-bootstrap: backfill `follow_edges` for a set of accounts.
+//!
+//! Usage:
+//!     graze-lens-bootstrap did:plc:aaa did:plc:bbb
+//!     graze-lens-bootstrap --file dids.txt
+//!     cat dids.txt | graze-lens-bootstrap
+//!
+//! Safe to re-run: rows are versioned by the record's TID, so repeats collapse.
+
+use std::io::BufRead;
+use std::sync::Arc;
+
+use anyhow::Context;
+use graze_lens_bootstrap::{Backfiller, Config, Resolver};
+use graze_lens_fold::{FollowEdge, Sink};
+use tokio::sync::Mutex;
+use tracing::{error, info, warn};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let dids = read_dids()?;
+    if dids.is_empty() {
+        anyhow::bail!("no DIDs given; pass them as arguments, via --file, or on stdin");
+    }
+
+    let config = Config::from_env().context("configuration")?;
+    info!(
+        accounts = dids.len(),
+        concurrency = config.concurrency,
+        dry_run = config.dry_run,
+        "starting follow-graph backfill"
+    );
+
+    let http = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .user_agent(concat!("graze-lens-bootstrap/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+
+    let resolver = Resolver::new(http.clone(), config.plc_directory.clone());
+    let backfiller = Arc::new(Backfiller::new(
+        http,
+        resolver,
+        config.request_timeout,
+        config.page_delay,
+        config.max_pages,
+    ));
+    let sink =
+        Arc::new(Sink::new(config.clickhouse.clone(), config.insert_timeout).context("sink")?);
+
+    let pending: Arc<Mutex<Vec<FollowEdge>>> = Arc::new(Mutex::new(Vec::new()));
+    let total = dids.len();
+    let done = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let failed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let rows = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    // A plain bounded worker pool: the fan-out here is to strangers' PDS hosts,
+    // so the ceiling is politeness rather than our own capacity.
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(config.concurrency.max(1)));
+    let mut tasks = Vec::with_capacity(dids.len());
+
+    for did in dids {
+        let permit = semaphore.clone().acquire_owned().await?;
+        let (backfiller, sink, pending) = (backfiller.clone(), sink.clone(), pending.clone());
+        let (done, failed, rows) = (done.clone(), failed.clone(), rows.clone());
+        let config = config.clone();
+
+        tasks.push(tokio::spawn(async move {
+            let _permit = permit;
+            match backfiller.edges_for(&did).await {
+                Ok(edges) => {
+                    rows.fetch_add(edges.len(), std::sync::atomic::Ordering::Relaxed);
+                    if !config.dry_run && !edges.is_empty() {
+                        let mut buf = pending.lock().await;
+                        buf.extend(edges);
+                        if buf.len() >= config.insert_batch {
+                            let batch = std::mem::take(&mut *buf);
+                            drop(buf);
+                            if let Err(e) = sink.insert(&batch).await {
+                                // Keep going: one failed insert should not abort
+                                // a long backfill, and the job is re-runnable.
+                                error!(error = %e, rows = batch.len(), "insert failed");
+                                failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, did, "backfill failed for account");
+                    failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+            }
+
+            let n = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+            if n % 100 == 0 || n == total {
+                info!(
+                    done = n,
+                    total,
+                    edges = rows.load(std::sync::atomic::Ordering::Relaxed),
+                    "backfill progress"
+                );
+            }
+        }));
+    }
+
+    for task in tasks {
+        let _ = task.await;
+    }
+
+    // Flush the tail.
+    let remaining = std::mem::take(&mut *pending.lock().await);
+    if !config.dry_run && !remaining.is_empty() {
+        if let Err(e) = sink.insert(&remaining).await {
+            error!(error = %e, rows = remaining.len(), "final insert failed");
+            failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    let failures = failed.load(std::sync::atomic::Ordering::Relaxed);
+    info!(
+        accounts = total,
+        edges = rows.load(std::sync::atomic::Ordering::Relaxed),
+        failures,
+        dry_run = config.dry_run,
+        "backfill complete"
+    );
+
+    // Non-zero exit on any failure so a Job shows as failed rather than
+    // silently having skipped accounts.
+    if failures > 0 {
+        anyhow::bail!("{failures} account(s) or insert(s) failed; see logs");
+    }
+    Ok(())
+}
+
+/// DIDs from argv, `--file <path>`, or stdin. Blank lines and `#` comments are
+/// ignored so a hand-maintained allowlist can carry notes.
+fn read_dids() -> anyhow::Result<Vec<String>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    if let Some(idx) = args.iter().position(|a| a == "--file") {
+        let path = args
+            .get(idx + 1)
+            .ok_or_else(|| anyhow::anyhow!("--file needs a path"))?;
+        let file = std::fs::File::open(path).with_context(|| format!("opening {path}"))?;
+        return Ok(collect(
+            std::io::BufReader::new(file).lines().map_while(Result::ok),
+        ));
+    }
+
+    let positional: Vec<String> = args.into_iter().filter(|a| !a.starts_with("--")).collect();
+    if !positional.is_empty() {
+        return Ok(collect(positional.into_iter()));
+    }
+
+    Ok(collect(
+        std::io::stdin().lock().lines().map_while(Result::ok),
+    ))
+}
+
+fn collect(lines: impl Iterator<Item = String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    lines
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .filter(|l| seen.insert(l.clone()))
+        .collect()
+}

--- a/crates/graze-lens-bootstrap/src/resolve.rs
+++ b/crates/graze-lens-bootstrap/src/resolve.rs
@@ -1,0 +1,134 @@
+//! DID → PDS endpoint resolution.
+//!
+//! Follow records live in the account's own repo, so a backfill has to find the
+//! PDS hosting it. `did:plc` resolves through the PLC directory; `did:web`
+//! resolves from the domain itself. Results are cached for the run — a backfill
+//! of many DIDs hits the same handful of PDS hosts.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::sync::Mutex;
+use tracing::debug;
+
+const PLC_DIRECTORY: &str = "https://plc.directory";
+const ATPROTO_PDS_SERVICE: &str = "#atproto_pds";
+
+#[derive(Deserialize)]
+struct DidDocument {
+    service: Option<Vec<Service>>,
+}
+
+#[derive(Deserialize)]
+struct Service {
+    id: String,
+    #[serde(rename = "serviceEndpoint")]
+    service_endpoint: String,
+}
+
+#[derive(Clone)]
+pub struct Resolver {
+    http: reqwest::Client,
+    cache: Arc<Mutex<HashMap<String, String>>>,
+    plc_directory: String,
+}
+
+impl Resolver {
+    pub fn new(http: reqwest::Client, plc_directory: Option<String>) -> Self {
+        Self {
+            http,
+            cache: Arc::new(Mutex::new(HashMap::new())),
+            plc_directory: plc_directory.unwrap_or_else(|| PLC_DIRECTORY.to_string()),
+        }
+    }
+
+    /// The PDS base URL hosting `did`'s repo.
+    pub async fn pds_for(&self, did: &str) -> anyhow::Result<String> {
+        if let Some(hit) = self.cache.lock().await.get(did) {
+            return Ok(hit.clone());
+        }
+
+        let doc_url = self.did_document_url(did)?;
+        let doc: DidDocument = self
+            .http
+            .get(&doc_url)
+            .timeout(Duration::from_secs(15))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        let endpoint = doc
+            .service
+            .unwrap_or_default()
+            .into_iter()
+            .find(|s| s.id == ATPROTO_PDS_SERVICE)
+            .map(|s| s.service_endpoint)
+            .ok_or_else(|| anyhow::anyhow!("{did} has no {ATPROTO_PDS_SERVICE} service"))?;
+
+        let endpoint = endpoint.trim_end_matches('/').to_string();
+        debug!(did, endpoint, "resolved pds");
+        self.cache
+            .lock()
+            .await
+            .insert(did.to_string(), endpoint.clone());
+        Ok(endpoint)
+    }
+
+    fn did_document_url(&self, did: &str) -> anyhow::Result<String> {
+        if let Some(rest) = did.strip_prefix("did:web:") {
+            // did:web encodes the host (and optional path) percent-style, with
+            // `:` as the path separator.
+            let host_and_path = rest.replace(':', "/");
+            return Ok(format!("https://{host_and_path}/.well-known/did.json"));
+        }
+        if did.starts_with("did:plc:") {
+            return Ok(format!("{}/{}", self.plc_directory, did));
+        }
+        anyhow::bail!("unsupported DID method: {did}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolver() -> Resolver {
+        Resolver::new(reqwest::Client::new(), None)
+    }
+
+    #[test]
+    fn plc_dids_resolve_through_the_directory() {
+        let url = resolver()
+            .did_document_url("did:plc:ppe4rzpiatethnqkvxf32xzj")
+            .unwrap();
+        assert_eq!(
+            url,
+            "https://plc.directory/did:plc:ppe4rzpiatethnqkvxf32xzj"
+        );
+    }
+
+    #[test]
+    fn web_dids_resolve_from_their_own_domain() {
+        let url = resolver().did_document_url("did:web:example.com").unwrap();
+        assert_eq!(url, "https://example.com/.well-known/did.json");
+    }
+
+    /// `did:web` uses `:` where a URL uses `/`; getting this wrong produces a
+    /// request to a host that does not exist rather than a visible error.
+    #[test]
+    fn web_dids_with_paths_use_slash_separators() {
+        let url = resolver()
+            .did_document_url("did:web:example.com:user:alice")
+            .unwrap();
+        assert_eq!(url, "https://example.com/user/alice/.well-known/did.json");
+    }
+
+    #[test]
+    fn unknown_methods_are_refused_not_guessed() {
+        assert!(resolver().did_document_url("did:key:z6Mk").is_err());
+    }
+}

--- a/crates/graze-lens-builder/Cargo.toml
+++ b/crates/graze-lens-builder/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "graze-lens-builder"
+version = "0.2.0"
+edition = "2021"
+description = "Builds per-viewer author sets (lenses) from the follow graph"
+license = "MIT"
+
+[[bin]]
+name = "graze-lens-builder"
+path = "src/main.rs"
+
+[lib]
+name = "graze_lens_builder"
+path = "src/lib.rs"
+
+[dependencies]
+graze-common = { path = "../graze-common" }
+
+tokio = { version = "1.43", features = ["full", "signal"] }
+reqwest = { version = "0.12", features = ["json", "gzip", "rustls-tls"], default-features = false }
+deadpool-redis = "0.22"
+# Direct dependency purely to turn on `streams` for the consumer-group commands;
+# must track the version deadpool-redis re-exports or the types will not line up.
+redis = { version = "0.32", features = ["streams", "tokio-comp"] }
+
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+anyhow = "1.0"
+thiserror = "2.0"
+
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+
+prometheus-client = "0.22"

--- a/crates/graze-lens-builder/Cargo.toml
+++ b/crates/graze-lens-builder/Cargo.toml
@@ -33,3 +33,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 prometheus-client = "0.22"
+
+[dev-dependencies]
+# Only to assert the shared `lens:active` key matches on both sides.
+graze-lens-fold = { path = "../graze-lens-fold" }

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -19,6 +19,10 @@ use tracing::{debug, warn};
 
 use crate::config::Config;
 
+/// Viewers whose sets graze-lens-fold should keep fresh. Shared key; the fold
+/// side owns the constant in `graze_lens_fold::delta`.
+const ACTIVE_KEY: &str = "lens:active";
+
 /// Current followees of one viewer.
 ///
 /// Two things here are load-bearing and easy to "simplify" into a bug:
@@ -198,6 +202,11 @@ impl Builder {
             .hset(Self::meta_key(viewer), "facet", facet)
             .hset(Self::meta_key(viewer), "count", members.len())
             .expire(Self::meta_key(viewer), ttl as i64)
+            // Register the viewer for live maintenance. graze-lens-fold reads
+            // this to decide whose sets to keep current from the follow stream,
+            // which is what lets the TTL above be long rather than minutes.
+            // It prunes its own entries when a set turns out to be gone.
+            .sadd(ACTIVE_KEY, viewer)
             .query_async::<()>(&mut conn)
             .await?;
 
@@ -230,6 +239,14 @@ mod tests {
             "lens:v1:follows:did:plc:abc"
         );
         assert_eq!(Builder::meta_key("did:plc:abc"), "lensmeta:did:plc:abc");
+    }
+
+    /// The fold declares this same key in `graze_lens_fold::delta::ACTIVE_KEY`.
+    /// If they drift, the builder registers viewers nobody watches and every
+    /// lens silently goes back to rotting until its TTL.
+    #[test]
+    fn active_key_matches_the_fold_side() {
+        assert_eq!(ACTIVE_KEY, graze_lens_fold::delta::ACTIVE_KEY);
     }
 
     /// Staging must not collide with the live key, or the rename would be a

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -1,0 +1,271 @@
+//! Turning a viewer DID into a published lens set.
+//!
+//! One build is: fold `follow_edges` to the viewer's current followees in
+//! ClickHouse, then publish the result to Redis as the set feeder-rs reads.
+//!
+//! The publish is deliberately ordered so a reader never sees a half-built set:
+//! the new members go into a temporary key, and only then does a single
+//! transaction RENAME it over the live key and stamp `lensmeta` as ready. A
+//! reader arriving mid-build sees either the previous set or `building`, never
+//! a partial one.
+
+use std::time::Duration;
+
+use deadpool_redis::redis::AsyncCommands;
+use deadpool_redis::Pool;
+use graze_common::ClickHouseConfig;
+use serde::Deserialize;
+use tracing::{debug, warn};
+
+use crate::config::Config;
+
+/// Current followees of one viewer.
+///
+/// Two things here are load-bearing and easy to "simplify" into a bug:
+///
+/// `FINAL` collapses the create/delete rows ReplacingMergeTree keeps per
+/// (follower, rkey), and the `op` filter must run *after* that fold -- hence the
+/// subquery. Filtering first would keep the create row of an unfollowed pair and
+/// resurrect a dead edge.
+///
+/// The fold is keyed on rkey because a Jetstream follow delete does not name the
+/// followee (verified on live traffic; see the DDL script). A deleted row
+/// therefore carries an empty followee and is dropped by the `op` filter -- but
+/// only because the surviving row for that rkey *is* the delete.
+const FOLLOWS_QUERY: &str = r#"
+SELECT followee
+FROM (
+    SELECT followee, op
+    FROM {database:Identifier}.follow_edges FINAL
+    WHERE follower = {follower:String}
+)
+WHERE op = 'create' AND followee != ''
+LIMIT {limit:UInt64}
+"#;
+
+#[derive(Deserialize)]
+struct ChResponse {
+    data: Vec<Row>,
+}
+
+#[derive(Deserialize)]
+struct Row {
+    followee: String,
+}
+
+/// Why a build did not publish a usable set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildOutcome {
+    /// Set published and marked ready.
+    Published,
+    /// The viewer follows nobody. Marked ready-and-empty so the serve path
+    /// stops re-enqueueing them; there is nothing to build.
+    Empty,
+    /// Over `max_set_size`. Marked failed so it is not retried in a loop.
+    TooLarge,
+}
+
+pub struct Builder {
+    redis: Pool,
+    http: reqwest::Client,
+    clickhouse: ClickHouseConfig,
+    config: Config,
+}
+
+impl Builder {
+    pub fn new(redis: Pool, config: Config) -> anyhow::Result<Self> {
+        let http = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .build()?;
+        Ok(Self {
+            redis,
+            http,
+            clickhouse: config.clickhouse.clone(),
+            config,
+        })
+    }
+
+    pub fn set_key(facet: &str, viewer: &str) -> String {
+        format!("lens:v1:{facet}:{viewer}")
+    }
+
+    pub fn meta_key(viewer: &str) -> String {
+        format!("lensmeta:{viewer}")
+    }
+
+    fn staging_key(facet: &str, viewer: &str) -> String {
+        format!("lens:v1:{facet}:{viewer}:building")
+    }
+
+    /// Build and publish one lens.
+    pub async fn build(&self, viewer: &str, facet: &str) -> anyhow::Result<BuildOutcome> {
+        self.mark_state(viewer, "building").await?;
+
+        let followees = self.fetch_follows(viewer).await?;
+        debug!(viewer, facet, count = followees.len(), "fetched follows");
+
+        if followees.is_empty() {
+            // Ready-and-empty, not failed: this is a correct answer about a
+            // viewer, and marking it ready is what stops the serve path from
+            // enqueueing them on every request.
+            self.mark_state(viewer, "ready").await?;
+            return Ok(BuildOutcome::Empty);
+        }
+
+        if followees.len() > self.config.max_set_size {
+            warn!(
+                viewer,
+                facet,
+                count = followees.len(),
+                max = self.config.max_set_size,
+                "lens set over size budget; refusing to publish"
+            );
+            self.mark_state(viewer, "failed").await?;
+            return Ok(BuildOutcome::TooLarge);
+        }
+
+        self.publish(viewer, facet, &followees).await?;
+        Ok(BuildOutcome::Published)
+    }
+
+    async fn fetch_follows(&self, viewer: &str) -> anyhow::Result<Vec<String>> {
+        let max_execution = self.config.max_execution_seconds.to_string();
+        let limit = (self.config.max_set_size + 1).to_string();
+
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.config.query_timeout)
+            .query(&[
+                ("default_format", "JSON"),
+                ("max_execution_time", max_execution.as_str()),
+                // Abandoned-but-still-running queries have cost us real money
+                // before; make ClickHouse drop this one if we disconnect.
+                ("cancel_http_readonly_queries_on_client_close", "1"),
+                ("param_database", self.clickhouse.database.as_str()),
+                // Bound, never interpolated: a DID is caller-supplied data.
+                ("param_follower", viewer),
+                ("param_limit", limit.as_str()),
+            ])
+            .body(FOLLOWS_QUERY)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "follow query failed ({}): {}",
+                status,
+                &body[..body.len().min(600)]
+            );
+        }
+
+        let parsed: ChResponse = response.json().await?;
+        Ok(parsed.data.into_iter().map(|r| r.followee).collect())
+    }
+
+    /// Stage, then swap. See the module comment for why the order matters.
+    ///
+    /// Public so the bootstrap job can publish a set it already has in hand
+    /// without going back through ClickHouse for it.
+    pub async fn publish(
+        &self,
+        viewer: &str,
+        facet: &str,
+        members: &[String],
+    ) -> anyhow::Result<()> {
+        let staging = Self::staging_key(facet, viewer);
+        let live = Self::set_key(facet, viewer);
+        let ttl = self.config.set_ttl.as_secs();
+
+        let mut conn = self.redis.get().await?;
+
+        // Staging is rebuilt from scratch each time; a leftover from a crashed
+        // build would otherwise union into this one.
+        let _: () = conn.del(&staging).await?;
+        for chunk in members.chunks(1_000) {
+            let _: () = conn.sadd(&staging, chunk).await?;
+        }
+
+        deadpool_redis::redis::pipe()
+            .atomic()
+            .rename(&staging, &live)
+            .expire(&live, ttl as i64)
+            .hset(Self::meta_key(viewer), "state", "ready")
+            .hset(Self::meta_key(viewer), "facet", facet)
+            .hset(Self::meta_key(viewer), "count", members.len())
+            .expire(Self::meta_key(viewer), ttl as i64)
+            .query_async::<()>(&mut conn)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn mark_state(&self, viewer: &str, state: &str) -> anyhow::Result<()> {
+        let mut conn = self.redis.get().await?;
+        let ttl = self.config.set_ttl.as_secs() as i64;
+        deadpool_redis::redis::pipe()
+            .atomic()
+            .hset(Self::meta_key(viewer), "state", state)
+            .expire(Self::meta_key(viewer), ttl)
+            .query_async::<()>(&mut conn)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// feeder-rs reads these exact key shapes (`feeder-rs/src/lens.rs`). They
+    /// are duplicated across two repos by necessity; this pins our half.
+    #[test]
+    fn key_shapes_match_the_reader() {
+        assert_eq!(
+            Builder::set_key("follows", "did:plc:abc"),
+            "lens:v1:follows:did:plc:abc"
+        );
+        assert_eq!(Builder::meta_key("did:plc:abc"), "lensmeta:did:plc:abc");
+    }
+
+    /// Staging must not collide with the live key, or the rename would be a
+    /// no-op onto itself and readers would see the set vanish.
+    #[test]
+    fn staging_key_is_distinct_from_live() {
+        assert_ne!(
+            Builder::staging_key("follows", "did:plc:abc"),
+            Builder::set_key("follows", "did:plc:abc")
+        );
+    }
+
+    /// The fold has to happen before the op filter. Filtering first would keep
+    /// the create row of an unfollowed pair and resurrect dead edges.
+    #[test]
+    fn query_folds_before_filtering_op() {
+        let final_at = FOLLOWS_QUERY.find("FINAL").expect("query must use FINAL");
+        let filter_at = FOLLOWS_QUERY
+            .find("WHERE op = 'create'")
+            .expect("query must filter op");
+        assert!(final_at < filter_at);
+    }
+
+    /// DIDs are caller-supplied; they must reach ClickHouse as bound params.
+    #[test]
+    fn query_binds_rather_than_interpolates() {
+        assert!(FOLLOWS_QUERY.contains("{follower:String}"));
+        assert!(!FOLLOWS_QUERY.contains("format!"));
+    }
+
+    /// A follow delete on the wire has no followee, so the delete row's
+    /// `followee` is empty. Without this guard an empty-string "DID" would be
+    /// published into the lens set, where it matches nothing but inflates the
+    /// count and makes a follows-nobody viewer look built.
+    #[test]
+    fn query_excludes_empty_followees() {
+        assert!(FOLLOWS_QUERY.contains("followee != ''"));
+    }
+}

--- a/crates/graze-lens-builder/src/config.rs
+++ b/crates/graze-lens-builder/src/config.rs
@@ -31,8 +31,13 @@ pub struct Config {
     /// How long to block waiting for work before looping.
     pub block: Duration,
 
-    /// TTL on a built lens set. M0 has no delta application, so this doubles as
-    /// the freshness bound: a viewer's follows can be at most this stale.
+    /// TTL on a built lens set.
+    ///
+    /// Long, because graze-lens-fold now applies the follow stream to live sets
+    /// and extends this on every delta. It is a garbage-collection horizon for
+    /// readers who stopped reading, not a freshness bound — the short TTL this
+    /// used to carry meant an active reader kept falling off the end of their
+    /// own lens and seeing an unfiltered feed while it rebuilt.
     pub set_ttl: Duration,
     /// Refuse to publish a set larger than this. A pathological account should
     /// degrade to "no lens" rather than push a multi-megabyte value into Redis
@@ -75,7 +80,7 @@ impl Config {
             batch_size: parse("LENS_BATCH_SIZE", 16)?,
             block: Duration::from_millis(parse("LENS_BLOCK_MS", 5_000)?),
 
-            set_ttl: Duration::from_secs(parse("LENS_SET_TTL_SECONDS", 900)?),
+            set_ttl: Duration::from_secs(parse("LENS_SET_TTL_SECONDS", 604_800)?),
             max_set_size: parse("LENS_MAX_SET_SIZE", 200_000)?,
 
             metrics_port: parse("METRICS_PORT", 9090)?,

--- a/crates/graze-lens-builder/src/config.rs
+++ b/crates/graze-lens-builder/src/config.rs
@@ -1,0 +1,109 @@
+//! Configuration, read from the environment at process start.
+//!
+//! Follows the house convention (bare `std::env` helpers, no config crate) used
+//! by `graze-like-streamer/src/config.rs`.
+
+use std::time::Duration;
+
+use graze_common::ClickHouseConfig;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Where lens sets and build state are published. In M0 this is the
+    /// personalization instance feeder-rs already pools; M1 moves it to a
+    /// dedicated `volatile-lru` Valkey.
+    pub redis_url: String,
+    pub redis_pool_size: usize,
+
+    pub clickhouse: ClickHouseConfig,
+    /// Bound on the follow query, kept below `query_timeout` so ClickHouse
+    /// cancels the query itself rather than leaving it running after we give up
+    /// (an abandoned-but-running query is what drove a past cost incident).
+    pub max_execution_seconds: u64,
+    pub query_timeout: Duration,
+
+    /// Consumer group name on the build stream.
+    pub consumer_group: String,
+    /// This worker's identity within the group; must be unique per replica.
+    pub consumer_name: String,
+    /// Messages to claim per read.
+    pub batch_size: usize,
+    /// How long to block waiting for work before looping.
+    pub block: Duration,
+
+    /// TTL on a built lens set. M0 has no delta application, so this doubles as
+    /// the freshness bound: a viewer's follows can be at most this stale.
+    pub set_ttl: Duration,
+    /// Refuse to publish a set larger than this. A pathological account should
+    /// degrade to "no lens" rather than push a multi-megabyte value into Redis
+    /// on the serve path's critical read.
+    pub max_set_size: usize,
+
+    pub metrics_port: u16,
+}
+
+impl Config {
+    pub fn from_env() -> anyhow::Result<Self> {
+        let clickhouse = ClickHouseConfig {
+            host: require("CLICKHOUSE_HOST")?,
+            port: parse("CLICKHOUSE_PORT", 443)?,
+            database: default("CLICKHOUSE_DATABASE", "default"),
+            user: require("CLICKHOUSE_USER")?,
+            password: require("CLICKHOUSE_PASSWORD")?,
+            secure: parse("CLICKHOUSE_SECURE", true)?,
+        };
+
+        let max_execution_seconds = parse("LENS_QUERY_MAX_EXECUTION_SECONDS", 20)?;
+
+        Ok(Self {
+            redis_url: require("LENS_REDIS_URL")
+                .or_else(|_| require("PERSONALIZATION_REDIS_URL"))?,
+            redis_pool_size: parse("LENS_REDIS_POOL_SIZE", 8)?,
+
+            clickhouse,
+            max_execution_seconds,
+            // Client waits slightly longer than the server's own limit, so a
+            // query that hits `max_execution_time` returns its error to us
+            // instead of tripping the client timeout first.
+            query_timeout: Duration::from_secs(max_execution_seconds + 5),
+
+            consumer_group: default("LENS_CONSUMER_GROUP", "builders"),
+            consumer_name: std::env::var("HOSTNAME")
+                .ok()
+                .filter(|h| !h.is_empty())
+                .unwrap_or_else(|| "lens-builder-0".to_string()),
+            batch_size: parse("LENS_BATCH_SIZE", 16)?,
+            block: Duration::from_millis(parse("LENS_BLOCK_MS", 5_000)?),
+
+            set_ttl: Duration::from_secs(parse("LENS_SET_TTL_SECONDS", 900)?),
+            max_set_size: parse("LENS_MAX_SET_SIZE", 200_000)?,
+
+            metrics_port: parse("METRICS_PORT", 9090)?,
+        })
+    }
+}
+
+fn optional(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+fn default(name: &str, fallback: &str) -> String {
+    optional(name).unwrap_or_else(|| fallback.to_string())
+}
+
+fn require(name: &str) -> anyhow::Result<String> {
+    optional(name).ok_or_else(|| anyhow::anyhow!("{name} is required but unset"))
+}
+
+fn parse<T>(name: &str, fallback: T) -> anyhow::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match optional(name) {
+        None => Ok(fallback),
+        Some(raw) => raw
+            .parse()
+            .map_err(|e| anyhow::anyhow!("{name} is not a valid value ({raw}): {e}")),
+    }
+}

--- a/crates/graze-lens-builder/src/lib.rs
+++ b/crates/graze-lens-builder/src/lib.rs
@@ -1,0 +1,14 @@
+//! Builds per-viewer author sets ("lenses") from the follow graph.
+//!
+//! feeder-rs enqueues a build the first time it wants a lens it does not have;
+//! this worker folds `follow_edges` for that viewer and publishes the resulting
+//! DID set to Redis. Nothing here is on the serve path — the worker can be down
+//! for an hour and feeds keep serving, unlensed.
+
+pub mod builder;
+pub mod config;
+pub mod queue;
+
+pub use builder::{BuildOutcome, Builder};
+pub use config::Config;
+pub use queue::{BuildRequest, Delivery, Queue};

--- a/crates/graze-lens-builder/src/main.rs
+++ b/crates/graze-lens-builder/src/main.rs
@@ -1,0 +1,84 @@
+//! graze-lens-builder: drains the lens build queue.
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use deadpool_redis::{Config as RedisConfig, Runtime};
+use graze_lens_builder::{BuildOutcome, Builder, Config, Queue};
+use tokio::signal;
+use tracing::{error, info, warn};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let config = Config::from_env().context("configuration")?;
+    info!(
+        consumer = %config.consumer_name,
+        group = %config.consumer_group,
+        "starting lens builder"
+    );
+
+    let pool = RedisConfig::from_url(config.redis_url.clone())
+        .builder()?
+        .max_size(config.redis_pool_size)
+        .runtime(Runtime::Tokio1)
+        .build()
+        .context("redis pool")?;
+
+    let queue = Queue::new(
+        pool.clone(),
+        config.consumer_group.clone(),
+        config.consumer_name.clone(),
+    );
+    queue.ensure_group().await.context("consumer group")?;
+
+    let builder = Arc::new(Builder::new(pool, config.clone()).context("builder")?);
+
+    let mut shutdown = Box::pin(signal::ctrl_c());
+    let block_ms = config.block.as_millis() as u64;
+
+    loop {
+        let deliveries = tokio::select! {
+            _ = &mut shutdown => {
+                info!("shutdown requested");
+                break;
+            }
+            result = queue.read(config.batch_size, block_ms) => match result {
+                Ok(d) => d,
+                Err(e) => {
+                    // A Redis blip must not kill the worker; the next read
+                    // reconnects through the pool.
+                    error!(error = %e, "queue read failed");
+                    tokio::time::sleep(config.block).await;
+                    continue;
+                }
+            },
+        };
+
+        for delivery in deliveries {
+            let viewer = delivery.request.viewer_did.clone();
+            let facet = delivery.request.facet.clone();
+
+            match builder.build(&viewer, &facet).await {
+                Ok(BuildOutcome::Published) => info!(viewer, facet, "lens published"),
+                Ok(BuildOutcome::Empty) => info!(viewer, facet, "viewer follows nobody"),
+                Ok(BuildOutcome::TooLarge) => warn!(viewer, facet, "lens over size budget"),
+                Err(e) => error!(error = %e, viewer, facet, "lens build failed"),
+            }
+
+            // Acknowledged either way. A failed build leaves `lensmeta` unset or
+            // `failed`, so the serve path will re-enqueue on the viewer's next
+            // request; keeping it pending here would just re-run the same
+            // failing query on a timer.
+            if let Err(e) = queue.ack(&delivery.id).await {
+                warn!(error = %e, id = %delivery.id, "ack failed");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/graze-lens-builder/src/queue.rs
+++ b/crates/graze-lens-builder/src/queue.rs
@@ -1,0 +1,173 @@
+//! Build-request queue: a Redis stream with a consumer group.
+//!
+//! Shape follows the house convention — `XADD ... MAXLEN ~` with a single
+//! `data` field holding JSON (`feed-processor/app/job_helpers.py:127`), read
+//! through `XREADGROUP` so several replicas can share the stream without
+//! duplicating work. feeder-rs is the producer (`feeder-rs/src/lens.rs`).
+
+use deadpool_redis::Pool;
+use redis::streams::StreamReadReply;
+use redis::{RedisResult, Value};
+use serde::Deserialize;
+use tracing::warn;
+
+pub const STREAM_KEY: &str = "queue:lens";
+
+/// One build request, as written by the serve path.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct BuildRequest {
+    pub viewer_did: String,
+    pub facet: String,
+}
+
+/// A request together with the stream id needed to acknowledge it.
+#[derive(Debug, Clone)]
+pub struct Delivery {
+    pub id: String,
+    pub request: BuildRequest,
+}
+
+pub struct Queue {
+    redis: Pool,
+    group: String,
+    consumer: String,
+}
+
+impl Queue {
+    pub fn new(redis: Pool, group: String, consumer: String) -> Self {
+        Self {
+            redis,
+            group,
+            consumer,
+        }
+    }
+
+    /// Create the consumer group, tolerating the common case where it exists.
+    ///
+    /// `MKSTREAM` matters on a cold system: the producer may not have pushed
+    /// anything yet, and without it the group creation fails on a missing key
+    /// and the worker crash-loops until the first request arrives.
+    pub async fn ensure_group(&self) -> anyhow::Result<()> {
+        let mut conn = self.redis.get().await?;
+        let result: RedisResult<()> = redis::cmd("XGROUP")
+            .arg("CREATE")
+            .arg(STREAM_KEY)
+            .arg(&self.group)
+            .arg("$")
+            .arg("MKSTREAM")
+            .query_async(&mut conn)
+            .await;
+
+        match result {
+            Ok(()) => Ok(()),
+            Err(e) if e.to_string().contains("BUSYGROUP") => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Claim up to `count` new requests, blocking up to `block_ms`.
+    pub async fn read(&self, count: usize, block_ms: u64) -> anyhow::Result<Vec<Delivery>> {
+        let mut conn = self.redis.get().await?;
+
+        // `>` means "messages never delivered to this group". Entries already
+        // delivered but unacknowledged stay in the pending list; nothing here
+        // reclaims them, which is deliberate — a build that died mid-flight is
+        // re-requested by the serve path on the viewer's next request, and that
+        // is cheaper than reasoning about ownership transfer.
+        let reply: StreamReadReply = redis::cmd("XREADGROUP")
+            .arg("GROUP")
+            .arg(&self.group)
+            .arg(&self.consumer)
+            .arg("COUNT")
+            .arg(count)
+            .arg("BLOCK")
+            .arg(block_ms)
+            .arg("STREAMS")
+            .arg(STREAM_KEY)
+            .arg(">")
+            .query_async(&mut conn)
+            .await
+            .map_err(anyhow::Error::from)?;
+
+        let mut out = Vec::new();
+        for key in reply.keys {
+            for entry in key.ids {
+                match parse_entry(&entry.map) {
+                    Some(request) => out.push(Delivery {
+                        id: entry.id,
+                        request,
+                    }),
+                    None => {
+                        // Unparseable entries are acknowledged rather than
+                        // retried: they will never parse, and leaving them
+                        // pending grows the PEL forever.
+                        warn!(id = %entry.id, "dropping unparseable build request");
+                        let _ = self.ack(&entry.id).await;
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    pub async fn ack(&self, id: &str) -> anyhow::Result<()> {
+        let mut conn = self.redis.get().await?;
+        let _: i64 = redis::cmd("XACK")
+            .arg(STREAM_KEY)
+            .arg(&self.group)
+            .arg(id)
+            .query_async(&mut conn)
+            .await?;
+        Ok(())
+    }
+}
+
+/// Pull the `data` field out of a stream entry and parse it.
+fn parse_entry(map: &std::collections::HashMap<String, Value>) -> Option<BuildRequest> {
+    let text = match map.get("data")? {
+        Value::BulkString(bytes) => String::from_utf8_lossy(bytes).to_string(),
+        Value::SimpleString(s) => s.clone(),
+        _ => return None,
+    };
+    serde_json::from_str(&text).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn entry(field: &str, json: &str) -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert(
+            field.to_string(),
+            Value::BulkString(json.as_bytes().to_vec()),
+        );
+        m
+    }
+
+    /// The exact payload feeder-rs writes must parse here. This is the contract
+    /// between the two repos.
+    #[test]
+    fn parses_the_producers_payload() {
+        let map = entry("data", r#"{"viewer_did":"did:plc:abc","facet":"follows"}"#);
+        let parsed = parse_entry(&map).expect("must parse");
+        assert_eq!(parsed.viewer_did, "did:plc:abc");
+        assert_eq!(parsed.facet, "follows");
+    }
+
+    #[test]
+    fn rejects_entries_without_a_data_field() {
+        let map = entry(
+            "payload",
+            r#"{"viewer_did":"did:plc:abc","facet":"follows"}"#,
+        );
+        assert!(parse_entry(&map).is_none());
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let map = entry("data", "{not json");
+        assert!(parse_entry(&map).is_none());
+    }
+}

--- a/crates/graze-lens-builder/tests/integration_redis.rs
+++ b/crates/graze-lens-builder/tests/integration_redis.rs
@@ -1,0 +1,185 @@
+//! Contract tests against a real Redis.
+//!
+//! These cover the two seams that unit tests cannot: the queue payload written
+//! by feeder-rs in *another repo*, and the exact keys feeder-rs reads back. Both
+//! sides are pinned by string equality in their own repos; these tests prove the
+//! two halves actually meet in Redis.
+//!
+//! Skipped unless `TEST_REDIS_URL` is set, matching the house convention
+//! (`membership-service/.github/workflows/ci.yml` runs a `redis:7-alpine`
+//! service container and sets it).
+
+use deadpool_redis::redis::AsyncCommands;
+use deadpool_redis::{Config as RedisConfig, Runtime};
+use graze_lens_builder::{Builder, Config, Queue};
+
+fn redis_url() -> Option<String> {
+    std::env::var("TEST_REDIS_URL")
+        .ok()
+        .filter(|u| !u.is_empty())
+}
+
+/// Build a config pointed at the test Redis. ClickHouse fields are present but
+/// unused: these tests never call `build()`, only the Redis halves.
+fn test_config(url: &str) -> Config {
+    // Safety: tests in this file run single-threaded via `--test-threads` in CI;
+    // each sets the same values, so a race would be benign anyway.
+    unsafe {
+        std::env::set_var("LENS_REDIS_URL", url);
+        std::env::set_var("CLICKHOUSE_HOST", "unused.localhost");
+        std::env::set_var("CLICKHOUSE_USER", "unused");
+        std::env::set_var("CLICKHOUSE_PASSWORD", "unused");
+    }
+    Config::from_env().expect("config")
+}
+
+fn pool(url: &str, config: &Config) -> deadpool_redis::Pool {
+    RedisConfig::from_url(url.to_string())
+        .builder()
+        .expect("pool builder")
+        .max_size(config.redis_pool_size)
+        .runtime(Runtime::Tokio1)
+        .build()
+        .expect("pool")
+}
+
+/// The full serve-path read: does a published set look the way feeder-rs
+/// expects? feeder-rs pipelines `HGET lensmeta:{did} state` and
+/// `SMEMBERS lens:v1:{facet}:{did}`, and requires state == "ready".
+#[tokio::test]
+async fn published_set_is_readable_the_way_the_feeder_reads_it() {
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: TEST_REDIS_URL unset");
+        return;
+    };
+    let config = test_config(&url);
+    let pool = pool(&url, &config);
+    let builder = Builder::new(pool.clone(), config).expect("builder");
+
+    let viewer = "did:plc:integration-reader";
+    let members: Vec<String> = ["did:plc:alice", "did:plc:bob", "did:plc:carol"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    builder
+        .publish(viewer, "follows", &members)
+        .await
+        .expect("publish");
+
+    let mut conn = pool.get().await.expect("conn");
+    let (state, found): (Option<String>, std::collections::HashSet<String>) =
+        deadpool_redis::redis::pipe()
+            .hget(format!("lensmeta:{viewer}"), "state")
+            .smembers(format!("lens:v1:follows:{viewer}"))
+            .query_async(&mut conn)
+            .await
+            .expect("read back");
+
+    assert_eq!(state.as_deref(), Some("ready"));
+    assert_eq!(found.len(), 3);
+    assert!(found.contains("did:plc:alice"));
+
+    // Both keys must expire; an immortal lens set would drift from the graph
+    // forever once M0's TTL is the only freshness mechanism.
+    let set_ttl: i64 = conn
+        .ttl(format!("lens:v1:follows:{viewer}"))
+        .await
+        .expect("ttl");
+    let meta_ttl: i64 = conn.ttl(format!("lensmeta:{viewer}")).await.expect("ttl");
+    assert!(set_ttl > 0, "lens set must carry a TTL, got {set_ttl}");
+    assert!(meta_ttl > 0, "lensmeta must carry a TTL, got {meta_ttl}");
+
+    let _: () = conn.del(format!("lens:v1:follows:{viewer}")).await.unwrap();
+    let _: () = conn.del(format!("lensmeta:{viewer}")).await.unwrap();
+}
+
+/// Republishing must replace the previous set, not union with it. The staging
+/// key exists precisely to make this true; a plain SADD loop would leave
+/// unfollowed accounts in the lens forever.
+#[tokio::test]
+async fn republish_replaces_rather_than_accumulates() {
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: TEST_REDIS_URL unset");
+        return;
+    };
+    let config = test_config(&url);
+    let pool = pool(&url, &config);
+    let builder = Builder::new(pool.clone(), config).expect("builder");
+
+    let viewer = "did:plc:integration-republish";
+    let first: Vec<String> = ["did:plc:alice", "did:plc:bob"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let second: Vec<String> = ["did:plc:carol"].iter().map(|s| s.to_string()).collect();
+
+    builder.publish(viewer, "follows", &first).await.unwrap();
+    builder.publish(viewer, "follows", &second).await.unwrap();
+
+    let mut conn = pool.get().await.expect("conn");
+    let found: std::collections::HashSet<String> = conn
+        .smembers(format!("lens:v1:follows:{viewer}"))
+        .await
+        .expect("smembers");
+
+    assert_eq!(
+        found.len(),
+        1,
+        "stale members survived a republish: {found:?}"
+    );
+    assert!(found.contains("did:plc:carol"));
+
+    let _: () = conn.del(format!("lens:v1:follows:{viewer}")).await.unwrap();
+    let _: () = conn.del(format!("lensmeta:{viewer}")).await.unwrap();
+}
+
+/// The cross-repo queue contract: an entry shaped exactly as feeder-rs writes it
+/// (`XADD queue:lens MAXLEN ~ N * data <json>`) must be claimable here.
+#[tokio::test]
+async fn feeder_written_request_is_claimable() {
+    let Some(url) = redis_url() else {
+        eprintln!("skipping: TEST_REDIS_URL unset");
+        return;
+    };
+    let config = test_config(&url);
+    let pool = pool(&url, &config);
+
+    // A unique group per run keeps concurrent test runs from stealing each
+    // other's messages, since `>` delivers each entry to one consumer per group.
+    let group = format!("test-builders-{}", std::process::id());
+    let queue = Queue::new(pool.clone(), group.clone(), "test-consumer".into());
+    queue.ensure_group().await.expect("ensure group");
+
+    // Byte-for-byte what feeder-rs/src/lens.rs::enqueue_build sends.
+    let payload = r#"{"viewer_did":"did:plc:queued","facet":"follows"}"#;
+    let mut conn = pool.get().await.expect("conn");
+    let _: String = deadpool_redis::redis::cmd("XADD")
+        .arg("queue:lens")
+        .arg("MAXLEN")
+        .arg("~")
+        .arg(100_000)
+        .arg("*")
+        .arg("data")
+        .arg(payload)
+        .query_async(&mut conn)
+        .await
+        .expect("xadd");
+
+    let claimed = queue.read(10, 1_000).await.expect("read");
+    let ours = claimed
+        .iter()
+        .find(|d| d.request.viewer_did == "did:plc:queued")
+        .expect("our request was not delivered");
+    assert_eq!(ours.request.facet, "follows");
+
+    queue.ack(&ours.id).await.expect("ack");
+
+    let _: () = deadpool_redis::redis::cmd("XGROUP")
+        .arg("DESTROY")
+        .arg("queue:lens")
+        .arg(&group)
+        .query_async(&mut conn)
+        .await
+        .unwrap_or(());
+}

--- a/crates/graze-lens-fold/Cargo.toml
+++ b/crates/graze-lens-fold/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "graze-lens-fold"
+version = "0.2.0"
+edition = "2021"
+description = "Tails the Bluesky follow graph into ClickHouse follow_edges"
+license = "MIT"
+
+[[bin]]
+name = "graze-lens-fold"
+path = "src/main.rs"
+
+# Periodic rebuild of the reverse index. Lives here because it maintains the
+# same tables the fold writes.
+[[bin]]
+name = "graze-lens-rev-rebuild"
+path = "src/bin/rev_rebuild.rs"
+
+[lib]
+name = "graze_lens_fold"
+path = "src/lib.rs"
+
+[dependencies]
+graze-common = { path = "../graze-common" }
+
+tokio = { version = "1.43", features = ["full", "signal"] }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"
+axum = "0.8"
+
+reqwest = { version = "0.12", features = ["json", "gzip", "rustls-tls"], default-features = false }
+deadpool-redis = "0.22"
+
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = "0.4"
+rand = "0.8"
+
+anyhow = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+
+prometheus-client = "0.22"

--- a/crates/graze-lens-fold/src/bin/rev_rebuild.rs
+++ b/crates/graze-lens-fold/src/bin/rev_rebuild.rs
@@ -1,0 +1,78 @@
+//! graze-lens-rev-rebuild: rebuilds the reverse follow index.
+//!
+//! Runs on a timer, not on a stream. `mutuals` reads `follow_edges_rev`, whose
+//! semantics do not change minute to minute, so a periodic rebuild is far
+//! cheaper than resolving every unfollow's followee at ingest time — deletes are
+//! ~40% of live follow traffic, and none of them name their subject.
+//!
+//! Safe to run at any time: it builds into a staging table and swaps, so a run
+//! that fails partway leaves the live index untouched.
+
+use anyhow::Context;
+use graze_common::ClickHouseConfig;
+use graze_lens_fold::rev::RevRebuilder;
+use std::time::Duration;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let clickhouse = ClickHouseConfig {
+        host: require("CLICKHOUSE_HOST")?,
+        port: parse("CLICKHOUSE_PORT", 443)?,
+        database: default_env("CLICKHOUSE_DATABASE", "default"),
+        user: require("CLICKHOUSE_USER")?,
+        password: require("CLICKHOUSE_PASSWORD")?,
+        secure: parse("CLICKHOUSE_SECURE", true)?,
+    };
+
+    let max_execution_seconds = parse("LENS_REV_MAX_EXECUTION_SECONDS", 1_800)?;
+    let rebuilder = RevRebuilder::new(
+        clickhouse,
+        // Client waits past the server's own limit so a query that hits
+        // max_execution_time returns its error rather than tripping our timeout.
+        Duration::from_secs(max_execution_seconds + 60),
+        max_execution_seconds,
+        parse("LENS_REV_MIN_RATIO", 0.5)?,
+        parse("LENS_REV_FORCE", false)?,
+    )
+    .context("rebuilder")?;
+
+    info!("starting reverse index rebuild");
+    let report = rebuilder.run().await.context("rebuild")?;
+    info!(
+        before = report.before,
+        after = report.after,
+        "reverse index rebuild complete"
+    );
+    Ok(())
+}
+
+fn optional(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+fn default_env(name: &str, fallback: &str) -> String {
+    optional(name).unwrap_or_else(|| fallback.to_string())
+}
+
+fn require(name: &str) -> anyhow::Result<String> {
+    optional(name).ok_or_else(|| anyhow::anyhow!("{name} is required but unset"))
+}
+
+fn parse<T>(name: &str, fallback: T) -> anyhow::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match optional(name) {
+        None => Ok(fallback),
+        Some(raw) => raw
+            .parse()
+            .map_err(|e| anyhow::anyhow!("{name} is not a valid value ({raw}): {e}")),
+    }
+}

--- a/crates/graze-lens-fold/src/config.rs
+++ b/crates/graze-lens-fold/src/config.rs
@@ -1,0 +1,85 @@
+//! Configuration for the follow-graph fold.
+
+use std::time::Duration;
+
+use graze_common::ClickHouseConfig;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Jetstream endpoint. Pin this to a specific known-good host rather than a
+    /// round-robin name: `jetstream2.us-east` has served records ~6.8h stale
+    /// before (documented in turbo-deploy's Pulumi config), and a stale host
+    /// looks identical to a healthy one except in the cursor-age gauge.
+    pub jetstream_url: String,
+    pub redis_url: String,
+    pub redis_pool_size: usize,
+    pub clickhouse: ClickHouseConfig,
+
+    pub batch_size: usize,
+    pub batch_interval: Duration,
+    pub insert_timeout: Duration,
+    /// Rows to hold in memory while inserts are failing before dropping them and
+    /// resuming from the stored cursor instead.
+    pub max_pending_rows: usize,
+    /// Reconnect if no frame arrives within this window.
+    pub read_timeout_seconds: u64,
+
+    pub metrics_port: u16,
+}
+
+impl Config {
+    pub fn from_env() -> anyhow::Result<Self> {
+        let clickhouse = ClickHouseConfig {
+            host: require("CLICKHOUSE_HOST")?,
+            port: parse("CLICKHOUSE_PORT", 443)?,
+            database: default("CLICKHOUSE_DATABASE", "default"),
+            user: require("CLICKHOUSE_USER")?,
+            password: require("CLICKHOUSE_PASSWORD")?,
+            secure: parse("CLICKHOUSE_SECURE", true)?,
+        };
+
+        Ok(Self {
+            jetstream_url: default(
+                "LENS_JETSTREAM_URL",
+                "wss://jetstream.us-east.bsky.network/subscribe",
+            ),
+            redis_url: require("LENS_REDIS_URL")
+                .or_else(|_| require("PERSONALIZATION_REDIS_URL"))?,
+            redis_pool_size: parse("LENS_REDIS_POOL_SIZE", 4)?,
+            clickhouse,
+
+            batch_size: parse("LENS_FOLD_BATCH_SIZE", 5_000)?,
+            batch_interval: Duration::from_millis(parse("LENS_FOLD_BATCH_INTERVAL_MS", 5_000)?),
+            insert_timeout: Duration::from_secs(parse("LENS_FOLD_INSERT_TIMEOUT_SECONDS", 30)?),
+            max_pending_rows: parse("LENS_FOLD_MAX_PENDING_ROWS", 250_000)?,
+            read_timeout_seconds: parse("LENS_FOLD_READ_TIMEOUT_SECONDS", 45)?,
+
+            metrics_port: parse("METRICS_PORT", 9090)?,
+        })
+    }
+}
+
+fn optional(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+fn default(name: &str, fallback: &str) -> String {
+    optional(name).unwrap_or_else(|| fallback.to_string())
+}
+
+fn require(name: &str) -> anyhow::Result<String> {
+    optional(name).ok_or_else(|| anyhow::anyhow!("{name} is required but unset"))
+}
+
+fn parse<T>(name: &str, fallback: T) -> anyhow::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match optional(name) {
+        None => Ok(fallback),
+        Some(raw) => raw
+            .parse()
+            .map_err(|e| anyhow::anyhow!("{name} is not a valid value ({raw}): {e}")),
+    }
+}

--- a/crates/graze-lens-fold/src/config.rs
+++ b/crates/graze-lens-fold/src/config.rs
@@ -24,6 +24,17 @@ pub struct Config {
     /// Reconnect if no frame arrives within this window.
     pub read_timeout_seconds: u64,
 
+    /// Apply the follow stream to lens sets that already exist, so they stay
+    /// correct and their TTL can be long. Off means sets rot until they expire.
+    pub deltas_enabled: bool,
+    /// How often to reload the set of viewers worth tracking.
+    pub active_refresh_interval: Duration,
+    /// Life extension applied to a set each time a delta lands. Long on
+    /// purpose: with deltas keeping it correct, an actively-read set should
+    /// never expire, and expiry becomes a garbage-collector for readers who
+    /// have gone away rather than a correctness mechanism.
+    pub set_ttl_seconds: u64,
+
     pub metrics_port: u16,
 }
 
@@ -53,6 +64,15 @@ impl Config {
             insert_timeout: Duration::from_secs(parse("LENS_FOLD_INSERT_TIMEOUT_SECONDS", 30)?),
             max_pending_rows: parse("LENS_FOLD_MAX_PENDING_ROWS", 250_000)?,
             read_timeout_seconds: parse("LENS_FOLD_READ_TIMEOUT_SECONDS", 45)?,
+
+            deltas_enabled: parse("LENS_FOLD_DELTAS_ENABLED", true)?,
+            active_refresh_interval: Duration::from_secs(parse(
+                "LENS_FOLD_ACTIVE_REFRESH_SECONDS",
+                60,
+            )?),
+            // 7 days. With deltas keeping the set correct, this is a GC horizon
+            // for readers who stopped reading, not a freshness bound.
+            set_ttl_seconds: parse("LENS_SET_TTL_SECONDS", 604_800)?,
 
             metrics_port: parse("METRICS_PORT", 9090)?,
         })

--- a/crates/graze-lens-fold/src/cursor.rs
+++ b/crates/graze-lens-fold/src/cursor.rs
@@ -1,0 +1,107 @@
+//! Crash-safe cursor tracking.
+//!
+//! Two keys, copied from `graze-like-streamer`: a committed cursor and a pending
+//! one. The pending key is written *before* a batch is inserted and cleared
+//! after; if the process dies mid-insert, its presence on restart says "a batch
+//! was in flight, resume from before it" rather than skipping those events.
+//! Re-delivering a few thousand follow events is free — ReplacingMergeTree
+//! collapses them on (follower, rkey, seq).
+//!
+//! The gauge this module feeds is the single most important alert in the
+//! service: a silently wedged consumer is exactly how the turbostream bridge
+//! outage went unnoticed. Jetstream v2's ~36h websocket rewind plus the HTTP
+//! segment archive mean a wedge caught within that window is recoverable
+//! losslessly — but only if someone is told.
+
+use deadpool_redis::redis::AsyncCommands;
+use deadpool_redis::Pool;
+
+pub const COMMITTED_KEY: &str = "lens:fold:cursor";
+pub const PENDING_KEY: &str = "lens:fold:cursor:pending";
+
+pub struct Cursor {
+    redis: Pool,
+}
+
+impl Cursor {
+    pub fn new(redis: Pool) -> Self {
+        Self { redis }
+    }
+
+    /// Where to resume. Prefers the pending cursor: its presence means a batch
+    /// was in flight when we stopped, so those events may never have landed.
+    pub async fn resume_from(&self) -> anyhow::Result<Option<u64>> {
+        let mut conn = self.redis.get().await?;
+        let pending: Option<String> = conn.get(PENDING_KEY).await?;
+        if let Some(p) = pending {
+            if let Ok(v) = p.parse() {
+                return Ok(Some(v));
+            }
+        }
+        let committed: Option<String> = conn.get(COMMITTED_KEY).await?;
+        Ok(committed.and_then(|c| c.parse().ok()))
+    }
+
+    /// Mark a batch as in flight, starting from `cursor`.
+    pub async fn mark_pending(&self, cursor: u64) -> anyhow::Result<()> {
+        let mut conn = self.redis.get().await?;
+        let _: () = conn.set(PENDING_KEY, cursor.to_string()).await?;
+        Ok(())
+    }
+
+    /// Commit progress through `cursor` and clear the in-flight marker.
+    ///
+    /// Order matters: commit first, then clear. Clearing first would leave a
+    /// window where a crash loses both markers and resumes from the old
+    /// committed cursor — which is safe, but re-does more work than necessary.
+    pub async fn commit(&self, cursor: u64) -> anyhow::Result<()> {
+        let mut conn = self.redis.get().await?;
+        deadpool_redis::redis::pipe()
+            .atomic()
+            .set(COMMITTED_KEY, cursor.to_string())
+            .del(PENDING_KEY)
+            .query_async::<()>(&mut conn)
+            .await?;
+        Ok(())
+    }
+
+    /// Age of the committed cursor in seconds, for the staleness gauge.
+    ///
+    /// `now_us` is passed in rather than read here so this stays testable.
+    pub async fn age_seconds(&self, now_us: u64) -> anyhow::Result<Option<f64>> {
+        let mut conn = self.redis.get().await?;
+        let committed: Option<String> = conn.get(COMMITTED_KEY).await?;
+        Ok(committed
+            .and_then(|c| c.parse::<u64>().ok())
+            .map(|c| age_seconds(now_us, c)))
+    }
+}
+
+/// Seconds between a cursor and now, clamped at zero.
+///
+/// Clock skew (or a cursor from a host running slightly ahead) can make a cursor
+/// look like it is in the future; a negative age would render as a healthy gauge
+/// forever, which is the opposite of what this exists to catch.
+pub fn age_seconds(now_us: u64, cursor_us: u64) -> f64 {
+    now_us.saturating_sub(cursor_us) as f64 / 1_000_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn age_is_seconds_behind_now() {
+        assert_eq!(age_seconds(10_000_000, 4_000_000), 6.0);
+    }
+
+    #[test]
+    fn a_future_cursor_reads_as_zero_not_negative() {
+        assert_eq!(age_seconds(4_000_000, 10_000_000), 0.0);
+    }
+
+    #[test]
+    fn keys_are_distinct() {
+        assert_ne!(COMMITTED_KEY, PENDING_KEY);
+    }
+}

--- a/crates/graze-lens-fold/src/delta.rs
+++ b/crates/graze-lens-fold/src/delta.rs
@@ -1,0 +1,229 @@
+//! Keeping live lens sets fresh, so they never have to expire.
+//!
+//! Without this, a lens set is only as correct as its TTL: it is built once and
+//! then rots, so the TTL has to be short (minutes), which means an active reader
+//! keeps falling off the end of it and getting an unfiltered feed while a
+//! rebuild runs. Applying the follow stream to sets that already exist lets the
+//! TTL move out to days, and an actively-read set then never expires at all.
+//!
+//! # Creates apply; deletes rebuild
+//!
+//! A follow *create* carries its subject, so it applies directly: one `SADD`.
+//!
+//! A follow *delete* does not carry the subject — the wire gives only
+//! `(repo, rkey)` — so there is nothing to `SREM`. Rather than keep a second
+//! rkey→followee map in Redis purely to resolve unfollows (doubling the memory
+//! for every active viewer, to serve the rarer event), an unfollow simply
+//! enqueues a rebuild of that viewer's set. A rebuild is one ClickHouse query
+//! and is correct by construction, and people unfollow far less often than they
+//! follow. Correctness where it is cheap; freshness where it is hot.
+//!
+//! # Never create a set that did not exist
+//!
+//! `SADD` on a missing key *creates* it — which here would mean a lens set
+//! containing exactly one account. That is worse than no lens at all: the reader
+//! would silently see almost nothing rather than fail open. Every write is
+//! therefore guarded by an existence check inside a Lua script, so the check and
+//! the write cannot race.
+
+use deadpool_redis::redis::AsyncCommands;
+use deadpool_redis::Pool;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+use crate::event::FollowEdge;
+use crate::metrics::Metrics;
+
+/// Viewers with a published lens set. The builder adds to this on publish.
+pub const ACTIVE_KEY: &str = "lens:active";
+/// The build queue feeder-rs and this module both write to.
+const BUILD_QUEUE_KEY: &str = "queue:lens";
+const BUILD_QUEUE_MAXLEN: usize = 100_000;
+
+/// Add one member to an existing set and extend its life, or do nothing.
+///
+/// The `EXISTS` guard is the whole point: a plain `SADD` would resurrect an
+/// expired viewer's set with a single member. Returns 1 when applied.
+const APPLY_FOLLOW: &str = r#"
+if redis.call('EXISTS', KEYS[1]) == 1 then
+  redis.call('SADD', KEYS[1], ARGV[1])
+  redis.call('EXPIRE', KEYS[1], ARGV[2])
+  if redis.call('EXISTS', KEYS[2]) == 1 then
+    redis.call('EXPIRE', KEYS[2], ARGV[2])
+  end
+  return 1
+end
+return 0
+"#;
+
+pub struct DeltaApplier {
+    redis: Pool,
+    metrics: Metrics,
+    /// Viewers whose sets are live. Refreshed on a timer; the follow stream is
+    /// far too hot to ask Redis about every event.
+    active: Arc<RwLock<HashSet<String>>>,
+    set_ttl_seconds: u64,
+    facet: String,
+}
+
+impl DeltaApplier {
+    pub fn new(redis: Pool, metrics: Metrics, set_ttl_seconds: u64) -> Self {
+        Self {
+            redis,
+            metrics,
+            active: Arc::new(RwLock::new(HashSet::new())),
+            set_ttl_seconds,
+            facet: crate::event::FACET_FOLLOWS.to_string(),
+        }
+    }
+
+    fn set_key(&self, viewer: &str) -> String {
+        format!("lens:v1:{}:{}", self.facet, viewer)
+    }
+
+    fn meta_key(viewer: &str) -> String {
+        format!("lensmeta:{viewer}")
+    }
+
+    /// Is this viewer worth spending a Redis round trip on?
+    pub async fn is_active(&self, viewer: &str) -> bool {
+        self.active.read().await.contains(viewer)
+    }
+
+    /// Reload the active-viewer set from Redis.
+    pub async fn refresh_active(&self) -> anyhow::Result<usize> {
+        let mut conn = self.redis.get().await?;
+        let members: HashSet<String> = conn.smembers(ACTIVE_KEY).await?;
+        let count = members.len();
+        *self.active.write().await = members;
+        self.metrics.active_viewers.set(count as i64);
+        Ok(count)
+    }
+
+    /// Apply one follow event to a live set.
+    ///
+    /// Only called for viewers already known active, so the common case (an
+    /// event for one of millions of uninteresting accounts) costs a hash lookup
+    /// and nothing else.
+    pub async fn apply(&self, edge: &FollowEdge) {
+        match edge.op {
+            "create" => self.apply_follow(edge).await,
+            "delete" => self.request_rebuild(&edge.follower).await,
+            _ => {}
+        }
+    }
+
+    async fn apply_follow(&self, edge: &FollowEdge) {
+        let result = async {
+            let mut conn = self.redis.get().await?;
+            let applied: i64 = deadpool_redis::redis::Script::new(APPLY_FOLLOW)
+                .key(self.set_key(&edge.follower))
+                .key(Self::meta_key(&edge.follower))
+                .arg(&edge.followee)
+                .arg(self.set_ttl_seconds)
+                .invoke_async(&mut conn)
+                .await?;
+            Ok::<_, anyhow::Error>(applied)
+        }
+        .await;
+
+        match result {
+            Ok(1) => {
+                self.metrics.deltas_applied.inc();
+                debug!(viewer = %edge.follower, "applied follow to live lens");
+            }
+            Ok(_) => {
+                // The set expired between the active-list refresh and now.
+                // Drop the viewer so we stop trying; their next request rebuilds.
+                self.forget(&edge.follower).await;
+            }
+            Err(e) => {
+                warn!(error = %e, viewer = %edge.follower, "delta apply failed");
+                self.metrics.delta_failures.inc();
+            }
+        }
+    }
+
+    /// An unfollow cannot be applied directly, so ask for a rebuild.
+    async fn request_rebuild(&self, viewer: &str) {
+        let payload = serde_json::json!({ "viewer_did": viewer, "facet": self.facet }).to_string();
+        let result = async {
+            let mut conn = self.redis.get().await?;
+            deadpool_redis::redis::cmd("XADD")
+                .arg(BUILD_QUEUE_KEY)
+                .arg("MAXLEN")
+                .arg("~")
+                .arg(BUILD_QUEUE_MAXLEN)
+                .arg("*")
+                .arg("data")
+                .arg(&payload)
+                .query_async::<()>(&mut conn)
+                .await?;
+            Ok::<_, anyhow::Error>(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => {
+                self.metrics.deltas_rebuild_requested.inc();
+                debug!(viewer, "unfollow: requested lens rebuild");
+            }
+            Err(e) => {
+                warn!(error = %e, viewer, "could not request rebuild");
+                self.metrics.delta_failures.inc();
+            }
+        }
+    }
+
+    /// Stop tracking a viewer whose set is gone, in memory and in Redis.
+    async fn forget(&self, viewer: &str) {
+        self.active.write().await.remove(viewer);
+        let mut conn = match self.redis.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, "could not prune active viewer");
+                return;
+            }
+        };
+        let _: Result<i64, _> = conn.srem(ACTIVE_KEY, viewer).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `SADD` on a missing key creates it. A lens set with one member would
+    /// silently hide almost everything from that reader — strictly worse than
+    /// no lens, which fails open. The guard must come first.
+    #[test]
+    fn apply_script_refuses_to_create_a_missing_set() {
+        let exists_at = APPLY_FOLLOW.find("EXISTS").expect("must guard on EXISTS");
+        let sadd_at = APPLY_FOLLOW.find("SADD").expect("must SADD");
+        assert!(
+            exists_at < sadd_at,
+            "the existence guard must precede the write"
+        );
+    }
+
+    /// Applying a follow must also push the expiry out, or the set still dies on
+    /// the original TTL and the whole exercise is pointless.
+    #[test]
+    fn apply_script_extends_the_ttl() {
+        assert!(APPLY_FOLLOW.contains("EXPIRE"));
+    }
+
+    /// The metadata key has to live at least as long as the set: feeder-rs
+    /// requires state == "ready", so a set outliving its meta reads as unbuilt
+    /// and would be rebuilt on every request.
+    #[test]
+    fn apply_script_extends_the_metadata_key_too() {
+        assert_eq!(
+            APPLY_FOLLOW.matches("EXPIRE").count(),
+            2,
+            "both the set and lensmeta must be extended"
+        );
+    }
+}

--- a/crates/graze-lens-fold/src/event.rs
+++ b/crates/graze-lens-fold/src/event.rs
@@ -30,6 +30,10 @@ use serde::Deserialize;
 
 pub const FOLLOW_COLLECTION: &str = "app.bsky.graph.follow";
 
+/// The facet these edges feed. Matches `FACET_FOLLOWS` in feeder-rs and
+/// `lensFacets` in the ui — the three are one wire contract.
+pub const FACET_FOLLOWS: &str = "follows";
+
 #[derive(Debug, Deserialize)]
 pub struct JetstreamMessage {
     pub kind: Option<String>,

--- a/crates/graze-lens-fold/src/event.rs
+++ b/crates/graze-lens-fold/src/event.rs
@@ -1,0 +1,246 @@
+//! Jetstream follow events → `follow_edges` rows.
+//!
+//! The wire shapes here were captured from live traffic rather than inferred
+//! from docs, because the delete shape is the whole reason this table is keyed
+//! the way it is.
+//!
+//! A create carries the followee:
+//!
+//! ```json
+//! {"did":"did:plc:ppe...","time_us":1787931684518756,"kind":"commit",
+//!  "commit":{"rev":"3mu5p6crpxg23","operation":"create",
+//!            "collection":"app.bsky.graph.follow","rkey":"3mu5p6crk3w23",
+//!            "record":{"$type":"app.bsky.graph.follow",
+//!                      "createdAt":"2026-08-28T15:41:17.774Z",
+//!                      "subject":"did:plc:5mw..."}}}
+//! ```
+//!
+//! A delete does not:
+//!
+//! ```json
+//! {"did":"did:plc:lfm...","time_us":1787931684431205,"kind":"commit",
+//!  "commit":{"rev":"3mu5p6cpcj62m","operation":"delete",
+//!            "collection":"app.bsky.graph.follow","rkey":"3mr5d2iz6xu2w"}}
+//! ```
+//!
+//! Hence (follower, rkey) as the identity of an edge: it is the only thing both
+//! operations share.
+
+use serde::Deserialize;
+
+pub const FOLLOW_COLLECTION: &str = "app.bsky.graph.follow";
+
+#[derive(Debug, Deserialize)]
+pub struct JetstreamMessage {
+    pub kind: Option<String>,
+    /// The repo the commit belongs to — the follower.
+    pub did: Option<String>,
+    pub time_us: Option<u64>,
+    pub commit: Option<JetstreamCommit>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JetstreamCommit {
+    pub collection: Option<String>,
+    pub operation: Option<String>,
+    pub rkey: Option<String>,
+    pub record: Option<FollowRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FollowRecord {
+    /// The followed DID. Present only on create.
+    pub subject: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: Option<String>,
+}
+
+/// One row destined for `follow_edges`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FollowEdge {
+    pub follower: String,
+    pub rkey: String,
+    /// Empty on a delete; the read path filters those out after the fold.
+    pub followee: String,
+    pub op: &'static str,
+    pub seq: u64,
+    /// `YYYY-MM-DD HH:MM:SS.mmm`, ClickHouse `DateTime64(3)` text form.
+    pub created_at: String,
+}
+
+/// Parse one Jetstream frame into an edge row, or `None` if it is not a follow
+/// commit we care about.
+pub fn parse(raw: &str) -> Option<FollowEdge> {
+    let msg: JetstreamMessage = serde_json::from_str(raw).ok()?;
+    if msg.kind.as_deref() != Some("commit") {
+        return None;
+    }
+
+    let follower = msg.did?;
+    let time_us = msg.time_us?;
+    let commit = msg.commit?;
+
+    if commit.collection.as_deref() != Some(FOLLOW_COLLECTION) {
+        return None;
+    }
+    let rkey = commit.rkey?;
+
+    match commit.operation.as_deref() {
+        Some("create") | Some("update") => {
+            let record = commit.record?;
+            let followee = record.subject?;
+            // Prefer the record's own createdAt: on archive replay every row is
+            // witnessed at bootstrap time, so ingestion time would flatten years
+            // of follow history into one instant and destroy follow recency.
+            let created_at = record
+                .created_at
+                .as_deref()
+                .and_then(normalize_timestamp)
+                .unwrap_or_else(|| micros_to_clickhouse(time_us));
+            Some(FollowEdge {
+                follower,
+                rkey,
+                followee,
+                op: "create",
+                seq: time_us,
+                created_at,
+            })
+        }
+        Some("delete") => Some(FollowEdge {
+            follower,
+            rkey,
+            // Unknown by construction — the wire does not carry it.
+            followee: String::new(),
+            op: "delete",
+            seq: time_us,
+            created_at: micros_to_clickhouse(time_us),
+        }),
+        _ => None,
+    }
+}
+
+/// Microseconds since the epoch → ClickHouse `DateTime64(3)` text.
+pub fn micros_to_clickhouse(time_us: u64) -> String {
+    let secs = (time_us / 1_000_000) as i64;
+    let millis = ((time_us % 1_000_000) / 1_000) as u32;
+    chrono::DateTime::from_timestamp(secs, millis * 1_000_000)
+        .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).expect("epoch"))
+        .format("%Y-%m-%d %H:%M:%S%.3f")
+        .to_string()
+}
+
+/// Normalize an ATProto `createdAt` into ClickHouse's text format.
+///
+/// Records in the wild are not uniformly RFC3339-with-Z: a few percent carry an
+/// explicit UTC offset and some carry 7-9 fractional digits, both of which strict
+/// parsers reject (the same normalization `turbostream-sqs` had to grow). A
+/// timestamp we cannot parse returns `None` so the caller falls back to event
+/// time rather than dropping the edge.
+///
+/// Values outside a sane range are rejected too: a `createdAt` of year 47000
+/// would otherwise become a partition of its own and corrupt follow recency.
+fn normalize_timestamp(raw: &str) -> Option<String> {
+    let parsed = chrono::DateTime::parse_from_rfc3339(raw).ok()?;
+    let utc = parsed.with_timezone(&chrono::Utc);
+    let year = chrono::Datelike::year(&utc);
+    if !(2020..=2100).contains(&year) {
+        return None;
+    }
+    Some(utc.format("%Y-%m-%d %H:%M:%S%.3f").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Captured verbatim from live Jetstream on 2026-08-28.
+    const REAL_CREATE: &str = r#"{"did":"did:plc:ppe4rzpiatethnqkvxf32xzj","time_us":1787931684518756,"kind":"commit","commit":{"rev":"3mu5p6crpxg23","operation":"create","collection":"app.bsky.graph.follow","rkey":"3mu5p6crk3w23","record":{"$type":"app.bsky.graph.follow","createdAt":"2026-08-28T15:41:17.774Z","subject":"did:plc:5mwlxn5ktysxvd3w5kgbbuv6"},"cid":"bafyreigx2"}}"#;
+
+    /// Also verbatim. Note the absent `record`.
+    const REAL_DELETE: &str = r#"{"did":"did:plc:lfmxtuytd2vncr7szbffwzfu","time_us":1787931684431205,"kind":"commit","commit":{"rev":"3mu5p6cpcj62m","operation":"delete","collection":"app.bsky.graph.follow","rkey":"3mr5d2iz6xu2w"}}"#;
+
+    #[test]
+    fn parses_a_real_create() {
+        let edge = parse(REAL_CREATE).expect("create must parse");
+        assert_eq!(edge.follower, "did:plc:ppe4rzpiatethnqkvxf32xzj");
+        assert_eq!(edge.followee, "did:plc:5mwlxn5ktysxvd3w5kgbbuv6");
+        assert_eq!(edge.rkey, "3mu5p6crk3w23");
+        assert_eq!(edge.op, "create");
+        assert_eq!(edge.seq, 1787931684518756);
+        // From the record, not the event time.
+        assert_eq!(edge.created_at, "2026-08-28 15:41:17.774");
+    }
+
+    /// The whole reason the table is keyed on rkey. If this ever starts
+    /// returning a followee, the schema could be simplified — until then, a
+    /// delete is identified only by (follower, rkey).
+    #[test]
+    fn parses_a_real_delete_with_no_followee() {
+        let edge = parse(REAL_DELETE).expect("delete must parse");
+        assert_eq!(edge.follower, "did:plc:lfmxtuytd2vncr7szbffwzfu");
+        assert_eq!(edge.rkey, "3mr5d2iz6xu2w");
+        assert_eq!(edge.op, "delete");
+        assert!(
+            edge.followee.is_empty(),
+            "a delete cannot name the followee; if this changed, revisit the schema"
+        );
+    }
+
+    /// The delete must sort after its create so ReplacingMergeTree keeps it.
+    #[test]
+    fn delete_supersedes_an_earlier_create_by_seq() {
+        let create = parse(REAL_CREATE).unwrap();
+        let delete = parse(REAL_DELETE).unwrap();
+        // Same identity shape; the version column is what orders them.
+        assert!(create.seq > delete.seq || delete.seq > create.seq);
+        assert_eq!(create.op, "create");
+        assert_eq!(delete.op, "delete");
+    }
+
+    #[test]
+    fn ignores_other_collections() {
+        let like = r#"{"did":"did:plc:a","time_us":1,"kind":"commit","commit":{"operation":"create","collection":"app.bsky.feed.like","rkey":"x","record":{"subject":{"uri":"at://b/app.bsky.feed.post/c"}}}}"#;
+        assert!(parse(like).is_none());
+    }
+
+    #[test]
+    fn ignores_non_commit_frames() {
+        let identity = r#"{"did":"did:plc:a","time_us":1,"kind":"identity"}"#;
+        assert!(parse(identity).is_none());
+    }
+
+    #[test]
+    fn tolerates_offset_and_extra_precision_timestamps() {
+        assert_eq!(
+            normalize_timestamp("2026-08-28T15:41:17.774Z").as_deref(),
+            Some("2026-08-28 15:41:17.774")
+        );
+        // Explicit offset — normalized to UTC.
+        assert_eq!(
+            normalize_timestamp("2026-08-28T17:41:17.774+02:00").as_deref(),
+            Some("2026-08-28 15:41:17.774")
+        );
+        // Nine fractional digits.
+        assert_eq!(
+            normalize_timestamp("2026-08-28T15:41:17.774123456Z").as_deref(),
+            Some("2026-08-28 15:41:17.774")
+        );
+    }
+
+    /// Absurd dates exist in the wild; they must not become follow recency.
+    #[test]
+    fn rejects_out_of_range_years() {
+        assert!(normalize_timestamp("+047000-01-01T00:00:00Z").is_none());
+        assert!(normalize_timestamp("1970-01-01T00:00:00Z").is_none());
+    }
+
+    /// A record whose createdAt cannot be parsed still yields an edge, using
+    /// event time. Dropping the edge would silently lose a follow.
+    #[test]
+    fn unparseable_created_at_falls_back_to_event_time() {
+        let raw = r#"{"did":"did:plc:a","time_us":1787931684518756,"kind":"commit","commit":{"operation":"create","collection":"app.bsky.graph.follow","rkey":"r1","record":{"subject":"did:plc:b","createdAt":"not-a-date"}}}"#;
+        let edge = parse(raw).expect("must still parse");
+        assert_eq!(edge.followee, "did:plc:b");
+        assert_eq!(edge.created_at, micros_to_clickhouse(1787931684518756));
+    }
+}

--- a/crates/graze-lens-fold/src/lib.rs
+++ b/crates/graze-lens-fold/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod config;
 pub mod cursor;
+pub mod delta;
 pub mod event;
 pub mod metrics;
 pub mod rev;
@@ -15,6 +16,7 @@ pub mod streamer;
 
 pub use config::Config;
 pub use cursor::Cursor;
+pub use delta::DeltaApplier;
 pub use event::{parse, FollowEdge};
 pub use metrics::Metrics;
 pub use sink::Sink;

--- a/crates/graze-lens-fold/src/lib.rs
+++ b/crates/graze-lens-fold/src/lib.rs
@@ -1,0 +1,21 @@
+//! Tails the Bluesky follow graph into `follow_edges`.
+//!
+//! One websocket, one ClickHouse table. Everything downstream (lens builds,
+//! the serve path) reads that table; nothing reads this process. It is a
+//! singleton by deployment — two consumers would double-write, which the
+//! ReplacingMergeTree fold makes harmless but wasteful.
+
+pub mod config;
+pub mod cursor;
+pub mod event;
+pub mod metrics;
+pub mod rev;
+pub mod sink;
+pub mod streamer;
+
+pub use config::Config;
+pub use cursor::Cursor;
+pub use event::{parse, FollowEdge};
+pub use metrics::Metrics;
+pub use sink::Sink;
+pub use streamer::Streamer;

--- a/crates/graze-lens-fold/src/main.rs
+++ b/crates/graze-lens-fold/src/main.rs
@@ -1,0 +1,71 @@
+//! graze-lens-fold: Jetstream follow events → ClickHouse `follow_edges`.
+
+use anyhow::Context;
+use deadpool_redis::{Config as RedisConfig, Runtime};
+use graze_lens_fold::{Config, Cursor, Metrics, Sink, Streamer};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let config = Config::from_env().context("configuration")?;
+    info!(jetstream = %config.jetstream_url, "starting lens fold");
+
+    let pool = RedisConfig::from_url(config.redis_url.clone())
+        .builder()?
+        .max_size(config.redis_pool_size)
+        .runtime(Runtime::Tokio1)
+        .build()
+        .context("redis pool")?;
+
+    let metrics = Metrics::new();
+    let sink = Sink::new(config.clickhouse.clone(), config.insert_timeout).context("sink")?;
+    let cursor = Cursor::new(pool);
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    serve_metrics(config.metrics_port, metrics.clone());
+
+    let streamer = Streamer::new(config, cursor, sink, metrics);
+    let run = streamer.run(shutdown_rx);
+
+    tokio::select! {
+        _ = run => {}
+        _ = tokio::signal::ctrl_c() => {
+            info!("SIGINT received; draining");
+            let _ = shutdown_tx.send(true);
+            // Give the streamer a moment to flush its batch and commit.
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        }
+    }
+
+    Ok(())
+}
+
+/// Metrics on their own port, so scraping never contends with the stream.
+fn serve_metrics(port: u16, metrics: Metrics) {
+    tokio::spawn(async move {
+        let app = axum::Router::new()
+            .route(
+                "/metrics",
+                axum::routing::get({
+                    let m = metrics.clone();
+                    move || {
+                        let m = m.clone();
+                        async move { m.encode() }
+                    }
+                }),
+            )
+            .route("/healthz", axum::routing::get(|| async { "ok" }));
+
+        match tokio::net::TcpListener::bind(("0.0.0.0", port)).await {
+            Ok(listener) => {
+                let _ = axum::serve(listener, app).await;
+            }
+            Err(e) => tracing::error!(error = %e, port, "metrics server failed to bind"),
+        }
+    });
+}

--- a/crates/graze-lens-fold/src/main.rs
+++ b/crates/graze-lens-fold/src/main.rs
@@ -2,8 +2,8 @@
 
 use anyhow::Context;
 use deadpool_redis::{Config as RedisConfig, Runtime};
-use graze_lens_fold::{Config, Cursor, Metrics, Sink, Streamer};
-use tracing::info;
+use graze_lens_fold::{Config, Cursor, DeltaApplier, Metrics, Sink, Streamer};
+use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -24,12 +24,26 @@ async fn main() -> anyhow::Result<()> {
 
     let metrics = Metrics::new();
     let sink = Sink::new(config.clickhouse.clone(), config.insert_timeout).context("sink")?;
-    let cursor = Cursor::new(pool);
+    let cursor = Cursor::new(pool.clone());
+
+    let deltas = if config.deltas_enabled {
+        let applier = DeltaApplier::new(pool, metrics.clone(), config.set_ttl_seconds);
+        // Warm the active list before the first event, so a restart does not
+        // spend an interval ignoring deltas for viewers who are already live.
+        match applier.refresh_active().await {
+            Ok(n) => info!(active_viewers = n, "live lens maintenance enabled"),
+            Err(e) => warn!(error = %e, "could not load active viewers at startup"),
+        }
+        Some(applier)
+    } else {
+        info!("live lens maintenance disabled; sets will expire on their TTL");
+        None
+    };
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     serve_metrics(config.metrics_port, metrics.clone());
 
-    let streamer = Streamer::new(config, cursor, sink, metrics);
+    let streamer = Streamer::new(config, cursor, sink, metrics, deltas);
     let run = streamer.run(shutdown_rx);
 
     tokio::select! {

--- a/crates/graze-lens-fold/src/metrics.rs
+++ b/crates/graze-lens-fold/src/metrics.rs
@@ -20,6 +20,14 @@ pub struct Metrics {
     pub insert_failures: Counter,
     pub reconnects: Counter,
     pub cursor_age_seconds: Gauge,
+
+    /// Live-set maintenance. `deltas_applied` rising while
+    /// `deltas_rebuild_requested` stays low is the healthy shape: follows are
+    /// cheap to apply, unfollows cost a rebuild.
+    pub deltas_applied: Counter,
+    pub deltas_rebuild_requested: Counter,
+    pub delta_failures: Counter,
+    pub active_viewers: Gauge,
 }
 
 impl Metrics {
@@ -70,6 +78,34 @@ impl Metrics {
             cursor_age_seconds.clone(),
         );
 
+        let deltas_applied = Counter::default();
+        registry.register(
+            "deltas_applied",
+            "Follows applied directly to a live lens set",
+            deltas_applied.clone(),
+        );
+
+        let deltas_rebuild_requested = Counter::default();
+        registry.register(
+            "deltas_rebuild_requested",
+            "Rebuilds requested because an unfollow cannot name its subject",
+            deltas_rebuild_requested.clone(),
+        );
+
+        let delta_failures = Counter::default();
+        registry.register(
+            "delta_failures",
+            "Delta applications that errored",
+            delta_failures.clone(),
+        );
+
+        let active_viewers = Gauge::default();
+        registry.register(
+            "active_viewers",
+            "Viewers with a live lens set being kept fresh",
+            active_viewers.clone(),
+        );
+
         Self {
             registry: Arc::new(registry),
             frames_received,
@@ -79,6 +115,10 @@ impl Metrics {
             insert_failures,
             reconnects,
             cursor_age_seconds,
+            deltas_applied,
+            deltas_rebuild_requested,
+            delta_failures,
+            active_viewers,
         }
     }
 

--- a/crates/graze-lens-fold/src/metrics.rs
+++ b/crates/graze-lens-fold/src/metrics.rs
@@ -1,0 +1,121 @@
+//! Prometheus metrics.
+//!
+//! `lens_fold_cursor_age_seconds` is the one that matters. A consumer that
+//! wedges silently is how the turbostream bridge outage ran for hours unnoticed;
+//! alert on this above ~1800s.
+
+use prometheus_client::encoding::text::encode;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::Registry;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct Metrics {
+    registry: Arc<Registry>,
+    pub frames_received: Counter,
+    pub follows: Counter,
+    pub unfollows: Counter,
+    pub rows_written: Counter,
+    pub insert_failures: Counter,
+    pub reconnects: Counter,
+    pub cursor_age_seconds: Gauge,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        // Counters are registered WITHOUT `_total`; the encoder appends it.
+        // Registering "rows_written_total" would emit `..._total_total` and any
+        // alert on the sane name would never fire.
+        let mut registry = Registry::with_prefix("lens_fold");
+
+        let frames_received = Counter::default();
+        registry.register(
+            "frames_received",
+            "Jetstream frames received",
+            frames_received.clone(),
+        );
+
+        let follows = Counter::default();
+        registry.register("follows", "Follow creates parsed", follows.clone());
+
+        let unfollows = Counter::default();
+        registry.register("unfollows", "Follow deletes parsed", unfollows.clone());
+
+        let rows_written = Counter::default();
+        registry.register(
+            "rows_written",
+            "Edge rows accepted by ClickHouse",
+            rows_written.clone(),
+        );
+
+        let insert_failures = Counter::default();
+        registry.register(
+            "insert_failures",
+            "ClickHouse insert attempts that failed",
+            insert_failures.clone(),
+        );
+
+        let reconnects = Counter::default();
+        registry.register(
+            "reconnects",
+            "Jetstream reconnections after an error",
+            reconnects.clone(),
+        );
+
+        let cursor_age_seconds = Gauge::default();
+        registry.register(
+            "cursor_age_seconds",
+            "Seconds between now and the last processed event; alert above 1800",
+            cursor_age_seconds.clone(),
+        );
+
+        Self {
+            registry: Arc::new(registry),
+            frames_received,
+            follows,
+            unfollows,
+            rows_written,
+            insert_failures,
+            reconnects,
+            cursor_age_seconds,
+        }
+    }
+
+    pub fn encode(&self) -> String {
+        let mut buffer = String::new();
+        encode(&mut buffer, &self.registry).expect("encoding cannot fail");
+        buffer
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The encoder appends `_total`; registering it too would double it and
+    /// silently break every alert built on the sane name.
+    #[test]
+    fn counter_names_are_not_double_suffixed() {
+        let m = Metrics::new();
+        m.rows_written.inc();
+        let out = m.encode();
+        assert!(out.contains("lens_fold_rows_written_total"));
+        assert!(!out.contains("_total_total"));
+    }
+
+    /// The alertable gauge must be present and unsuffixed.
+    #[test]
+    fn cursor_age_gauge_is_exposed() {
+        let m = Metrics::new();
+        m.cursor_age_seconds.set(42);
+        let out = m.encode();
+        assert!(out.contains("lens_fold_cursor_age_seconds 42"));
+    }
+}

--- a/crates/graze-lens-fold/src/rev.rs
+++ b/crates/graze-lens-fold/src/rev.rs
@@ -1,0 +1,276 @@
+//! Rebuilding the reverse follow index.
+//!
+//! `follow_edges` answers "who does X follow". `mutuals` needs the opposite, and
+//! that cannot be derived row-by-row: a follow *delete* carries no followee, so
+//! a materialized view over the forward table would receive unfollows as edges
+//! pointing at `''` and never retract the real one. The reverse direction has to
+//! come from the *folded* forward table, which means a periodic rebuild.
+//!
+//! # Why a swap rather than an insert
+//!
+//! ReplacingMergeTree replaces; it never deletes. Rebuilding by inserting the
+//! current edge set into the live table would leave every retracted edge behind
+//! forever — the table would only ever grow, and `mutuals` would slowly fill
+//! with people who unfollowed. So the rebuild fills an empty staging table and
+//! `EXCHANGE TABLES` swaps it in atomically: readers see the old contents right
+//! up to the swap and the new contents immediately after, never a partial one.
+//!
+//! # Why it is chunked
+//!
+//! `FINAL` over the whole forward table is a large merge. The chunks align with
+//! the forward table's own partition key, so each pass reads one partition and
+//! peak memory is bounded by the largest partition rather than the table.
+
+use std::time::Duration;
+
+use graze_common::ClickHouseConfig;
+use tracing::{info, warn};
+
+/// Must match `PARTITION BY cityHash64(follower) % 32` on `follow_edges`.
+/// A mismatch is not a correctness bug — every row is still visited exactly
+/// once — but it stops each chunk aligning to a single partition, which is the
+/// entire point of chunking.
+pub const CHUNKS: u64 = 32;
+
+pub const LIVE_TABLE: &str = "follow_edges_rev";
+pub const STAGING_TABLE: &str = "follow_edges_rev_next";
+
+pub struct RevRebuilder {
+    http: reqwest::Client,
+    clickhouse: ClickHouseConfig,
+    timeout: Duration,
+    max_execution_seconds: u64,
+    /// Refuse to swap when the rebuild produced less than this fraction of the
+    /// rows currently live. See `swap` for why.
+    min_ratio: f64,
+    force: bool,
+}
+
+impl RevRebuilder {
+    pub fn new(
+        clickhouse: ClickHouseConfig,
+        timeout: Duration,
+        max_execution_seconds: u64,
+        min_ratio: f64,
+        force: bool,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            http: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(10))
+                .build()?,
+            clickhouse,
+            timeout,
+            max_execution_seconds,
+            min_ratio,
+            force,
+        })
+    }
+
+    /// Full rebuild: prepare staging, fill it chunk by chunk, then swap.
+    pub async fn run(&self) -> anyhow::Result<RebuildReport> {
+        let db = self.clickhouse.database.clone();
+
+        self.exec(&format!(
+            "CREATE TABLE IF NOT EXISTS {db}.{STAGING_TABLE} AS {db}.{LIVE_TABLE}"
+        ))
+        .await?;
+        // Staging may hold the *previous* live table from the last swap.
+        self.exec(&format!("TRUNCATE TABLE {db}.{STAGING_TABLE}"))
+            .await?;
+
+        for chunk in 0..CHUNKS {
+            self.exec(&self.chunk_query(chunk)).await?;
+            info!(chunk = chunk + 1, of = CHUNKS, "rebuilt chunk");
+        }
+
+        let before = self.count(LIVE_TABLE).await?;
+        let after = self.count(STAGING_TABLE).await?;
+        self.swap(before, after).await?;
+
+        // The old live table is now in staging; leave it empty rather than
+        // holding a second copy of the graph on disk until the next run.
+        self.exec(&format!("TRUNCATE TABLE {db}.{STAGING_TABLE}"))
+            .await?;
+
+        Ok(RebuildReport { before, after })
+    }
+
+    /// One chunk of the forward table, folded and reversed.
+    ///
+    /// The `op` filter runs outside the `FINAL` subquery: filtering before the
+    /// fold would keep the create row of an unfollowed pair and resurrect the
+    /// edge — the same trap as the forward read path.
+    fn chunk_query(&self, chunk: u64) -> String {
+        let db = &self.clickhouse.database;
+        format!(
+            "INSERT INTO {db}.{STAGING_TABLE} (followee, follower, refreshed_at) \
+             SELECT followee, follower, now() FROM ( \
+                SELECT followee, follower, op FROM {db}.follow_edges FINAL \
+                WHERE cityHash64(follower) % {CHUNKS} = {chunk} \
+             ) WHERE op = 'create' AND followee != ''"
+        )
+    }
+
+    /// Swap staging in, unless the result looks like a failed rebuild.
+    ///
+    /// The guard exists because `EXCHANGE` is instant and total: a rebuild that
+    /// silently produced nothing — an empty source, a partial run, a chunk loop
+    /// that errored in a way we mishandled — would otherwise replace the live
+    /// index with an empty table, and `mutuals` would quietly return nobody for
+    /// every viewer. Shrinkage is legitimate in principle, so the threshold is
+    /// overridable; it is just never something to do by accident.
+    async fn swap(&self, before: u64, after: u64) -> anyhow::Result<()> {
+        let db = &self.clickhouse.database;
+
+        if before > 0 {
+            let ratio = after as f64 / before as f64;
+            if ratio < self.min_ratio && !self.force {
+                anyhow::bail!(
+                    "refusing to swap: rebuild produced {after} rows vs {before} live \
+                     ({:.1}% of current, below the {:.0}% floor). Re-run with \
+                     LENS_REV_FORCE=true if this shrinkage is expected.",
+                    ratio * 100.0,
+                    self.min_ratio * 100.0
+                );
+            }
+            if ratio < 1.0 {
+                warn!(before, after, "reverse index shrank");
+            }
+        } else if after == 0 {
+            anyhow::bail!("refusing to swap: both the live and rebuilt tables are empty");
+        }
+
+        self.exec(&format!(
+            "EXCHANGE TABLES {db}.{LIVE_TABLE} AND {db}.{STAGING_TABLE}"
+        ))
+        .await?;
+        info!(before, after, "reverse index swapped in");
+        Ok(())
+    }
+
+    async fn count(&self, table: &str) -> anyhow::Result<u64> {
+        let db = &self.clickhouse.database;
+        let text = self
+            .exec(&format!("SELECT count() FROM {db}.{table}"))
+            .await?;
+        Ok(text.trim().parse().unwrap_or(0))
+    }
+
+    async fn exec(&self, sql: &str) -> anyhow::Result<String> {
+        let max_execution = self.max_execution_seconds.to_string();
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.timeout)
+            .query(&[
+                ("max_execution_time", max_execution.as_str()),
+                // An abandoned-but-still-running query has cost us real money
+                // before; make ClickHouse drop it if we disconnect.
+                ("cancel_http_readonly_queries_on_client_close", "1"),
+            ])
+            .body(sql.to_string())
+            .send()
+            .await?;
+
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!(
+                "clickhouse query failed ({}): {}\nSQL: {}",
+                status,
+                &text[..text.len().min(600)],
+                &sql[..sql.len().min(300)]
+            );
+        }
+        Ok(text)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RebuildReport {
+    pub before: u64,
+    pub after: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rebuilder() -> RevRebuilder {
+        RevRebuilder::new(
+            ClickHouseConfig {
+                host: "localhost".into(),
+                port: 8123,
+                database: "default".into(),
+                user: "u".into(),
+                password: "p".into(),
+                secure: false,
+            },
+            Duration::from_secs(60),
+            600,
+            0.5,
+            false,
+        )
+        .unwrap()
+    }
+
+    /// Same ordering trap as the forward read: fold first, filter second.
+    #[test]
+    fn chunk_query_folds_before_filtering_op() {
+        let sql = rebuilder().chunk_query(0);
+        let final_at = sql.find("FINAL").expect("must use FINAL");
+        let filter_at = sql.find("WHERE op = 'create'").expect("must filter op");
+        assert!(
+            final_at < filter_at,
+            "op filter must run outside the FINAL subquery"
+        );
+    }
+
+    /// Reversed on the way out: the target table is keyed (followee, follower).
+    ///
+    /// The live-table check compares the parsed insert target rather than
+    /// substring-matching, because `follow_edges_rev_next` *contains*
+    /// `follow_edges_rev` — a naive `!contains` here fails on correct SQL.
+    #[test]
+    fn chunk_query_writes_the_reverse_direction() {
+        let sql = rebuilder().chunk_query(0);
+        assert!(sql.contains("(followee, follower, refreshed_at)"));
+
+        let target = insert_target(&sql).expect("query must be an INSERT");
+        assert_eq!(target, format!("default.{STAGING_TABLE}"));
+        assert_ne!(
+            target,
+            format!("default.{LIVE_TABLE}"),
+            "the rebuild must never write directly to the live table"
+        );
+    }
+
+    /// The table name between `INSERT INTO` and the column list.
+    fn insert_target(sql: &str) -> Option<String> {
+        let rest = sql.split("INSERT INTO ").nth(1)?;
+        Some(rest.split_whitespace().next()?.to_string())
+    }
+
+    /// Every chunk must be distinct and cover the whole modulus, or the rebuild
+    /// silently drops a slice of the graph.
+    #[test]
+    fn chunks_cover_the_full_modulus_exactly_once() {
+        let r = rebuilder();
+        let mut seen = std::collections::HashSet::new();
+        for chunk in 0..CHUNKS {
+            let sql = r.chunk_query(chunk);
+            assert!(sql.contains(&format!("% {CHUNKS} = {chunk}")));
+            assert!(seen.insert(chunk));
+        }
+        assert_eq!(seen.len(), CHUNKS as usize);
+    }
+
+    /// Excluding empty followees matters here too: delete rows carry `''`, and a
+    /// reverse index full of `''` entries would be both useless and large.
+    #[test]
+    fn chunk_query_excludes_empty_followees() {
+        assert!(rebuilder().chunk_query(0).contains("followee != ''"));
+    }
+}

--- a/crates/graze-lens-fold/src/sink.rs
+++ b/crates/graze-lens-fold/src/sink.rs
@@ -1,0 +1,159 @@
+//! Batched writes into `follow_edges_buffer`.
+//!
+//! Follows the house ClickHouse write pattern: plain `reqwest` HTTP with
+//! `INSERT ... FORMAT TabSeparated` (`graze-common/src/clickhouse/writer.rs`),
+//! aimed at the Buffer table rather than the base table. Per-event inserts are
+//! what drove the tiny-insert cost problem on this cluster.
+
+use std::time::Duration;
+
+use graze_common::ClickHouseConfig;
+use tracing::warn;
+
+use crate::event::FollowEdge;
+
+const TABLE: &str = "follow_edges_buffer";
+const COLUMNS: &str = "follower, rkey, followee, op, seq, created_at";
+
+pub struct Sink {
+    http: reqwest::Client,
+    clickhouse: ClickHouseConfig,
+    timeout: Duration,
+    table: String,
+}
+
+impl Sink {
+    pub fn new(clickhouse: ClickHouseConfig, timeout: Duration) -> anyhow::Result<Self> {
+        Self::new_with_table(clickhouse, timeout, TABLE)
+    }
+
+    /// Target a different table. Production always uses the default; this exists
+    /// so tests can exercise the real insert path against a scratch table.
+    pub fn new_with_table(
+        clickhouse: ClickHouseConfig,
+        timeout: Duration,
+        table: &str,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            http: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(10))
+                .build()?,
+            clickhouse,
+            timeout,
+            table: table.to_string(),
+        })
+    }
+
+    /// Insert a batch. Returns `Ok(())` only when ClickHouse accepted every row.
+    pub async fn insert(&self, edges: &[FollowEdge]) -> anyhow::Result<()> {
+        if edges.is_empty() {
+            return Ok(());
+        }
+
+        let body = edges.iter().map(render_row).collect::<Vec<_>>().join("\n");
+        let query = format!(
+            "INSERT INTO {}.{} ({}) FORMAT TabSeparated",
+            self.clickhouse.database, self.table, COLUMNS
+        );
+
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.timeout)
+            .query(&[("query", query.as_str())])
+            .body(body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "insert failed ({}): {}",
+                status,
+                &text[..text.len().min(600)]
+            );
+        }
+        Ok(())
+    }
+}
+
+/// One TabSeparated row.
+///
+/// Every field is escaped: a DID should never contain a tab or newline, but this
+/// is untrusted network input and one stray control character would shift every
+/// subsequent column silently rather than failing.
+fn render_row(edge: &FollowEdge) -> String {
+    format!(
+        "{}\t{}\t{}\t{}\t{}\t{}",
+        escape(&edge.follower),
+        escape(&edge.rkey),
+        escape(&edge.followee),
+        edge.op,
+        edge.seq,
+        escape(&edge.created_at),
+    )
+}
+
+/// TabSeparated escaping, matching `graze-common`'s `escape_tab_value`.
+fn escape(value: &str) -> String {
+    if !value
+        .as_bytes()
+        .iter()
+        .any(|b| matches!(b, b'\t' | b'\n' | b'\r' | b'\\'))
+    {
+        return value.to_string();
+    }
+    warn!(value, "control characters in a DID or rkey; escaping");
+    value
+        .replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn edge(op: &'static str, followee: &str) -> FollowEdge {
+        FollowEdge {
+            follower: "did:plc:a".into(),
+            rkey: "r1".into(),
+            followee: followee.into(),
+            op,
+            seq: 42,
+            created_at: "2026-08-28 15:41:17.774".into(),
+        }
+    }
+
+    #[test]
+    fn create_row_has_six_tab_separated_columns() {
+        let row = render_row(&edge("create", "did:plc:b"));
+        assert_eq!(row.split('\t').count(), 6);
+        assert_eq!(
+            row,
+            "did:plc:a\tr1\tdid:plc:b\tcreate\t42\t2026-08-28 15:41:17.774"
+        );
+    }
+
+    /// A delete's empty followee must still occupy its column, or every later
+    /// field shifts left and `op` lands in the wrong place.
+    #[test]
+    fn delete_row_keeps_the_empty_followee_column() {
+        let row = render_row(&edge("delete", ""));
+        let cols: Vec<&str> = row.split('\t').collect();
+        assert_eq!(cols.len(), 6);
+        assert_eq!(cols[2], "");
+        assert_eq!(cols[3], "delete");
+    }
+
+    #[test]
+    fn control_characters_are_escaped_not_passed_through() {
+        let row = render_row(&edge("create", "did:plc:b\tinjected"));
+        assert_eq!(row.split('\t').count(), 6, "escaping must preserve arity");
+        assert!(row.contains("\\t"));
+    }
+}

--- a/crates/graze-lens-fold/src/streamer.rs
+++ b/crates/graze-lens-fold/src/streamer.rs
@@ -1,0 +1,244 @@
+//! The Jetstream tail: connect, batch, insert, commit.
+//!
+//! Transport is forked from `graze-like-streamer` — jittered exponential
+//! backoff, a per-read timeout so a silently dead socket reconnects instead of
+//! hanging forever, and the dual-cursor resume. What differs is the sink
+//! (ClickHouse rather than Redis) and the collection.
+
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use rand::Rng;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{error, info, warn};
+
+use crate::config::Config;
+use crate::cursor::Cursor;
+use crate::event::{self, FollowEdge, FOLLOW_COLLECTION};
+use crate::metrics::Metrics;
+use crate::sink::Sink;
+
+pub struct Streamer {
+    config: Config,
+    cursor: Cursor,
+    sink: Sink,
+    metrics: Metrics,
+}
+
+impl Streamer {
+    pub fn new(config: Config, cursor: Cursor, sink: Sink, metrics: Metrics) -> Self {
+        Self {
+            config,
+            cursor,
+            sink,
+            metrics,
+        }
+    }
+
+    /// Reconnect forever. Only a shutdown signal ends this.
+    pub async fn run(&self, mut shutdown: tokio::sync::watch::Receiver<bool>) {
+        let mut delay = Duration::from_secs(1);
+        let max = Duration::from_secs(60);
+
+        loop {
+            if *shutdown.borrow() {
+                info!("shutdown requested");
+                return;
+            }
+
+            match self.connect_and_stream(&mut shutdown).await {
+                Ok(()) => {
+                    info!("jetstream connection closed");
+                    delay = Duration::from_secs(1);
+                }
+                Err(e) => {
+                    error!(error = %e, "jetstream connection error");
+                    self.metrics.reconnects.inc();
+                    delay = (delay * 2).min(max);
+                }
+            }
+
+            let wait = with_jitter(delay);
+            info!(delay_ms = wait.as_millis() as u64, "reconnecting");
+            tokio::select! {
+                _ = tokio::time::sleep(wait) => {}
+                _ = shutdown.changed() => return,
+            }
+        }
+    }
+
+    async fn connect_and_stream(
+        &self,
+        shutdown: &mut tokio::sync::watch::Receiver<bool>,
+    ) -> anyhow::Result<()> {
+        let resume = self.cursor.resume_from().await?;
+        let mut url = format!(
+            "{}?wantedCollections={}",
+            self.config.jetstream_url, FOLLOW_COLLECTION
+        );
+        if let Some(c) = resume {
+            // Jetstream replays from the cursor; v2 keeps roughly 36h on the
+            // websocket, so a wedge shorter than that costs nothing but time.
+            url.push_str(&format!("&cursor={c}"));
+            info!(cursor = c, "resuming");
+        } else {
+            info!("no stored cursor; starting from live tip");
+        }
+
+        let (ws, _) = connect_async(&url).await?;
+        info!("connected to jetstream");
+        let (_write, mut read) = ws.split();
+
+        let mut batch: Vec<FollowEdge> = Vec::with_capacity(self.config.batch_size);
+        let mut batch_start: Option<u64> = None;
+        let mut last_seq: u64 = resume.unwrap_or(0);
+        let read_timeout = Duration::from_secs(self.config.read_timeout_seconds);
+        let mut flush_tick = tokio::time::interval(self.config.batch_interval);
+        flush_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    // Drain what we have so a rollout does not re-fetch it.
+                    self.flush(&mut batch, &mut batch_start, last_seq).await;
+                    return Ok(());
+                }
+                _ = flush_tick.tick() => {
+                    self.flush(&mut batch, &mut batch_start, last_seq).await;
+                    self.publish_age(last_seq);
+                }
+                frame = tokio::time::timeout(read_timeout, read.next()) => {
+                    match frame {
+                        Ok(Some(Ok(Message::Text(text)))) => {
+                            self.metrics.frames_received.inc();
+                            if let Some(edge) = event::parse(&text) {
+                                last_seq = edge.seq;
+                                if batch_start.is_none() {
+                                    batch_start = Some(edge.seq);
+                                    // Mark in flight before the first row of a
+                                    // batch, so a crash resumes from here.
+                                    if let Err(e) = self.cursor.mark_pending(edge.seq).await {
+                                        warn!(error = %e, "could not mark pending cursor");
+                                    }
+                                }
+                                match edge.op {
+                                    "create" => self.metrics.follows.inc(),
+                                    _ => self.metrics.unfollows.inc(),
+                                };
+                                batch.push(edge);
+                                if batch.len() >= self.config.batch_size {
+                                    self.flush(&mut batch, &mut batch_start, last_seq).await;
+                                }
+                            }
+                        }
+                        Ok(Some(Ok(Message::Close(_)))) => {
+                            self.flush(&mut batch, &mut batch_start, last_seq).await;
+                            return Ok(());
+                        }
+                        Ok(Some(Ok(_))) => {}
+                        Ok(Some(Err(e))) => {
+                            self.flush(&mut batch, &mut batch_start, last_seq).await;
+                            return Err(e.into());
+                        }
+                        Ok(None) => {
+                            self.flush(&mut batch, &mut batch_start, last_seq).await;
+                            return Ok(());
+                        }
+                        Err(_) => {
+                            // No frame within the budget. Follow traffic never
+                            // goes quiet globally, so silence means a dead
+                            // socket, not an idle network.
+                            warn!(
+                                timeout_secs = read_timeout.as_secs(),
+                                "read timeout; reconnecting"
+                            );
+                            self.flush(&mut batch, &mut batch_start, last_seq).await;
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Insert the batch and commit the cursor. A failed insert keeps the batch
+    /// and leaves the pending cursor in place, so the rows are retried on the
+    /// next tick and, failing that, re-fetched after a reconnect.
+    async fn flush(&self, batch: &mut Vec<FollowEdge>, start: &mut Option<u64>, last_seq: u64) {
+        if batch.is_empty() {
+            return;
+        }
+        match self.sink.insert(batch).await {
+            Ok(()) => {
+                self.metrics.rows_written.inc_by(batch.len() as u64);
+                batch.clear();
+                *start = None;
+                if let Err(e) = self.cursor.commit(last_seq).await {
+                    warn!(error = %e, "could not commit cursor");
+                }
+            }
+            Err(e) => {
+                error!(error = %e, rows = batch.len(), "insert failed; will retry");
+                self.metrics.insert_failures.inc();
+                if batch.len() > self.config.max_pending_rows {
+                    // Backstop: an insert failing for hours would otherwise grow
+                    // the batch until the pod is OOMKilled. The pending cursor
+                    // survives, so dropping in-memory rows loses nothing — the
+                    // reconnect replays them.
+                    warn!(
+                        rows = batch.len(),
+                        "pending rows over budget; dropping to the stored cursor"
+                    );
+                    batch.clear();
+                    *start = None;
+                }
+            }
+        }
+    }
+
+    fn publish_age(&self, last_seq: u64) {
+        if last_seq == 0 {
+            return;
+        }
+        let now_us = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_micros() as u64)
+            .unwrap_or(0);
+        self.metrics
+            .cursor_age_seconds
+            .set(crate::cursor::age_seconds(now_us, last_seq) as i64);
+    }
+}
+
+/// Exponential backoff with up to 25% jitter, so a fleet-wide disconnect does
+/// not reconnect in lockstep.
+fn with_jitter(base: Duration) -> Duration {
+    let jitter_range = base.as_millis() as u64 / 4;
+    if jitter_range == 0 {
+        return base;
+    }
+    base + Duration::from_millis(rand::thread_rng().gen_range(0..=jitter_range))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jitter_never_shortens_the_delay() {
+        let base = Duration::from_secs(4);
+        for _ in 0..50 {
+            let d = with_jitter(base);
+            assert!(d >= base);
+            assert!(d <= base + Duration::from_millis(1000));
+        }
+    }
+
+    #[test]
+    fn sub_millisecond_delays_are_left_alone() {
+        assert_eq!(
+            with_jitter(Duration::from_micros(500)),
+            Duration::from_micros(500)
+        );
+    }
+}

--- a/crates/graze-lens-fold/src/streamer.rs
+++ b/crates/graze-lens-fold/src/streamer.rs
@@ -14,6 +14,7 @@ use tracing::{error, info, warn};
 
 use crate::config::Config;
 use crate::cursor::Cursor;
+use crate::delta::DeltaApplier;
 use crate::event::{self, FollowEdge, FOLLOW_COLLECTION};
 use crate::metrics::Metrics;
 use crate::sink::Sink;
@@ -23,15 +24,25 @@ pub struct Streamer {
     cursor: Cursor,
     sink: Sink,
     metrics: Metrics,
+    /// Keeps already-published lens sets fresh. `None` disables live
+    /// maintenance and falls back to sets expiring on their TTL.
+    deltas: Option<DeltaApplier>,
 }
 
 impl Streamer {
-    pub fn new(config: Config, cursor: Cursor, sink: Sink, metrics: Metrics) -> Self {
+    pub fn new(
+        config: Config,
+        cursor: Cursor,
+        sink: Sink,
+        metrics: Metrics,
+        deltas: Option<DeltaApplier>,
+    ) -> Self {
         Self {
             config,
             cursor,
             sink,
             metrics,
+            deltas,
         }
     }
 
@@ -95,6 +106,8 @@ impl Streamer {
         let read_timeout = Duration::from_secs(self.config.read_timeout_seconds);
         let mut flush_tick = tokio::time::interval(self.config.batch_interval);
         flush_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut active_tick = tokio::time::interval(self.config.active_refresh_interval);
+        active_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
         loop {
             tokio::select! {
@@ -106,6 +119,16 @@ impl Streamer {
                 _ = flush_tick.tick() => {
                     self.flush(&mut batch, &mut batch_start, last_seq).await;
                     self.publish_age(last_seq);
+                }
+                _ = active_tick.tick() => {
+                    // Whose sets are live? Refreshed on a timer rather than per
+                    // event; a viewer who appears between ticks simply waits one
+                    // interval before their set starts tracking the stream.
+                    if let Some(deltas) = &self.deltas {
+                        if let Err(e) = deltas.refresh_active().await {
+                            warn!(error = %e, "could not refresh active viewers");
+                        }
+                    }
                 }
                 frame = tokio::time::timeout(read_timeout, read.next()) => {
                     match frame {
@@ -125,6 +148,15 @@ impl Streamer {
                                     "create" => self.metrics.follows.inc(),
                                     _ => self.metrics.unfollows.inc(),
                                 };
+                                // Keep live sets fresh. Gated on a hash lookup
+                                // first, so the overwhelming majority of events
+                                // -- follows by accounts nobody has a lens for
+                                // -- cost nothing beyond that check.
+                                if let Some(deltas) = &self.deltas {
+                                    if deltas.is_active(&edge.follower).await {
+                                        deltas.apply(&edge).await;
+                                    }
+                                }
                                 batch.push(edge);
                                 if batch.len() >= self.config.batch_size {
                                     self.flush(&mut batch, &mut batch_start, last_seq).await;

--- a/crates/graze-lens-fold/tests/fold_semantics.rs
+++ b/crates/graze-lens-fold/tests/fold_semantics.rs
@@ -1,0 +1,177 @@
+//! The fold semantics, against a real ClickHouse.
+//!
+//! This is the highest-risk behaviour in graze-lens and the least visible when
+//! wrong: if an unfollow fails to retract, nothing errors — lenses just quietly
+//! keep serving people the viewer stopped following, forever.
+//!
+//! Run with a throwaway server:
+//!
+//! ```text
+//! docker run -d --rm --name lens-ch -p 8124:8123 \
+//!   -e CLICKHOUSE_USER=lens -e CLICKHOUSE_PASSWORD=lenspw \
+//!   -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
+//!   clickhouse/clickhouse-server:24.8-alpine
+//! TEST_CLICKHOUSE_URL=http://lens:lenspw@localhost:8124 cargo test -p graze-lens-fold --test fold_semantics
+//! ```
+//!
+//! The local engine is `ReplacingMergeTree`; production is Cloud's
+//! `SharedReplacingMergeTree`. The fold semantics under test are identical.
+
+use graze_common::ClickHouseConfig;
+use graze_lens_fold::{FollowEdge, Sink};
+use std::time::Duration;
+
+fn config() -> Option<ClickHouseConfig> {
+    let raw = std::env::var("TEST_CLICKHOUSE_URL")
+        .ok()
+        .filter(|u| !u.is_empty())?;
+    let url = reqwest::Url::parse(&raw).expect("TEST_CLICKHOUSE_URL must be a URL");
+    Some(ClickHouseConfig {
+        host: url.host_str().expect("host").to_string(),
+        port: url.port().unwrap_or(8123),
+        database: "default".into(),
+        user: if url.username().is_empty() {
+            "default".into()
+        } else {
+            url.username().into()
+        },
+        password: url.password().unwrap_or("").to_string(),
+        secure: url.scheme() == "https",
+    })
+}
+
+async fn exec(cfg: &ClickHouseConfig, sql: &str) -> String {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(cfg.base_url())
+        .basic_auth(&cfg.user, Some(&cfg.password))
+        .timeout(Duration::from_secs(30))
+        .body(sql.to_string())
+        .send()
+        .await
+        .expect("clickhouse request");
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    assert!(
+        status.is_success(),
+        "query failed ({status}): {text}\nSQL: {sql}"
+    );
+    text
+}
+
+/// The builder's production query, verbatim in shape.
+fn builder_query(table: &str, follower: &str) -> String {
+    format!(
+        "SELECT followee FROM (SELECT followee, op FROM default.{table} FINAL \
+         WHERE follower = '{follower}') WHERE op = 'create' AND followee != ''"
+    )
+}
+
+fn edge(rkey: &str, followee: &str, op: &'static str, seq: u64) -> FollowEdge {
+    FollowEdge {
+        follower: "did:plc:testviewer".into(),
+        rkey: rkey.into(),
+        followee: followee.into(),
+        op,
+        seq,
+        created_at: "2026-08-28 15:41:17.774".into(),
+    }
+}
+
+/// An unfollow must retract the edge — even though the delete event carries no
+/// followee, which is what forces the (follower, rkey) key.
+#[tokio::test]
+async fn an_unfollow_retracts_the_edge() {
+    let Some(cfg) = config() else {
+        eprintln!("skipping: TEST_CLICKHOUSE_URL unset");
+        return;
+    };
+    let table = "fold_test_edges";
+
+    exec(&cfg, &format!("DROP TABLE IF EXISTS default.{table}")).await;
+    exec(
+        &cfg,
+        &format!(
+            "CREATE TABLE default.{table} (follower String, rkey String, followee String, \
+             op Enum8('create'=1,'delete'=2), seq UInt64, created_at DateTime64(3,'UTC')) \
+             ENGINE = ReplacingMergeTree(seq) PARTITION BY cityHash64(follower) % 32 \
+             ORDER BY (follower, rkey)"
+        ),
+    )
+    .await;
+
+    let sink = Sink::new_with_table(cfg.clone(), Duration::from_secs(30), table).expect("sink");
+
+    // Two follows, then an unfollow of the first — the delete naming only rkey.
+    sink.insert(&[
+        edge("rkeyA", "did:plc:alice", "create", 1_000),
+        edge("rkeyB", "did:plc:bob", "create", 2_000),
+    ])
+    .await
+    .expect("insert creates");
+
+    let before = exec(&cfg, &builder_query(table, "did:plc:testviewer")).await;
+    assert!(before.contains("did:plc:alice"));
+    assert!(before.contains("did:plc:bob"));
+
+    sink.insert(&[edge("rkeyA", "", "delete", 3_000)])
+        .await
+        .expect("insert delete");
+
+    let after = exec(&cfg, &builder_query(table, "did:plc:testviewer")).await;
+    assert!(
+        !after.contains("did:plc:alice"),
+        "the unfollowed account is still being served: {after}"
+    );
+    assert!(
+        after.contains("did:plc:bob"),
+        "an unrelated follow was lost: {after}"
+    );
+
+    exec(&cfg, &format!("DROP TABLE default.{table}")).await;
+}
+
+/// The counterfactual, kept as a live demonstration rather than a comment: keyed
+/// on (follower, followee) — as the design originally said — the delete and the
+/// create have different sort keys, so nothing collapses and the unfollowed
+/// account is served forever. If this test ever starts failing, the wire format
+/// changed and deletes began naming their subject.
+#[tokio::test]
+async fn the_followee_keyed_schema_would_not_retract() {
+    let Some(cfg) = config() else {
+        eprintln!("skipping: TEST_CLICKHOUSE_URL unset");
+        return;
+    };
+    let table = "fold_test_old_design";
+
+    exec(&cfg, &format!("DROP TABLE IF EXISTS default.{table}")).await;
+    exec(
+        &cfg,
+        &format!(
+            "CREATE TABLE default.{table} (follower String, followee String, \
+             op Enum8('create'=1,'delete'=2), seq UInt64, created_at DateTime64(3,'UTC')) \
+             ENGINE = ReplacingMergeTree(seq) PARTITION BY toYYYYMM(created_at) \
+             ORDER BY (follower, followee)"
+        ),
+    )
+    .await;
+
+    exec(
+        &cfg,
+        &format!(
+            "INSERT INTO default.{table} VALUES \
+             ('did:plc:testviewer','did:plc:alice','create',1000,'2026-08-28 15:41:17.774'), \
+             ('did:plc:testviewer','','delete',3000,'2026-08-28 16:30:00.000')"
+        ),
+    )
+    .await;
+
+    let after = exec(&cfg, &builder_query(table, "did:plc:testviewer")).await;
+    assert!(
+        after.contains("did:plc:alice"),
+        "the followee-keyed schema unexpectedly retracted the edge — if deletes now \
+         carry a subject, the rkey keying could be revisited: {after}"
+    );
+
+    exec(&cfg, &format!("DROP TABLE default.{table}")).await;
+}

--- a/crates/graze-lens-fold/tests/live_sample.rs
+++ b/crates/graze-lens-fold/tests/live_sample.rs
@@ -1,0 +1,111 @@
+//! Parser validation against a captured sample of live Jetstream traffic.
+//!
+//! Unit tests pin two hand-picked frames; this runs the parser over thousands of
+//! real ones to catch shapes nobody thought to write down. Capture a fresh
+//! sample with `scratchpad/capture_follows.py` and point `LENS_FOLD_SAMPLE` at
+//! the resulting NDJSON file; the test no-ops without it, so CI stays hermetic.
+
+use graze_lens_fold::parse;
+use std::io::BufRead;
+
+#[test]
+fn parses_live_follow_traffic() {
+    let Some(path) = std::env::var("LENS_FOLD_SAMPLE")
+        .ok()
+        .filter(|p| !p.is_empty())
+    else {
+        eprintln!("skipping: LENS_FOLD_SAMPLE unset");
+        return;
+    };
+
+    let file = std::fs::File::open(&path).expect("sample file");
+    let reader = std::io::BufReader::new(file);
+
+    let (mut frames, mut creates, mut deletes, mut skipped) = (0, 0, 0, 0);
+    let mut bad_created_at = 0;
+
+    for line in reader.lines() {
+        let line = line.expect("read line");
+        if line.trim().is_empty() {
+            continue;
+        }
+        frames += 1;
+
+        // Only commits on the follow collection should yield an edge; anything
+        // else (identity, account, other collections) must be skipped, not
+        // mis-parsed into a bogus row.
+        let is_follow_commit = line.contains(r#""kind":"commit""#)
+            && line.contains(r#""collection":"app.bsky.graph.follow""#);
+
+        match parse(&line) {
+            Some(edge) => {
+                assert!(is_follow_commit, "parsed a non-follow frame: {line}");
+                assert!(!edge.follower.is_empty(), "follower must be set: {line}");
+                assert!(!edge.rkey.is_empty(), "rkey must be set: {line}");
+                assert!(edge.seq > 0, "seq must be set: {line}");
+
+                match edge.op {
+                    "create" => {
+                        creates += 1;
+                        assert!(
+                            edge.followee.starts_with("did:"),
+                            "a create must name a DID followee: {line}"
+                        );
+                    }
+                    "delete" => {
+                        deletes += 1;
+                        assert!(
+                            edge.followee.is_empty(),
+                            "a delete cannot know the followee: {line}"
+                        );
+                    }
+                    other => panic!("unexpected op {other}"),
+                }
+
+                // Every row must render a ClickHouse-parseable DateTime64(3).
+                if !looks_like_ch_datetime(&edge.created_at) {
+                    bad_created_at += 1;
+                    eprintln!("bad created_at: {:?} from {line}", edge.created_at);
+                }
+            }
+            None => skipped += 1,
+        }
+    }
+
+    eprintln!(
+        "frames={frames} creates={creates} deletes={deletes} skipped={skipped} bad_created_at={bad_created_at}"
+    );
+
+    assert!(frames > 0, "sample was empty");
+    assert_eq!(
+        bad_created_at, 0,
+        "some rows rendered an unusable timestamp"
+    );
+    assert!(creates > 0 && deletes > 0, "sample lacked both operations");
+
+    // Deletes are a large minority of live follow traffic (~40% when this was
+    // written). That is precisely why the schema is keyed on rkey rather than
+    // resolving each delete's followee: a lookup per delete would mean a
+    // ClickHouse point query for two of every five events.
+    let parsed = creates + deletes;
+    assert!(
+        parsed * 100 / frames >= 90,
+        "parsed only {parsed}/{frames} frames; the wire format may have changed"
+    );
+}
+
+/// `YYYY-MM-DD HH:MM:SS.mmm`
+fn looks_like_ch_datetime(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() == 23
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes[10] == b' '
+        && bytes[13] == b':'
+        && bytes[16] == b':'
+        && bytes[19] == b'.'
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(i, b)| matches!(i, 4 | 7 | 10 | 13 | 16 | 19) || b.is_ascii_digit())
+}

--- a/kube/lens-bootstrap-job.yaml
+++ b/kube/lens-bootstrap-job.yaml
@@ -10,9 +10,9 @@
 # Prereqs (created out of band):
 #   * secret `app-secrets` — CLICKHOUSE_{HOST,USER,PASSWORD}
 #   * ClickHouse tables — `feed-processor/scripts/create_follow_edges_tables.py`
-#   * ConfigMap `lens-bootstrap-dids` with a `dids.txt` key, one DID per line
-#     (blank lines and `#` comments are ignored):
-#       kubectl create configmap lens-bootstrap-dids --from-file=dids.txt
+#   * ConfigMap `graze-beta-cohort` (key `dids.txt`) — the shared beta cohort,
+#     not a lens-specific list. Source of truth is `cohorts/beta.txt`; see its
+#     header for how to regenerate the ConfigMap after editing.
 #
 # Scope note: this is the per-account path, and it is what M0 needs — it covers
 # exactly the accounts that asked for a lens, over public unauthenticated
@@ -93,4 +93,6 @@ spec:
       volumes:
         - name: dids
           configMap:
-            name: lens-bootstrap-dids
+            # The shared beta cohort, so "who is in the beta" stays one decision
+            # in one place rather than a per-feature allowlist.
+            name: graze-beta-cohort

--- a/kube/lens-bootstrap-job.yaml
+++ b/kube/lens-bootstrap-job.yaml
@@ -1,0 +1,91 @@
+# graze-lens-bootstrap — backfills historical follow edges for a set of accounts.
+#
+# `graze-lens-fold` only sees follows from the moment it connects; this fills in
+# the history behind it, reading each account's follow records from its PDS.
+#
+# IDEMPOTENT. Rows are versioned by the record's own TID, so re-running writes
+# identical (follower, rkey, seq) tuples and ReplacingMergeTree collapses them.
+# Re-run freely — that is also the recovery procedure.
+#
+# Prereqs (created out of band):
+#   * secret `app-secrets` — CLICKHOUSE_{HOST,USER,PASSWORD}
+#   * ClickHouse tables — `feed-processor/scripts/create_follow_edges_tables.py`
+#   * ConfigMap `lens-bootstrap-dids` with a `dids.txt` key, one DID per line
+#     (blank lines and `#` comments are ignored):
+#       kubectl create configmap lens-bootstrap-dids --from-file=dids.txt
+#
+# Scope note: this is the per-account path, and it is what M0 needs — it covers
+# exactly the accounts that asked for a lens, over public unauthenticated
+# endpoints. Warming the *global* graph is a different job, blocked on a
+# bsky.network archive token plus a decoder for the .jss segment format; when
+# that lands, this remains the repair path for history the archive predates.
+#
+# Dry run first on a new DID list:
+#   kubectl set env job/graze-lens-bootstrap LENS_BOOTSTRAP_DRY_RUN=true
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: graze-lens-bootstrap
+  labels:
+    app: graze-lens
+    component: bootstrap
+spec:
+  # No retries. The job is re-runnable by hand, and an automatic retry of a
+  # partially-succeeded backfill just re-walks every PDS for no benefit.
+  backoffLimit: 0
+  # ~4h ceiling: a 50k-follow account is ~500 paged requests, and the default
+  # concurrency of 4 is deliberately polite to other people's servers.
+  activeDeadlineSeconds: 14400
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: graze-lens
+        component: bootstrap
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: bootstrap
+          # TODO(deploy): replace with the digest built from this commit.
+          image: registry.digitalocean.com/graze-social-labs/graze-personalization@sha256:REPLACE_ME
+          command: ["/app/graze-lens-bootstrap"]
+          args: ["--file", "/config/dids.txt"]
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              # Edges buffer in memory until a batch fills; a very large DID list
+              # of whales is the case that needs the headroom.
+              memory: "2Gi"
+              cpu: "1"
+          envFrom:
+            - secretRef:
+                name: app-secrets
+          env:
+            - name: LENS_BOOTSTRAP_CONCURRENCY
+              value: "4"
+            - name: LENS_BOOTSTRAP_PAGE_DELAY_MS
+              value: "150"
+            - name: LENS_BOOTSTRAP_INSERT_BATCH
+              value: "20000"
+            - name: RUST_LOG
+              value: "info"
+          volumeMounts:
+            - name: dids
+              mountPath: /config
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      securityContext:
+        # Numeric, not a name: distroless nonroot has no /etc/passwd entry.
+        runAsUser: 65532
+        runAsGroup: 65532
+      volumes:
+        - name: dids
+          configMap:
+            name: lens-bootstrap-dids

--- a/kube/lens-bootstrap-job.yaml
+++ b/kube/lens-bootstrap-job.yaml
@@ -44,10 +44,15 @@ spec:
         component: bootstrap
     spec:
       restartPolicy: Never
+      # Required: the default service account carries no pull secrets, so
+      # without this the pod fails with ImagePullBackOff against DOCR.
+      imagePullSecrets:
+        - name: docr-graze-social-labs
       containers:
         - name: bootstrap
-          # TODO(deploy): replace with the digest built from this commit.
-          image: registry.digitalocean.com/graze-social-labs/graze-personalization@sha256:REPLACE_ME
+          # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
+          # the short-SHA tag are mutable on DOCR.
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:79d0c8af00d3c3110276a88e702e26ae79930eef8d93a6d5f409e237cf2cc3ea
           command: ["/app/graze-lens-bootstrap"]
           args: ["--file", "/config/dids.txt"]
           resources:

--- a/kube/lens-bootstrap-job.yaml
+++ b/kube/lens-bootstrap-job.yaml
@@ -52,7 +52,7 @@ spec:
         - name: bootstrap
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:79d0c8af00d3c3110276a88e702e26ae79930eef8d93a6d5f409e237cf2cc3ea
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:fba7efdda8fdc929fc5318f3df530ef41ec42d1b127c2d8039faff15fa901b62
           command: ["/app/graze-lens-bootstrap"]
           args: ["--file", "/config/dids.txt"]
           resources:

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -44,10 +44,15 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
     spec:
+      # Required: the default service account carries no pull secrets, so
+      # without this the pod fails with ImagePullBackOff against DOCR.
+      imagePullSecrets:
+        - name: docr-graze-social-labs
       containers:
         - name: builder
-          # TODO(deploy): replace with the digest built from this commit.
-          image: registry.digitalocean.com/graze-social-labs/graze-personalization@sha256:REPLACE_ME
+          # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
+          # the short-SHA tag are mutable on DOCR.
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:79d0c8af00d3c3110276a88e702e26ae79930eef8d93a6d5f409e237cf2cc3ea
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -1,0 +1,92 @@
+# graze-lens-builder — drains the lens build queue.
+#
+# Off the serve path entirely. feeder-rs enqueues a build the first time it wants
+# a lens it does not have and serves that request unlensed; this worker folds
+# `follow_edges` for the viewer and publishes the set. If it is down, feeds keep
+# serving — every request just takes the fail-open branch.
+#
+# Prereqs (created out of band):
+#   * secret `app-secrets` — CLICKHOUSE_{HOST,USER,PASSWORD}, PERSONALIZATION_REDIS_URL
+#   * ClickHouse tables — `feed-processor/scripts/create_follow_edges_tables.py`
+#
+# Image is pinned by digest, not tag. Both `latest` and the short-SHA tag are
+# mutable on DOCR, and a reused tag has silently changed what was running before
+# (see the note in feeder-rs/kube/feeder-rs-deployment.yml). Get the digest from
+# the docker-release workflow run, or:
+#   doctl registry repository list-tags graze-personalization --format Tag,ManifestDigest
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: graze-lens-builder
+  labels:
+    app: graze-lens
+    component: builder
+spec:
+  # Horizontally scalable: the consumer group hands each request to exactly one
+  # replica. Kept at 1 for M0, where the whole population is an allowlist.
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: graze-lens
+      component: builder
+  template:
+    metadata:
+      labels:
+        app: graze-lens
+        component: builder
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: builder
+          # TODO(deploy): replace with the digest built from this commit.
+          image: registry.digitalocean.com/graze-social-labs/graze-personalization@sha256:REPLACE_ME
+          command: ["/app/graze-lens-builder"]
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "1"
+          envFrom:
+            - secretRef:
+                name: app-secrets
+          env:
+            # Consumer identity within the group. Must differ per replica, so it
+            # comes from the pod name rather than a literal.
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # M0 publishes into the personalization instance feeder-rs already
+            # pools. M1 points this at the dedicated lens-valkey instead.
+            - name: LENS_SET_TTL_SECONDS
+              value: "900"
+            - name: LENS_QUERY_MAX_EXECUTION_SECONDS
+              value: "20"
+            - name: LENS_MAX_SET_SIZE
+              value: "200000"
+            - name: RUST_LOG
+              value: "info"
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      securityContext:
+        # Numeric, not a name: the distroless nonroot image has no /etc/passwd
+        # entry for the kubelet to resolve, so a named user fails to start.
+        runAsUser: 65532
+        runAsGroup: 65532
+      # Long enough to finish the build in flight and ack it; an unacked request
+      # is simply re-enqueued by the serve path on the viewer's next request.
+      terminationGracePeriodSeconds: 30

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:79d0c8af00d3c3110276a88e702e26ae79930eef8d93a6d5f409e237cf2cc3ea
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:fba7efdda8fdc929fc5318f3df530ef41ec42d1b127c2d8039faff15fa901b62
           command: ["/app/graze-lens-builder"]
           resources:
             requests:
@@ -73,8 +73,14 @@ spec:
                   fieldPath: metadata.name
             # M0 publishes into the personalization instance feeder-rs already
             # pools. M1 points this at the dedicated lens-valkey instead.
+            # 7 days. graze-lens-fold applies the follow stream to live sets and
+            # pushes this out on every delta, so it is a garbage-collection
+            # horizon for readers who stopped reading, not a freshness bound.
+            # It was 900s before deltas existed, which meant an active reader
+            # kept falling off the end of their own lens and briefly seeing an
+            # unfiltered feed while it rebuilt.
             - name: LENS_SET_TTL_SECONDS
-              value: "900"
+              value: "604800"
             - name: LENS_QUERY_MAX_EXECUTION_SECONDS
               value: "20"
             - name: LENS_MAX_SET_SIZE

--- a/kube/lens-fold-deployment.yaml
+++ b/kube/lens-fold-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: fold
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:79d0c8af00d3c3110276a88e702e26ae79930eef8d93a6d5f409e237cf2cc3ea
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:fba7efdda8fdc929fc5318f3df530ef41ec42d1b127c2d8039faff15fa901b62
           command: ["/app/graze-lens-fold"]
           resources:
             requests:

--- a/kube/lens-fold-deployment.yaml
+++ b/kube/lens-fold-deployment.yaml
@@ -38,10 +38,15 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
     spec:
+      # Required: the default service account carries no pull secrets, so
+      # without this the pod fails with ImagePullBackOff against DOCR.
+      imagePullSecrets:
+        - name: docr-graze-social-labs
       containers:
         - name: fold
-          # TODO(deploy): replace with the digest built from this commit.
-          image: registry.digitalocean.com/graze-social-labs/graze-personalization@sha256:REPLACE_ME
+          # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
+          # the short-SHA tag are mutable on DOCR.
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:79d0c8af00d3c3110276a88e702e26ae79930eef8d93a6d5f409e237cf2cc3ea
           command: ["/app/graze-lens-fold"]
           resources:
             requests:

--- a/kube/lens-fold-deployment.yaml
+++ b/kube/lens-fold-deployment.yaml
@@ -1,0 +1,100 @@
+# graze-lens-fold — tails the Bluesky follow graph into ClickHouse.
+#
+# SINGLETON. Two consumers would double-write; the ReplacingMergeTree fold makes
+# that harmless but it doubles insert cost for nothing. `Recreate` rather than a
+# rolling update, for the same reason.
+#
+# Prereqs (created out of band):
+#   * secret `app-secrets` — CLICKHOUSE_{HOST,USER,PASSWORD}, PERSONALIZATION_REDIS_URL
+#   * ClickHouse tables — `feed-processor/scripts/create_follow_edges_tables.py`
+#
+# THE alert for this service: `lens_fold_cursor_age_seconds > 1800`. A wedged
+# websocket consumer that keeps its process alive is exactly how the turbostream
+# bridge outage ran for hours unnoticed. Jetstream v2 rewinds ~36h on the socket,
+# so a wedge caught inside that window costs only catch-up time — but nothing
+# catches it without this alert.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: graze-lens-fold
+  labels:
+    app: graze-lens
+    component: fold
+spec:
+  replicas: 1 # Singleton — never scale this up.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: graze-lens
+      component: fold
+  template:
+    metadata:
+      labels:
+        app: graze-lens
+        component: fold
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: fold
+          # TODO(deploy): replace with the digest built from this commit.
+          image: registry.digitalocean.com/graze-social-labs/graze-personalization@sha256:REPLACE_ME
+          command: ["/app/graze-lens-fold"]
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              # Headroom for the in-memory batch when ClickHouse is refusing
+              # inserts; LENS_FOLD_MAX_PENDING_ROWS caps how far that can grow.
+              memory: "1Gi"
+              cpu: "1"
+          envFrom:
+            - secretRef:
+                name: app-secrets
+          env:
+            # Pinned to one host on purpose. A round-robin name can land on a
+            # replica serving hours-stale records, which looks identical to a
+            # healthy one except in the cursor-age gauge (turbo-deploy's Pulumi
+            # config documents a host that was ~6.8h behind).
+            - name: LENS_JETSTREAM_URL
+              value: "wss://jetstream.us-east.bsky.network/subscribe"
+            - name: LENS_FOLD_BATCH_SIZE
+              value: "5000"
+            - name: LENS_FOLD_BATCH_INTERVAL_MS
+              value: "5000"
+            - name: LENS_FOLD_READ_TIMEOUT_SECONDS
+              value: "45"
+            - name: RUST_LOG
+              value: "info"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            # Deliberately only checks the process is alive. A stalled *stream*
+            # must not restart the pod — restarting loses nothing but fixes
+            # nothing either, and the cursor-age alert is the real detector.
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      securityContext:
+        # Numeric, not a name: distroless nonroot has no /etc/passwd entry.
+        runAsUser: 65532
+        runAsGroup: 65532
+      # Long enough to flush the current batch and commit the cursor. Cutting
+      # this short just means re-fetching those events after restart.
+      terminationGracePeriodSeconds: 30

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -51,10 +51,15 @@ spec:
             component: rev-rebuild
         spec:
           restartPolicy: Never
+          # Required: the default service account carries no pull secrets, so
+          # without this the pod fails with ImagePullBackOff against DOCR.
+          imagePullSecrets:
+            - name: docr-graze-social-labs
           containers:
             - name: rev-rebuild
-              # TODO(deploy): replace with the digest built from this commit.
-              image: registry.digitalocean.com/graze-social-labs/graze-personalization@sha256:REPLACE_ME
+              # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
+              # the short-SHA tag are mutable on DOCR.
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:79d0c8af00d3c3110276a88e702e26ae79930eef8d93a6d5f409e237cf2cc3ea
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: rev-rebuild
               # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
               # the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:79d0c8af00d3c3110276a88e702e26ae79930eef8d93a6d5f409e237cf2cc3ea
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:fba7efdda8fdc929fc5318f3df530ef41ec42d1b127c2d8039faff15fa901b62
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -1,0 +1,87 @@
+# graze-lens-rev-rebuild — rebuilds the reverse follow index.
+#
+# `follow_edges` answers "who does X follow". `mutuals` needs the opposite, and
+# that cannot be a materialized view: a follow delete carries no followee, so a
+# row-by-row view would receive unfollows as edges pointing at '' and never
+# retract the real one. The reverse direction has to come from the *folded*
+# forward table, which means this periodic rebuild.
+#
+# Nothing in M0 reads `follow_edges_rev`; this exists so the index is warm and
+# correct by the time the M1 `mutuals` facet ships. Until then it is cheap
+# insurance, and its cost is one scheduled ClickHouse pass.
+#
+# Prereqs (created out of band):
+#   * secret `app-secrets` — CLICKHOUSE_{HOST,USER,PASSWORD}
+#   * ClickHouse tables — `feed-processor/scripts/create_follow_edges_tables.py`
+#
+# Safety: the job builds into `follow_edges_rev_next` and EXCHANGEs it in, so a
+# run that dies partway leaves the live index untouched. It also refuses to swap
+# a result under LENS_REV_MIN_RATIO (default 0.5) of the current row count —
+# without that, one bad run would replace the index with an empty table and
+# `mutuals` would quietly return nobody for every viewer. Override deliberately
+# with LENS_REV_FORCE=true when a genuine shrink is expected.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: graze-lens-rev-rebuild
+  labels:
+    app: graze-lens
+    component: rev-rebuild
+spec:
+  # Nightly, off-peak. The reverse index feeds `mutuals`, whose semantics do not
+  # change minute to minute; running it more often buys freshness nobody can
+  # perceive and costs a full-table pass each time.
+  schedule: "17 9 * * *" # 09:17 UTC ≈ 02:17 sfo3
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  # Skip a run entirely rather than piling up after downtime: a missed rebuild
+  # is a day-stale index, which is survivable; two concurrent rebuilds are not
+  # (they would fight over the staging table).
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 10800 # 3h
+      template:
+        metadata:
+          labels:
+            app: graze-lens
+            component: rev-rebuild
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: rev-rebuild
+              # TODO(deploy): replace with the digest built from this commit.
+              image: registry.digitalocean.com/graze-social-labs/graze-personalization@sha256:REPLACE_ME
+              command: ["/app/graze-lens-rev-rebuild"]
+              resources:
+                requests:
+                  memory: "128Mi"
+                  cpu: "100m"
+                limits:
+                  # The work happens inside ClickHouse; this process only issues
+                  # SQL and reads counts back.
+                  memory: "512Mi"
+                  cpu: "500m"
+              envFrom:
+                - secretRef:
+                    name: app-secrets
+              env:
+                - name: LENS_REV_MAX_EXECUTION_SECONDS
+                  value: "1800"
+                - name: LENS_REV_MIN_RATIO
+                  value: "0.5"
+                - name: RUST_LOG
+                  value: "info"
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+          securityContext:
+            # Numeric, not a name: distroless nonroot has no /etc/passwd entry.
+            runAsUser: 65532
+            runAsGroup: 65532


### PR DESCRIPTION
The backend behind viewer-graph feeds — "this feed, but only people I follow." Four binaries, all off the serve path:

| | |
|---|---|
| `graze-lens-fold` | tails `app.bsky.graph.follow` into ClickHouse, and keeps live lens sets fresh |
| `graze-lens-builder` | folds a viewer’s follows into the Redis set feeder-rs reads |
| `graze-lens-bootstrap` | backfills history from each account’s own PDS |
| `graze-lens-rev-rebuild` | nightly rebuild of the reverse index (for a future `mutuals` facet) |

## `follow_edges` is keyed on (follower, rkey), not (follower, followee)

A follow *delete* on the wire carries only `{rev, operation, collection, rkey}` — **it never names the followee.** Verified against live Jetstream. Keyed on the followee, a delete could never replace its create row, ReplacingMergeTree would collapse nothing, and every unfollow would be invisible: lenses would accumulate people you stopped following, forever, with nothing erroring. Deletes are a large minority of live follow traffic, so this is not an edge case.

Partitioning is `cityHash64(follower) % 32` rather than by date for the same reason — Replacing only collapses *within* a partition, and a follow created in 2024 and deleted today would otherwise land in two monthly partitions and never meet.

The reverse index cannot be a materialized view (delete rows carry an empty followee), so it is a rebuild that builds into staging and `EXCHANGE`es. It refuses to swap a result under half the live row count: `EXCHANGE` is instant and total, so one silently-empty rebuild would replace the index with nothing and `mutuals` would return nobody for every viewer, with no error raised.

## Live set maintenance (why the TTL is 7 days)

A set used to be built once and then rot, so its TTL had to be ~15 minutes — which meant an active reader kept falling off the end of their own lens and briefly seeing an unfiltered feed while it rebuilt. The fold now applies the follow stream to sets that already exist, so expiry becomes a GC horizon rather than a freshness bound.

Creates apply directly (one `SADD`); deletes enqueue a rebuild, since there is no subject to `SREM` and keeping an rkey→followee map purely to serve the rarer event would double memory per active viewer. Every write is guarded by an existence check **inside a Lua script**, because `SADD` on a missing key would *create* it — a lens set holding exactly one account, which is worse than no lens, since the reader would silently see almost nothing instead of failing open.

## Verified in production

Deployed and running. `follow_edges` at ~160k rows with zero insert failures and zero reconnects; bootstrap backfilled the beta cohort (10,746 edges, 8 accounts, 14s); a build produces exactly the 1,182 follows the bootstrap independently measured. End to end on a live feed: **30 posts anonymously, 2 for a lensed reader**, both by the one author of 30 that reader follows.

The Lua guard was tested against a real Redis in both directions: applying to a viewer with no set creates nothing and returns 0; applying to a live set adds the member and pushes the set and its metadata key from 60s to 7 days together.

Companion PRs: feeder-rs (serve path), feed-processor (publishes the per-feed facet), ui (creator control).