### PR TITLE
Sync the dose-check fix into the repo

### DIFF
--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -25,7 +25,11 @@ data:
     # so without this bound every pre-flip row would land in the control arm.
     FLIP = os.environ.get("FOLLOW_SEED_FLIP_AT", "2026-08-27 17:29:54")
     DEC = "tryBase64Decode(interaction_feed_context)"
-    ARM = f"JSONExtractBool({DEC},'params','follow_seed')"
+    # TOP-LEVEL, not nested under `params`. The field was moved there so it would be written on
+    # no_user_data responses too, and this consumer was not updated with it -- so for 24 hours the
+    # dose check read 54 stale pre-move blobs instead of 17,494 live rows and reported NOT DELIVERED
+    # while the treatment was in fact working.
+    ARM = f"JSONExtractBool({DEC},'follow_seed')"
     SEEN = "app.bsky.feed.defs#interactionSeen"
 
     c = clickhouse_connect.get_client(
@@ -40,10 +44,28 @@ data:
     BASE = f"""FROM default.feed_interactions
     WHERE occurred >= toDateTime('{FLIP}') AND interaction_feed_context != ''
       AND JSONHas({DEC},'algo_id')
-      AND JSONHas({DEC},'params','follow_seed')
+      AND JSONHas({DEC},'follow_seed')
       AND interaction_event = '{SEEN}'"""
 
     print(f"=== follow-seed dose check (since {FLIP}Z) ===\n")
+
+    # Self-check before reporting anything. If rows carry the arm somewhere this script is not
+    # looking, every number below is drawn from the wrong population. This guard exists because that
+    # is exactly what happened: five separate times in this feature a producer changed and a
+    # consumer did not.
+    probe = c.query(f"""SELECT
+        countIf(JSONHas({DEC},'follow_seed')) AS top_level,
+        countIf(JSONHas({DEC},'params','follow_seed')) AS nested
+      FROM default.feed_interactions
+      WHERE occurred >= toDateTime('{FLIP}') AND interaction_feed_context != ''
+        AND JSONHas({DEC},'algo_id')
+        AND interaction_event = '{SEEN}'""").result_rows[0]
+    if probe[1] > probe[0]:
+        print(f"  !! ARM FIELD MOVED: {probe[1]:,} rows carry params.follow_seed but only")
+        print(f"     {probe[0]:,} carry top-level follow_seed. This script is reading the wrong")
+        print("     path and every number below is from the wrong population. Fix before reading.")
+        raise SystemExit(1)
+
 
     rows = c.query(f"""SELECT {ARM} AS arm, count() AS imp, uniqExact(did) AS users
                        {BASE} GROUP BY arm ORDER BY arm""").result_rows


### PR DESCRIPTION
The fix was applied directly to the cluster and its PR was **closed rather than merged** — deleting the branch closed it — so `main` still carried the nested `params.follow_seed` query while the live ConfigMap had the corrected top-level one.

Anyone applying the repo manifest would have silently reverted the cluster to reading **54 stale blobs instead of 17,494 live rows**.

Repo and live ConfigMap are now byte-identical, verified by diffing the rendered ConfigMap against the cluster rather than by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)