### PR TITLE
Record completeness for bulk-backfilled accounts, and never for a truncated one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,11 @@ COPY --from=builder /app/target/release/graze-feed-stats /app/graze-feed-stats
 COPY --from=builder /app/target/release/graze-lens-builder /app/graze-lens-builder
 COPY --from=builder /app/target/release/graze-lens-fold /app/graze-lens-fold
 COPY --from=builder /app/target/release/graze-lens-bootstrap /app/graze-lens-bootstrap
-# Built by -p graze-lens-fold; selected by `command:` in the CronJob.
+# Both built by -p graze-lens-fold; selected by `command:` in their CronJobs.
+# A binary missing here does not fail the build — it fails at container start,
+# on a schedule, as an OCI "no such file or directory" nobody is watching for.
 COPY --from=builder /app/target/release/graze-lens-rev-rebuild /app/graze-lens-rev-rebuild
+COPY --from=builder /app/target/release/graze-lens-project /app/graze-lens-project
 COPY --from=builder /app/target/release/graze-migrate-tranches /app/graze-migrate-tranches
 COPY --from=builder /app/target/release/graze-migrate-dates /app/graze-migrate-dates
 COPY --from=builder /app/target/release/graze-verify-migration /app/graze-verify-migration

--- a/crates/graze-lens-bootstrap/src/backfill.rs
+++ b/crates/graze-lens-bootstrap/src/backfill.rs
@@ -53,6 +53,21 @@ pub struct Backfilled {
     pub truncated: bool,
 }
 
+/// Ceiling on a single backoff wait. A host advertising a multi-minute
+/// Retry-After is telling us to come back in another run, not to hold a worker
+/// slot idle for it while thousands of other accounts wait behind it.
+const MAX_RETRY_WAIT: Duration = Duration::from_secs(30);
+
+/// `Retry-After`, as either delta-seconds or an HTTP date we ignore in favour of
+/// the caller's backoff. Only the numeric form is honoured, because the date
+/// form is rare here and mis-parsing it would stall a worker far longer than
+/// backing off would.
+fn retry_after(response: &reqwest::Response) -> Option<Duration> {
+    let raw = response.headers().get(reqwest::header::RETRY_AFTER)?;
+    let secs: u64 = raw.to_str().ok()?.trim().parse().ok()?;
+    Some(Duration::from_secs(secs))
+}
+
 pub struct Backfiller {
     http: reqwest::Client,
     resolver: Resolver,
@@ -60,6 +75,8 @@ pub struct Backfiller {
     /// Politeness delay between pages against one PDS.
     page_delay: Duration,
     max_pages: usize,
+    /// How many times one page may be retried after a 429 or 5xx.
+    max_retries: u32,
 }
 
 impl Backfiller {
@@ -69,6 +86,7 @@ impl Backfiller {
         request_timeout: Duration,
         page_delay: Duration,
         max_pages: usize,
+        max_retries: u32,
     ) -> Self {
         Self {
             http,
@@ -76,6 +94,7 @@ impl Backfiller {
             request_timeout,
             page_delay,
             max_pages,
+            max_retries,
         }
     }
 
@@ -103,13 +122,44 @@ impl Backfiller {
                 query.push(("cursor", c.clone()));
             }
 
-            let response = self
-                .http
-                .get(&url)
-                .query(&query)
-                .timeout(self.request_timeout)
-                .send()
-                .await?;
+            // Retried on 429/5xx rather than failing the account.
+            //
+            // A bulk run fans out over shared `*.host.bsky.network` hosts, and
+            // raising max_pages multiplies requests per account, so the job
+            // rate-limits *itself*: one run pushed 2,520 accounts into 429s and
+            // recorded them all as failures. Nothing was wrong with those
+            // accounts — we simply asked too fast, and then remembered our own
+            // impatience as their problem. Backing off is what makes a bulk
+            // warm-up honest about which accounts it actually could not read.
+            let mut attempt = 0u32;
+            let response = loop {
+                let response = self
+                    .http
+                    .get(&url)
+                    .query(&query)
+                    .timeout(self.request_timeout)
+                    .send()
+                    .await?;
+
+                let status = response.status();
+                let retryable =
+                    status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
+                if !retryable || attempt >= self.max_retries {
+                    break response;
+                }
+
+                // Honour Retry-After when the host sends one — it knows its own
+                // window better than any backoff curve we invent. Otherwise back
+                // off exponentially from the configured page delay.
+                let wait = retry_after(&response).unwrap_or_else(|| {
+                    let base = self.page_delay.max(Duration::from_millis(200));
+                    base * 2u32.saturating_pow(attempt + 1)
+                });
+                let wait = wait.min(MAX_RETRY_WAIT);
+                attempt += 1;
+                debug!(did, %status, attempt, wait_ms = wait.as_millis(), "backing off");
+                tokio::time::sleep(wait).await;
+            };
 
             if !response.status().is_success() {
                 let status = response.status();

--- a/crates/graze-lens-bootstrap/src/backfill.rs
+++ b/crates/graze-lens-bootstrap/src/backfill.rs
@@ -39,6 +39,20 @@ struct FollowValue {
     created_at: Option<String>,
 }
 
+/// The result of backfilling one account.
+///
+/// `truncated` is the field that matters to callers: it means we stopped at
+/// `max_pages` with records still unread, so these edges are a *prefix* of the
+/// account's follows, not their graph. A caller that records completeness must
+/// not do so for a truncated result — that would pin the account to a partial
+/// graph permanently, which is the same silent-wrong-lens failure the
+/// completeness marker exists to prevent, just harder to spot because the
+/// backfill genuinely ran.
+pub struct Backfilled {
+    pub edges: Vec<FollowEdge>,
+    pub truncated: bool,
+}
+
 pub struct Backfiller {
     http: reqwest::Client,
     resolver: Resolver,
@@ -70,13 +84,14 @@ impl Backfiller {
     /// Only creates are produced: listRecords reflects present state, so a
     /// record that is absent was either never created or already deleted, and
     /// in both cases there is nothing to write. Live deletes come from the fold.
-    pub async fn edges_for(&self, did: &str) -> anyhow::Result<Vec<FollowEdge>> {
+    pub async fn edges_for(&self, did: &str) -> anyhow::Result<Backfilled> {
         let pds = self.resolver.pds_for(did).await?;
         let url = format!("{pds}/xrpc/com.atproto.repo.listRecords");
 
         let mut edges = Vec::new();
         let mut cursor: Option<String> = None;
         let mut pages = 0usize;
+        let mut truncated = false;
 
         loop {
             let mut query: Vec<(&str, String)> = vec![
@@ -108,7 +123,13 @@ impl Backfiller {
                 // scale, where a slice of anyone's follow list has since left.
                 if is_repo_gone(status, &body) {
                     debug!(did, %status, "repo unavailable; treating as no records");
-                    return Ok(Vec::new());
+                    // Not truncated: this is a complete answer about an account
+                    // with nothing to read, not a partial read of one that has
+                    // records left.
+                    return Ok(Backfilled {
+                        edges: Vec::new(),
+                        truncated: false,
+                    });
                 }
 
                 anyhow::bail!(
@@ -144,6 +165,7 @@ impl Backfiller {
                     edges = edges.len(),
                     "hit max_pages; backfill truncated for this account"
                 );
+                truncated = true;
                 break;
             }
             if !self.page_delay.is_zero() {
@@ -151,7 +173,7 @@ impl Backfiller {
             }
         }
 
-        Ok(edges)
+        Ok(Backfilled { edges, truncated })
     }
 }
 

--- a/crates/graze-lens-bootstrap/src/backfill.rs
+++ b/crates/graze-lens-bootstrap/src/backfill.rs
@@ -99,6 +99,18 @@ impl Backfiller {
             if !response.status().is_success() {
                 let status = response.status();
                 let body = response.text().await.unwrap_or_default();
+
+                // An account that has been deleted or deactivated is not a
+                // backfill failure — it is an answer. The PDS is telling us
+                // this repo has no records, and treating that as an error makes
+                // a bulk run over thousands of accounts report failure for
+                // doing exactly the right thing. Seen constantly at hop-2
+                // scale, where a slice of anyone's follow list has since left.
+                if is_repo_gone(status, &body) {
+                    debug!(did, %status, "repo unavailable; treating as no records");
+                    return Ok(Vec::new());
+                }
+
                 anyhow::bail!(
                     "listRecords failed for {did} ({}): {}",
                     status,
@@ -175,6 +187,24 @@ fn edge_from_record(did: &str, record: &Record) -> Option<FollowEdge> {
         seq,
         created_at,
     })
+}
+
+/// Is this PDS response "that account is gone" rather than "something broke"?
+///
+/// Matched on the response body rather than the status alone, because a bare
+/// 400 also covers genuine client errors we do want to hear about — a malformed
+/// DID, a bad cursor. Only the specific repo-missing shapes are treated as an
+/// empty answer.
+fn is_repo_gone(status: reqwest::StatusCode, body: &str) -> bool {
+    if status != reqwest::StatusCode::BAD_REQUEST && status != reqwest::StatusCode::NOT_FOUND {
+        return false;
+    }
+    let b = body.to_ascii_lowercase();
+    b.contains("could not find repo")
+        || b.contains("reponotfound")
+        || b.contains("repodeactivated")
+        || b.contains("repotakendown")
+        || b.contains("account is deactivated")
 }
 
 /// `at://did/app.bsky.graph.follow/<rkey>` → `<rkey>`.
@@ -282,6 +312,44 @@ mod tests {
             None,
         );
         assert!(edge_from_record("did:plc:a", &r).is_none());
+    }
+
+    /// A deleted or deactivated account is an answer, not an error. At hop-2
+    /// scale a slice of anyone's follow list has since left, and failing the
+    /// whole run for that would report failure for correct behaviour.
+    #[test]
+    fn gone_repos_are_not_failures() {
+        use reqwest::StatusCode;
+        assert!(is_repo_gone(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"InvalidRequest","message":"Could not find repo: did:plc:x"}"#
+        ));
+        assert!(is_repo_gone(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"RepoNotFound"}"#
+        ));
+        assert!(is_repo_gone(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"RepoDeactivated"}"#
+        ));
+        assert!(is_repo_gone(StatusCode::NOT_FOUND, "RepoTakendown"));
+    }
+
+    /// But a genuine client error must still surface. A bare 400 is not on its
+    /// own evidence the account is gone.
+    #[test]
+    fn other_client_errors_still_fail() {
+        use reqwest::StatusCode;
+        assert!(!is_repo_gone(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"InvalidRequest","message":"Invalid cursor"}"#
+        ));
+        assert!(!is_repo_gone(StatusCode::BAD_REQUEST, "malformed did"));
+        assert!(!is_repo_gone(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Could not find repo"
+        ));
+        assert!(!is_repo_gone(StatusCode::TOO_MANY_REQUESTS, "slow down"));
     }
 
     #[test]

--- a/crates/graze-lens-bootstrap/src/completeness.rs
+++ b/crates/graze-lens-bootstrap/src/completeness.rs
@@ -21,12 +21,18 @@
 use std::time::Duration;
 
 use graze_common::ClickHouseConfig;
-use tracing::debug;
+use tracing::{debug, warn};
 
 const TABLE: &str = "lens_backfill_state";
 
 /// Where a viewer's backfill came from, for auditing a suspicious lens later.
+///
+/// Both paths write real markers and both count as complete; the distinction is
+/// purely so an audit can tell a lazily-repaired viewer from one warmed in bulk.
+/// `SOURCE_PDS` is the builder repairing a single viewer inline, on their own
+/// first lens request; `SOURCE_BOOTSTRAP` is the bulk Job warming a cohort.
 pub const SOURCE_PDS: &str = "pds";
+pub const SOURCE_BOOTSTRAP: &str = "bootstrap";
 
 pub struct CompletenessStore {
     http: reqwest::Client,
@@ -112,6 +118,76 @@ impl CompletenessStore {
         Ok(())
     }
 
+    /// Record many viewers at once.
+    ///
+    /// The bulk Job backfills thousands of accounts in one run, and one INSERT
+    /// per account is exactly the tiny-insert pattern that drives this cluster's
+    /// cost. Rows go over as TabSeparated in batches, matching the Sink.
+    ///
+    /// Callers must only pass viewers whose edges are already durable. A marker
+    /// written ahead of its edges is worse than no marker: the next build trusts
+    /// it, skips the backfill, and publishes a lens from a graph that was never
+    /// written.
+    pub async fn mark_many(&self, entries: &[(String, usize)], source: &str) -> anyhow::Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        // `backfilled_at` has no DEFAULT and is the ReplacingMergeTree *version*
+        // column, so it has to be sent: an omitted value would write epoch zero,
+        // which both destroys the audit trail the column exists for and loses
+        // every dedup race against any other row for that viewer. Sent as a unix
+        // integer, which TabSeparated accepts for DateTime, and read once per
+        // batch so a batch is internally consistent.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let body = entries
+            .iter()
+            .map(|(viewer, edges)| {
+                format!(
+                    "{}\t{}\t{}\t{}",
+                    escape_tsv(viewer),
+                    now,
+                    edges,
+                    escape_tsv(source)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let query = format!(
+            "INSERT INTO {}.{TABLE} (viewer, backfilled_at, edge_count, source) \
+             FORMAT TabSeparated",
+            self.clickhouse.database
+        );
+
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.timeout)
+            .query(&[("query", query.as_str())])
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "marking {} viewer(s) complete failed ({}): {}",
+                entries.len(),
+                status,
+                &text[..text.len().min(400)]
+            );
+        }
+        Ok(())
+    }
+
     async fn exec(&self, sql: &str, viewer: Option<&str>) -> anyhow::Result<String> {
         let mut query: Vec<(&str, String)> = vec![
             ("max_execution_time", self.max_execution_seconds.to_string()),
@@ -145,6 +221,27 @@ impl CompletenessStore {
     }
 }
 
+/// TabSeparated escaping, matching the Sink's.
+///
+/// A DID should never contain a tab, but this is untrusted network input and one
+/// stray control character would shift every later column silently rather than
+/// failing.
+fn escape_tsv(value: &str) -> String {
+    if !value
+        .as_bytes()
+        .iter()
+        .any(|b| matches!(b, b'\t' | b'\n' | b'\r' | b'\\'))
+    {
+        return value.to_string();
+    }
+    warn!(value, "control characters in a viewer DID; escaping");
+    value
+        .replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,6 +272,67 @@ mod tests {
         );
         assert!(sql.contains("{viewer:String}"));
         assert!(!sql.contains("did:plc:"));
+    }
+
+    /// The batched insert must name columns in the order its rows carry them.
+    /// A silent column shift here would write the timestamp into `edge_count`,
+    /// which the guard reads as "complete" for every viewer forever.
+    #[test]
+    fn batched_insert_columns_match_the_row_order() {
+        let s = store();
+        let query = format!(
+            "INSERT INTO {}.{TABLE} (viewer, backfilled_at, edge_count, source) \
+             FORMAT TabSeparated",
+            s.clickhouse.database
+        );
+        let row = format!(
+            "{}\t{}\t{}\t{}",
+            escape_tsv("did:plc:a"),
+            1788000000,
+            42,
+            escape_tsv(SOURCE_BOOTSTRAP)
+        );
+
+        let cols: Vec<&str> = query
+            .split_once('(')
+            .and_then(|(_, r)| r.split_once(')'))
+            .map(|(c, _)| c.split(',').map(str::trim).collect())
+            .expect("column list");
+        assert_eq!(
+            cols,
+            vec!["viewer", "backfilled_at", "edge_count", "source"]
+        );
+        assert_eq!(row.split('\t').count(), cols.len());
+        assert_eq!(row.split('\t').nth(2), Some("42"), "edge_count is third");
+    }
+
+    /// `backfilled_at` is the ReplacingMergeTree version column and has no
+    /// DEFAULT, so it must be sent. Omitting it writes epoch zero, which both
+    /// destroys the audit trail and loses every dedup race for that viewer.
+    #[test]
+    fn backfilled_at_is_always_sent() {
+        let s = store();
+        let query = format!(
+            "INSERT INTO {}.{TABLE} (viewer, backfilled_at, edge_count, source) FORMAT TabSeparated",
+            s.clickhouse.database
+        );
+        assert!(query.contains("backfilled_at"));
+    }
+
+    /// The two write paths must stay distinguishable, so an audit can tell a
+    /// lazily-repaired viewer from one warmed in bulk.
+    #[test]
+    fn sources_are_distinct() {
+        assert_ne!(SOURCE_PDS, SOURCE_BOOTSTRAP);
+    }
+
+    /// A control character in a DID would shift every later column silently.
+    #[test]
+    fn tsv_escaping_protects_the_column_boundaries() {
+        assert_eq!(escape_tsv("did:plc:ok"), "did:plc:ok");
+        assert_eq!(escape_tsv("did:plc:a\tb"), "did:plc:a\\tb");
+        assert_eq!(escape_tsv("did:plc:a\nb"), "did:plc:a\\nb");
+        assert!(!escape_tsv("did:plc:a\tb").contains('\t'));
     }
 
     /// A row recorded with zero edges is not evidence of a usable backfill —

--- a/crates/graze-lens-bootstrap/src/config.rs
+++ b/crates/graze-lens-bootstrap/src/config.rs
@@ -22,6 +22,8 @@ pub struct Config {
     /// account; beyond that the account is logged and truncated rather than
     /// paging indefinitely.
     pub max_pages: usize,
+    /// Retries for one page after a 429 or 5xx.
+    pub max_retries: u32,
 
     pub plc_directory: Option<String>,
     /// Resolve and fetch, but write nothing.
@@ -51,6 +53,7 @@ impl Config {
             request_timeout: Duration::from_secs(parse("LENS_BOOTSTRAP_REQUEST_TIMEOUT", 20)?),
             page_delay: Duration::from_millis(parse("LENS_BOOTSTRAP_PAGE_DELAY_MS", 150)?),
             max_pages: parse("LENS_BOOTSTRAP_MAX_PAGES", 600)?,
+            max_retries: parse("LENS_BOOTSTRAP_MAX_RETRIES", 4)?,
 
             plc_directory: optional("LENS_BOOTSTRAP_PLC_DIRECTORY"),
             dry_run: parse("LENS_BOOTSTRAP_DRY_RUN", false)?,

--- a/crates/graze-lens-bootstrap/src/lib.rs
+++ b/crates/graze-lens-bootstrap/src/lib.rs
@@ -24,9 +24,11 @@
 //! (follower, rkey, seq) tuples and ReplacingMergeTree collapses them.
 
 pub mod backfill;
+pub mod completeness;
 pub mod config;
 pub mod resolve;
 
-pub use backfill::Backfiller;
+pub use backfill::{Backfilled, Backfiller};
+pub use completeness::{CompletenessStore, SOURCE_BOOTSTRAP, SOURCE_PDS};
 pub use config::Config;
 pub use resolve::Resolver;

--- a/crates/graze-lens-bootstrap/src/main.rs
+++ b/crates/graze-lens-bootstrap/src/main.rs
@@ -48,6 +48,7 @@ async fn main() -> anyhow::Result<()> {
         config.request_timeout,
         config.page_delay,
         config.max_pages,
+        config.max_retries,
     ));
     let sink =
         Arc::new(Sink::new(config.clickhouse.clone(), config.insert_timeout).context("sink")?);

--- a/crates/graze-lens-bootstrap/src/main.rs
+++ b/crates/graze-lens-bootstrap/src/main.rs
@@ -11,7 +11,7 @@ use std::io::BufRead;
 use std::sync::Arc;
 
 use anyhow::Context;
-use graze_lens_bootstrap::{Backfiller, Config, Resolver};
+use graze_lens_bootstrap::{Backfiller, CompletenessStore, Config, Resolver, SOURCE_BOOTSTRAP};
 use graze_lens_fold::{FollowEdge, Sink};
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
@@ -52,7 +52,28 @@ async fn main() -> anyhow::Result<()> {
     let sink =
         Arc::new(Sink::new(config.clickhouse.clone(), config.insert_timeout).context("sink")?);
 
+    // Without this, every account this job backfills is re-walked from its PDS
+    // the first time it asks for a lens: the builder's completeness guard only
+    // trusts markers, and only the builder's own inline path was writing them.
+    // A 9,423-account run left 6 markers behind, so the bulk warming bought the
+    // cohort nothing but a slow first request each.
+    let completeness = Arc::new(
+        CompletenessStore::new(
+            config.clickhouse.clone(),
+            config.insert_timeout,
+            config.insert_timeout.as_secs().max(1),
+        )
+        .context("completeness store")?,
+    );
+
+    // Edges and the viewers they belong to travel together, and a viewer is only
+    // marked once the batch carrying their edges is durable. Marking on task
+    // completion instead would race the flush: a crash in between leaves a
+    // marker whose edges were never written, and the next build trusts it,
+    // skips the backfill, and publishes a lens from a graph that does not exist.
+    // That is the exact failure the marker was introduced to prevent.
     let pending: Arc<Mutex<Vec<FollowEdge>>> = Arc::new(Mutex::new(Vec::new()));
+    let pending_viewers: Arc<Mutex<Vec<(String, usize)>>> = Arc::new(Mutex::new(Vec::new()));
     let total = dids.len();
     let done = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let failed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -66,25 +87,53 @@ async fn main() -> anyhow::Result<()> {
     for did in dids {
         let permit = semaphore.clone().acquire_owned().await?;
         let (backfiller, sink, pending) = (backfiller.clone(), sink.clone(), pending.clone());
+        let (completeness, pending_viewers) = (completeness.clone(), pending_viewers.clone());
         let (done, failed, rows) = (done.clone(), failed.clone(), rows.clone());
         let config = config.clone();
 
         tasks.push(tokio::spawn(async move {
             let _permit = permit;
             match backfiller.edges_for(&did).await {
-                Ok(edges) => {
-                    rows.fetch_add(edges.len(), std::sync::atomic::Ordering::Relaxed);
-                    if !config.dry_run && !edges.is_empty() {
+                Ok(backfilled) => {
+                    let count = backfilled.edges.len();
+                    rows.fetch_add(count, std::sync::atomic::Ordering::Relaxed);
+                    if !config.dry_run && count > 0 {
                         let mut buf = pending.lock().await;
-                        buf.extend(edges);
+                        buf.extend(backfilled.edges);
+                        // A truncated account is deliberately not recorded: its
+                        // edges are a prefix, and a marker would freeze that
+                        // prefix as its graph forever. Zero-edge accounts are
+                        // skipped too — the guard treats a zero-edge row as
+                        // incomplete anyway, so writing one is pure noise.
+                        if !backfilled.truncated {
+                            pending_viewers.lock().await.push((did.clone(), count));
+                        }
+
                         if buf.len() >= config.insert_batch {
                             let batch = std::mem::take(&mut *buf);
                             drop(buf);
-                            if let Err(e) = sink.insert(&batch).await {
-                                // Keep going: one failed insert should not abort
-                                // a long backfill, and the job is re-runnable.
-                                error!(error = %e, rows = batch.len(), "insert failed");
-                                failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            let viewers = std::mem::take(&mut *pending_viewers.lock().await);
+                            match sink.insert(&batch).await {
+                                Ok(()) => {
+                                    // Only now are these viewers' edges durable.
+                                    if let Err(e) =
+                                        completeness.mark_many(&viewers, SOURCE_BOOTSTRAP).await
+                                    {
+                                        // Not fatal: the edges are written, so
+                                        // the worst case is the builder
+                                        // re-walking these accounts once.
+                                        warn!(error = %e, viewers = viewers.len(),
+                                              "recording completeness failed");
+                                    }
+                                }
+                                Err(e) => {
+                                    // Keep going: one failed insert should not
+                                    // abort a long backfill, and the job is
+                                    // re-runnable. The viewers are dropped
+                                    // unmarked, which is the safe direction.
+                                    error!(error = %e, rows = batch.len(), "insert failed");
+                                    failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                }
                             }
                         }
                     }
@@ -113,10 +162,22 @@ async fn main() -> anyhow::Result<()> {
 
     // Flush the tail.
     let remaining = std::mem::take(&mut *pending.lock().await);
+    let remaining_viewers = std::mem::take(&mut *pending_viewers.lock().await);
     if !config.dry_run && !remaining.is_empty() {
-        if let Err(e) = sink.insert(&remaining).await {
-            error!(error = %e, rows = remaining.len(), "final insert failed");
-            failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        match sink.insert(&remaining).await {
+            Ok(()) => {
+                if let Err(e) = completeness
+                    .mark_many(&remaining_viewers, SOURCE_BOOTSTRAP)
+                    .await
+                {
+                    warn!(error = %e, viewers = remaining_viewers.len(),
+                          "recording completeness failed for the final batch");
+                }
+            }
+            Err(e) => {
+                error!(error = %e, rows = remaining.len(), "final insert failed");
+                failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
         }
     }
 

--- a/crates/graze-lens-builder/Cargo.toml
+++ b/crates/graze-lens-builder/Cargo.toml
@@ -23,6 +23,7 @@ graze-lens-fold = { path = "../graze-lens-fold" }
 tokio = { version = "1.43", features = ["full", "signal"] }
 reqwest = { version = "0.12", features = ["json", "gzip", "rustls-tls"], default-features = false }
 deadpool-redis = "0.22"
+dashmap = "6"
 # Direct dependency purely to turn on `streams` for the consumer-group commands;
 # must track the version deadpool-redis re-exports or the types will not line up.
 redis = { version = "0.32", features = ["streams", "tokio-comp"] }

--- a/crates/graze-lens-builder/Cargo.toml
+++ b/crates/graze-lens-builder/Cargo.toml
@@ -15,6 +15,10 @@ path = "src/lib.rs"
 
 [dependencies]
 graze-common = { path = "../graze-common" }
+# The completeness guard backfills a viewer from their PDS before publishing,
+# and writes the edges through the same sink the fold uses.
+graze-lens-bootstrap = { path = "../graze-lens-bootstrap" }
+graze-lens-fold = { path = "../graze-lens-fold" }
 
 tokio = { version = "1.43", features = ["full", "signal"] }
 reqwest = { version = "0.12", features = ["json", "gzip", "rustls-tls"], default-features = false }
@@ -34,6 +38,3 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 prometheus-client = "0.22"
 
-[dev-dependencies]
-# Only to assert the shared `lens:active` key matches on both sides.
-graze-lens-fold = { path = "../graze-lens-fold" }

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -226,13 +226,7 @@ impl Builder {
         // `follows` publishes a v1 set (what feeder-rs reads today) and also a
         // v2 scored blob, so the reader can change formats without a flag day.
         // `follows²` is v2 only — a set cannot carry reach.
-        if facet == FACET_FOLLOWS2 {
-            return self.publish_second_degree(viewer, &followees).await;
-        }
-
-        self.publish(viewer, facet, &followees).await?;
-        self.publish_v2_uniform(viewer, facet, &followees).await;
-        Ok(BuildOutcome::Published)
+        self.publish_for_facet(viewer, facet, &followees).await
     }
 
     /// Build and publish `follows²` from the traversal projection.
@@ -414,7 +408,30 @@ impl Builder {
         }
 
         let followees: Vec<String> = edges.into_iter().map(|e| e.followee).collect();
-        self.publish(viewer, facet, &followees).await?;
+        // Route through the same facet dispatch as a normal build. Publishing
+        // directly here would ignore the facet entirely: a `follows2` request
+        // that happened to arrive for an un-backfilled viewer would silently
+        // publish their FIRST degree under the second-degree name — a lens that
+        // looks built, reports a plausible count, and is answering a different
+        // question than the one asked.
+        self.publish_for_facet(viewer, facet, &followees).await
+    }
+
+    /// Publish `followees` under whichever facet was requested.
+    ///
+    /// The single place that decides what a facet's output looks like, so the
+    /// normal and post-backfill paths cannot drift apart.
+    async fn publish_for_facet(
+        &self,
+        viewer: &str,
+        facet: &str,
+        followees: &[String],
+    ) -> anyhow::Result<BuildOutcome> {
+        if facet == FACET_FOLLOWS2 {
+            return self.publish_second_degree(viewer, followees).await;
+        }
+        self.publish(viewer, facet, followees).await?;
+        self.publish_v2_uniform(viewer, facet, followees).await;
         Ok(BuildOutcome::Published)
     }
 

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -15,9 +15,12 @@ use deadpool_redis::redis::AsyncCommands;
 use deadpool_redis::Pool;
 use graze_common::ClickHouseConfig;
 use serde::Deserialize;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
+use crate::completeness::CompletenessStore;
 use crate::config::Config;
+use graze_lens_bootstrap::{Backfiller, Resolver};
+use graze_lens_fold::Sink;
 
 /// Viewers whose sets graze-lens-fold should keep fresh. Shared key; the fold
 /// side owns the constant in `graze_lens_fold::delta`.
@@ -67,6 +70,10 @@ pub enum BuildOutcome {
     Empty,
     /// Over `max_set_size`. Marked failed so it is not retried in a loop.
     TooLarge,
+    /// This viewer has no backfill on record and backfill is not configured, so
+    /// any lens we built would be based on incidental stream data. Nothing is
+    /// published; the feed serves unlensed.
+    NeedsBackfill,
 }
 
 pub struct Builder {
@@ -74,9 +81,16 @@ pub struct Builder {
     http: reqwest::Client,
     clickhouse: ClickHouseConfig,
     config: Config,
+    /// Absent means the completeness guard is off and every viewer is treated
+    /// as complete — only appropriate for a backfill-free test setup.
+    completeness: Option<CompletenessStore>,
+    backfiller: Option<Backfiller>,
+    sink: Option<Sink>,
 }
 
 impl Builder {
+    /// A builder with no completeness guard. Publishes whatever ClickHouse
+    /// holds for a viewer, complete or not.
     pub fn new(redis: Pool, config: Config) -> anyhow::Result<Self> {
         let http = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
@@ -86,7 +100,37 @@ impl Builder {
             http,
             clickhouse: config.clickhouse.clone(),
             config,
+            completeness: None,
+            backfiller: None,
+            sink: None,
         })
+    }
+
+    /// The production builder: refuses to publish a lens for a viewer whose
+    /// follow history has not been backfilled, and backfills them instead.
+    pub fn with_backfill(redis: Pool, config: Config) -> anyhow::Result<Self> {
+        let mut builder = Self::new(redis, config)?;
+        let cfg = &builder.config;
+
+        let http = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .user_agent(concat!("graze-lens-builder/", env!("CARGO_PKG_VERSION")))
+            .build()?;
+
+        builder.completeness = Some(CompletenessStore::new(
+            cfg.clickhouse.clone(),
+            cfg.query_timeout,
+            cfg.max_execution_seconds,
+        )?);
+        builder.backfiller = Some(Backfiller::new(
+            http.clone(),
+            Resolver::new(http, cfg.plc_directory.clone()),
+            cfg.backfill_request_timeout,
+            cfg.backfill_page_delay,
+            cfg.backfill_max_pages,
+        ));
+        builder.sink = Some(Sink::new(cfg.clickhouse.clone(), cfg.query_timeout)?);
+        Ok(builder)
     }
 
     pub fn set_key(facet: &str, viewer: &str) -> String {
@@ -102,8 +146,21 @@ impl Builder {
     }
 
     /// Build and publish one lens.
+    ///
+    /// A viewer whose follow history was never backfilled is backfilled here
+    /// first. `graze-lens-fold` only sees follows made since it connected, so
+    /// building from ClickHouse alone would publish a handful of incidental
+    /// edges as if it were their graph — a wrong feed, not a narrow one, and
+    /// indistinguishable from someone who genuinely follows almost nobody.
     pub async fn build(&self, viewer: &str, facet: &str) -> anyhow::Result<BuildOutcome> {
         self.mark_state(viewer, "building").await?;
+
+        if let Some(store) = &self.completeness {
+            if !store.is_complete(viewer).await {
+                info!(viewer, facet, "no backfill on record; backfilling first");
+                return self.backfill_then_publish(viewer, facet).await;
+            }
+        }
 
         let followees = self.fetch_follows(viewer).await?;
         debug!(viewer, facet, count = followees.len(), "fetched follows");
@@ -128,6 +185,62 @@ impl Builder {
             return Ok(BuildOutcome::TooLarge);
         }
 
+        self.publish(viewer, facet, &followees).await?;
+        Ok(BuildOutcome::Published)
+    }
+
+    /// Pull a viewer's follows from their own PDS, persist them, and publish
+    /// the lens from what we just read.
+    ///
+    /// Publishing from memory rather than re-querying ClickHouse is deliberate.
+    /// The edges are written through `follow_edges_buffer`, which flushes on
+    /// 10k rows or 100 seconds — so a read immediately after the write would
+    /// see almost none of them and publish the very truncated lens this guard
+    /// exists to prevent. The rows still land for durability and for later
+    /// rebuilds; this build just does not depend on them being visible yet.
+    async fn backfill_then_publish(
+        &self,
+        viewer: &str,
+        facet: &str,
+    ) -> anyhow::Result<BuildOutcome> {
+        let (backfiller, sink, store) = match (&self.backfiller, &self.sink, &self.completeness) {
+            (Some(b), Some(s), Some(c)) => (b, s, c),
+            // Backfill is not configured; refusing to publish beats publishing
+            // a lens we know may be built on nothing.
+            _ => {
+                warn!(viewer, "backfill unavailable; refusing to publish a lens");
+                self.mark_state(viewer, "needs_backfill").await?;
+                return Ok(BuildOutcome::NeedsBackfill);
+            }
+        };
+
+        let edges = backfiller.edges_for(viewer).await?;
+        let count = edges.len();
+        info!(viewer, count, "backfilled follow history");
+
+        if !edges.is_empty() {
+            sink.insert(&edges).await?;
+        }
+
+        // Marked before publishing: if the process dies between the two, the
+        // next build finds the marker, skips the (already persisted) backfill,
+        // and builds from ClickHouse. Marking after would re-walk the PDS.
+        store.mark_complete(viewer, count).await?;
+
+        if count == 0 {
+            self.mark_state(viewer, "ready").await?;
+            return Ok(BuildOutcome::Empty);
+        }
+        if count > self.config.max_set_size {
+            warn!(
+                viewer,
+                count, "lens set over size budget; refusing to publish"
+            );
+            self.mark_state(viewer, "failed").await?;
+            return Ok(BuildOutcome::TooLarge);
+        }
+
+        let followees: Vec<String> = edges.into_iter().map(|e| e.followee).collect();
         self.publish(viewer, facet, &followees).await?;
         Ok(BuildOutcome::Published)
     }

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -28,8 +28,20 @@ use graze_lens_fold::Sink;
 /// side owns the constant in `graze_lens_fold::delta`.
 const ACTIVE_KEY: &str = "lens:active";
 
-/// Facet name on the wire. Matches `lensFacets` in the ui and feeder-rs.
+/// Facet names on the wire. These match `SUPPORTED_FACETS` in feeder-rs, which
+/// turns them into Redis key names — a name that disagrees between the two
+/// builds a key nobody reads.
+pub const FACET_FOLLOWS: &str = "follows";
 pub const FACET_FOLLOWS2: &str = "follows2";
+
+/// Facets this builder can actually produce.
+///
+/// Deliberately not every facet the *reader* accepts: `network` is a blend the
+/// reader composes from these two, so it is a legal thing to ask a feed for and
+/// an illegal thing to ask the builder for.
+pub fn is_buildable_facet(facet: &str) -> bool {
+    matches!(facet, FACET_FOLLOWS | FACET_FOLLOWS2)
+}
 
 fn now_secs() -> u32 {
     std::time::SystemTime::now()
@@ -86,6 +98,10 @@ pub enum BuildOutcome {
     /// any lens we built would be based on incidental stream data. Nothing is
     /// published; the feed serves unlensed.
     NeedsBackfill,
+    /// The requested facet is not one this builder produces. Nothing is
+    /// published and no state is written, so the viewer is left exactly as they
+    /// were rather than stuck mid-build.
+    UnknownFacet,
 }
 
 pub struct Builder {
@@ -191,6 +207,21 @@ impl Builder {
     /// edges as if it were their graph — a wrong feed, not a narrow one, and
     /// indistinguishable from someone who genuinely follows almost nobody.
     pub async fn build(&self, viewer: &str, facet: &str) -> anyhow::Result<BuildOutcome> {
+        // Reject an unknown facet before anything else, and in particular before
+        // marking the viewer "building" — a state nothing would ever clear.
+        //
+        // The dispatch below falls through to the first-degree publisher for any
+        // name it does not recognise, so an unknown facet would not fail: it
+        // would cheerfully publish the viewer's follows under that name, and the
+        // serve path would read a lens that answers a different question than
+        // the one its key claims. A composite like `network` is expanded by the
+        // reader into its underlying facets and never arrives here as itself, so
+        // seeing one is already a bug worth surfacing.
+        if !is_buildable_facet(facet) {
+            warn!(viewer, facet, "unknown facet; refusing to build");
+            return Ok(BuildOutcome::UnknownFacet);
+        }
+
         self.mark_state(viewer, "building").await?;
 
         if let Some(store) = &self.completeness {
@@ -531,6 +562,22 @@ impl Builder {
 
 #[cfg(test)]
 mod tests {
+    /// The reader accepts `network` and expands it into these two before
+    /// enqueueing; the builder must never accept it directly, or it would
+    /// publish a first-degree set under a name that promises a blend.
+    #[test]
+    fn only_real_facets_are_buildable() {
+        assert!(is_buildable_facet(FACET_FOLLOWS));
+        assert!(is_buildable_facet(FACET_FOLLOWS2));
+        assert!(
+            !is_buildable_facet("network"),
+            "network is composed by the reader, not built here"
+        );
+        assert!(!is_buildable_facet("mutuals"), "not implemented yet");
+        assert!(!is_buildable_facet(""));
+        assert!(!is_buildable_facet("FOLLOWS"), "matching is exact");
+    }
+
     use super::*;
 
     /// feeder-rs reads these exact key shapes (`feeder-rs/src/lens.rs`). They

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -19,12 +19,24 @@ use tracing::{debug, info, warn};
 
 use crate::completeness::CompletenessStore;
 use crate::config::Config;
+use crate::interner::Interner;
+use crate::second_degree;
 use graze_lens_bootstrap::{Backfiller, Resolver};
 use graze_lens_fold::Sink;
 
 /// Viewers whose sets graze-lens-fold should keep fresh. Shared key; the fold
 /// side owns the constant in `graze_lens_fold::delta`.
 const ACTIVE_KEY: &str = "lens:active";
+
+/// Facet name on the wire. Matches `lensFacets` in the ui and feeder-rs.
+pub const FACET_FOLLOWS2: &str = "follows2";
+
+fn now_secs() -> u32 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as u32)
+        .unwrap_or(0)
+}
 
 /// Current followees of one viewer.
 ///
@@ -86,6 +98,8 @@ pub struct Builder {
     completeness: Option<CompletenessStore>,
     backfiller: Option<Backfiller>,
     sink: Option<Sink>,
+    /// Shared DID interner, on the cache Redis. Required for v2/follows2.
+    interner: Option<Interner>,
 }
 
 impl Builder {
@@ -103,13 +117,22 @@ impl Builder {
             completeness: None,
             backfiller: None,
             sink: None,
+            interner: None,
         })
     }
 
     /// The production builder: refuses to publish a lens for a viewer whose
     /// follow history has not been backfilled, and backfills them instead.
-    pub fn with_backfill(redis: Pool, config: Config) -> anyhow::Result<Self> {
+    ///
+    /// `interner_redis` is the *cache* Redis, where the shared DID id space
+    /// lives — a different instance from the one lens blobs are published to.
+    pub fn with_backfill(
+        redis: Pool,
+        interner_redis: Option<Pool>,
+        config: Config,
+    ) -> anyhow::Result<Self> {
         let mut builder = Self::new(redis, config)?;
+        builder.interner = interner_redis.map(Interner::new);
         let cfg = &builder.config;
 
         let http = reqwest::Client::builder()
@@ -200,8 +223,143 @@ impl Builder {
             return Ok(BuildOutcome::TooLarge);
         }
 
+        // `follows` publishes a v1 set (what feeder-rs reads today) and also a
+        // v2 scored blob, so the reader can change formats without a flag day.
+        // `follows²` is v2 only — a set cannot carry reach.
+        if facet == FACET_FOLLOWS2 {
+            return self.publish_second_degree(viewer, &followees).await;
+        }
+
         self.publish(viewer, facet, &followees).await?;
+        self.publish_v2_uniform(viewer, facet, &followees).await;
         Ok(BuildOutcome::Published)
+    }
+
+    /// Build and publish `follows²` from the traversal projection.
+    async fn publish_second_degree(
+        &self,
+        viewer: &str,
+        first_degree: &[String],
+    ) -> anyhow::Result<BuildOutcome> {
+        let Some(interner) = &self.interner else {
+            warn!(viewer, "no interner configured; cannot build follows2");
+            self.mark_state(viewer, "failed").await?;
+            return Ok(BuildOutcome::NeedsBackfill);
+        };
+
+        // Seeds must be ids, and must be inlined into the query. Interning the
+        // viewer's own follows is cheap and mostly cache-hits after the first
+        // build.
+        let ids = interner.intern_many(first_degree).await?;
+        let seeds: Vec<u32> = ids.values().copied().collect();
+        if seeds.is_empty() {
+            self.mark_state(viewer, "ready").await?;
+            return Ok(BuildOutcome::Empty);
+        }
+
+        let sql = second_degree::reach_query(
+            &self.clickhouse.database,
+            &seeds,
+            self.config.second_degree_cap,
+        );
+        let text = self.query_text(&sql).await?;
+
+        let mut map = second_degree::parse_reach_tsv(&text, self.config.second_degree_top_k);
+        second_degree::exclude_first_degree(&mut map, &seeds);
+        second_degree::warn_if_thin(viewer, seeds.len(), map.all_ids.len());
+
+        if map.is_empty() {
+            self.mark_state(viewer, "ready").await?;
+            return Ok(BuildOutcome::Empty);
+        }
+
+        let built_at = now_secs();
+        let blob = map.encode(built_at);
+        info!(
+            viewer,
+            seeds = seeds.len(),
+            reached = map.all_ids.len(),
+            scored = map.entries.len(),
+            max_reach = map.max_reach,
+            bytes = blob.len(),
+            "built second degree"
+        );
+
+        self.publish_blob(viewer, FACET_FOLLOWS2, &blob).await?;
+        Ok(BuildOutcome::Published)
+    }
+
+    /// Also publish `follows` as a v2 blob, at uniform full weight.
+    ///
+    /// A follow carries no strength signal, so every entry is full confidence;
+    /// the value is format uniformity, so the reader has one decoder and the
+    /// blend has one shape to weight. Best-effort: the v1 set is still the
+    /// authority until the reader moves over, so a failure here must not fail
+    /// the build.
+    async fn publish_v2_uniform(&self, viewer: &str, facet: &str, followees: &[String]) {
+        let Some(interner) = &self.interner else {
+            return;
+        };
+        let result = async {
+            let ids = interner.intern_many(followees).await?;
+            let entries: Vec<(u32, u16)> = ids
+                .values()
+                .map(|id| (*id, crate::scored::WEIGHT_MAX))
+                .collect();
+            let blob = crate::scored::encode(crate::scored::FACET_FOLLOWS, now_secs(), entries);
+            self.publish_blob(viewer, facet, &blob).await
+        }
+        .await;
+        if let Err(e) = result {
+            warn!(error = %e, viewer, facet, "v2 mirror publish failed; v1 set still authoritative");
+        }
+    }
+
+    /// Write a v2 blob and mark the viewer ready.
+    async fn publish_blob(&self, viewer: &str, facet: &str, blob: &[u8]) -> anyhow::Result<()> {
+        let key = format!("lens:v2:{facet}:{viewer}");
+        let ttl = self.config.set_ttl.as_secs();
+        let mut conn = self.redis.get().await?;
+        deadpool_redis::redis::pipe()
+            .atomic()
+            .set_ex(&key, blob, ttl)
+            .hset(Self::meta_key(viewer), "state", "ready")
+            .hset(
+                Self::meta_key(viewer),
+                format!("v2_{facet}_bytes"),
+                blob.len(),
+            )
+            .expire(Self::meta_key(viewer), ttl as i64)
+            .sadd(ACTIVE_KEY, viewer)
+            .query_async::<()>(&mut conn)
+            .await?;
+        Ok(())
+    }
+
+    /// Run a query that returns raw text (TSV).
+    async fn query_text(&self, sql: &str) -> anyhow::Result<String> {
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.config.query_timeout)
+            .query(&[
+                (
+                    "max_execution_time",
+                    self.config.max_execution_seconds.to_string(),
+                ),
+                ("cancel_http_readonly_queries_on_client_close", "1".into()),
+            ])
+            .body(sql.to_string())
+            .send()
+            .await?;
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!("query failed ({status}): {}", &text[..text.len().min(400)]);
+        }
+        Ok(text)
     }
 
     /// Pull a viewer's follows from their own PDS, persist them, and publish

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -17,10 +17,10 @@ use graze_common::ClickHouseConfig;
 use serde::Deserialize;
 use tracing::{debug, info, warn};
 
-use crate::completeness::CompletenessStore;
 use crate::config::Config;
 use crate::interner::Interner;
 use crate::second_degree;
+use graze_lens_bootstrap::CompletenessStore;
 use graze_lens_bootstrap::{Backfiller, Resolver};
 use graze_lens_fold::Sink;
 
@@ -412,9 +412,15 @@ impl Builder {
             }
         };
 
-        let edges = backfiller.edges_for(viewer).await?;
+        let backfilled = backfiller.edges_for(viewer).await?;
+        let edges = backfilled.edges;
         let count = edges.len();
-        info!(viewer, count, "backfilled follow history");
+        info!(
+            viewer,
+            count,
+            truncated = backfilled.truncated,
+            "backfilled follow history"
+        );
 
         if !edges.is_empty() {
             sink.insert(&edges).await?;
@@ -423,7 +429,23 @@ impl Builder {
         // Marked before publishing: if the process dies between the two, the
         // next build finds the marker, skips the (already persisted) backfill,
         // and builds from ClickHouse. Marking after would re-walk the PDS.
-        store.mark_complete(viewer, count).await?;
+        //
+        // Except when the backfill was truncated. These edges are a prefix of
+        // the account's follows, not their graph, and a marker would make that
+        // prefix permanent: every later build would trust it and skip the walk.
+        // Leaving the marker off costs a re-walk per request for a handful of
+        // very large accounts, and buys the chance to get them whole once
+        // `backfill_max_pages` is raised. The lens still publishes meanwhile —
+        // a wide-but-partial lens is a reasonable feed, an invisibly frozen one
+        // is not.
+        if backfilled.truncated {
+            warn!(
+                viewer,
+                count, "backfill truncated; not recording completeness"
+            );
+        } else {
+            store.mark_complete(viewer, count).await?;
+        }
 
         if count == 0 {
             self.mark_state(viewer, "ready").await?;

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -167,6 +167,7 @@ impl Builder {
             cfg.backfill_request_timeout,
             cfg.backfill_page_delay,
             cfg.backfill_max_pages,
+            cfg.backfill_max_retries,
         ));
         // Straight to the base table, NOT through follow_edges_buffer.
         //

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -129,7 +129,22 @@ impl Builder {
             cfg.backfill_page_delay,
             cfg.backfill_max_pages,
         ));
-        builder.sink = Some(Sink::new(cfg.clickhouse.clone(), cfg.query_timeout)?);
+        // Straight to the base table, NOT through follow_edges_buffer.
+        //
+        // The buffer exists to coalesce the *stream's* one-row-at-a-time
+        // inserts; a backfill is already a bulk write of hundreds or thousands
+        // of rows, so it gains nothing there and loses something important.
+        // Buffered rows are invisible to a plain SELECT on the base table until
+        // the buffer flushes (10k rows or 100s), so a rebuild landing inside
+        // that window would read back almost nothing and republish the
+        // truncated set this guard exists to prevent. Measured: a viewer
+        // backfilled to 681 follows had their set regress to 1 on the very next
+        // build. Writing directly closes the window entirely.
+        builder.sink = Some(Sink::new_with_table(
+            cfg.clickhouse.clone(),
+            cfg.query_timeout,
+            "follow_edges",
+        )?);
         Ok(builder)
     }
 

--- a/crates/graze-lens-builder/src/completeness.rs
+++ b/crates/graze-lens-builder/src/completeness.rs
@@ -1,0 +1,192 @@
+//! Has this viewer's follow history actually been backfilled?
+//!
+//! `graze-lens-fold` only sees follows made *since it connected*. So for anyone
+//! who was never backfilled, `follow_edges` holds a handful of incidental edges
+//! rather than their graph — and a lens built from that is not a narrower feed,
+//! it is the wrong feed. Nothing errors. The reader simply sees posts filtered
+//! against a graph that isn't theirs, and we cannot tell that apart from
+//! someone who genuinely follows very few people.
+//!
+//! This is the check that makes the difference legible: a viewer is only
+//! eligible for a lens once we have deliberately pulled their follow records
+//! from their own PDS and recorded that we did.
+//!
+//! # Scope
+//!
+//! Records that ONE account's own follows are complete. It says nothing about
+//! the wider graph — second-degree facets need everyone else's edges too, and
+//! only the archive replay can supply those. Do not reuse this marker to gate
+//! anything beyond first degree.
+
+use std::time::Duration;
+
+use graze_common::ClickHouseConfig;
+use tracing::debug;
+
+const TABLE: &str = "lens_backfill_state";
+
+/// Where a viewer's backfill came from, for auditing a suspicious lens later.
+pub const SOURCE_PDS: &str = "pds";
+
+pub struct CompletenessStore {
+    http: reqwest::Client,
+    clickhouse: ClickHouseConfig,
+    timeout: Duration,
+    max_execution_seconds: u64,
+}
+
+impl CompletenessStore {
+    pub fn new(
+        clickhouse: ClickHouseConfig,
+        timeout: Duration,
+        max_execution_seconds: u64,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            http: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(10))
+                .build()?,
+            clickhouse,
+            timeout,
+            max_execution_seconds,
+        })
+    }
+
+    /// True when this viewer's own follows have been backfilled.
+    ///
+    /// Errs on the side of "not complete": a ClickHouse blip makes us backfill
+    /// again, which is wasteful but idempotent, whereas assuming completeness
+    /// would publish a wrong lens.
+    pub async fn is_complete(&self, viewer: &str) -> bool {
+        match self.lookup(viewer).await {
+            Ok(found) => found,
+            Err(e) => {
+                debug!(error = %e, viewer, "completeness lookup failed; treating as incomplete");
+                false
+            }
+        }
+    }
+
+    async fn lookup(&self, viewer: &str) -> anyhow::Result<bool> {
+        let db = &self.clickhouse.database;
+        let sql = format!(
+            "SELECT count() FROM {db}.{TABLE} WHERE viewer = {{viewer:String}} \
+             AND edge_count > 0"
+        );
+        let text = self.exec(&sql, Some(viewer)).await?;
+        Ok(text.trim().parse::<u64>().unwrap_or(0) > 0)
+    }
+
+    /// Record that we backfilled this viewer.
+    pub async fn mark_complete(&self, viewer: &str, edge_count: usize) -> anyhow::Result<()> {
+        let db = &self.clickhouse.database;
+        // Written to the base table rather than a buffer: the very next build
+        // reads this back, and a buffered row would still be invisible.
+        let sql = format!(
+            "INSERT INTO {db}.{TABLE} (viewer, backfilled_at, edge_count, source) \
+             VALUES ({{viewer:String}}, now(), {{edges:UInt32}}, '{SOURCE_PDS}')"
+        );
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.timeout)
+            .query(&[
+                ("max_execution_time", self.max_execution_seconds.to_string()),
+                ("param_viewer", viewer.to_string()),
+                ("param_edges", edge_count.to_string()),
+            ])
+            .body(sql)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "marking completeness failed ({}): {}",
+                status,
+                &body[..body.len().min(400)]
+            );
+        }
+        Ok(())
+    }
+
+    async fn exec(&self, sql: &str, viewer: Option<&str>) -> anyhow::Result<String> {
+        let mut query: Vec<(&str, String)> = vec![
+            ("max_execution_time", self.max_execution_seconds.to_string()),
+            ("cancel_http_readonly_queries_on_client_close", "1".into()),
+        ];
+        if let Some(v) = viewer {
+            query.push(("param_viewer", v.to_string()));
+        }
+
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.timeout)
+            .query(&query)
+            .body(sql.to_string())
+            .send()
+            .await?;
+
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!(
+                "completeness query failed ({}): {}",
+                status,
+                &text[..text.len().min(400)]
+            );
+        }
+        Ok(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> CompletenessStore {
+        CompletenessStore::new(
+            ClickHouseConfig {
+                host: "localhost".into(),
+                port: 8123,
+                database: "default".into(),
+                user: "u".into(),
+                password: "p".into(),
+                secure: false,
+            },
+            Duration::from_secs(30),
+            20,
+        )
+        .unwrap()
+    }
+
+    /// A viewer DID is caller-supplied and must never be interpolated.
+    #[test]
+    fn queries_bind_the_viewer() {
+        let s = store();
+        let sql = format!(
+            "SELECT count() FROM {}.{} WHERE viewer = {{viewer:String}} AND edge_count > 0",
+            s.clickhouse.database, TABLE
+        );
+        assert!(sql.contains("{viewer:String}"));
+        assert!(!sql.contains("did:plc:"));
+    }
+
+    /// A row recorded with zero edges is not evidence of a usable backfill —
+    /// it is evidence the account had nothing we could read. Treating it as
+    /// complete would permanently pin that viewer to an empty lens.
+    #[test]
+    fn zero_edge_rows_do_not_count_as_complete() {
+        let s = store();
+        let sql = format!(
+            "SELECT count() FROM {}.{} WHERE viewer = {{viewer:String}} AND edge_count > 0",
+            s.clickhouse.database, TABLE
+        );
+        assert!(sql.contains("edge_count > 0"));
+    }
+}

--- a/crates/graze-lens-builder/src/config.rs
+++ b/crates/graze-lens-builder/src/config.rs
@@ -67,6 +67,7 @@ pub struct Config {
     pub backfill_request_timeout: Duration,
     pub backfill_page_delay: Duration,
     pub backfill_max_pages: usize,
+    pub backfill_max_retries: u32,
     pub plc_directory: Option<String>,
 }
 
@@ -120,6 +121,7 @@ impl Config {
             )?),
             backfill_page_delay: Duration::from_millis(parse("LENS_BOOTSTRAP_PAGE_DELAY_MS", 150)?),
             backfill_max_pages: parse("LENS_BOOTSTRAP_MAX_PAGES", 600)?,
+            backfill_max_retries: parse("LENS_BOOTSTRAP_MAX_RETRIES", 4)?,
             plc_directory: optional("LENS_BOOTSTRAP_PLC_DIRECTORY"),
         })
     }

--- a/crates/graze-lens-builder/src/config.rs
+++ b/crates/graze-lens-builder/src/config.rs
@@ -46,6 +46,14 @@ pub struct Config {
 
     pub metrics_port: u16,
 
+    /// Scored entries kept per second-degree map. 20k at 6 bytes is 120 KB —
+    /// the strongest signals, sized to the serve path's read budget.
+    pub second_degree_top_k: usize,
+    /// Ceiling on rows pulled for one second-degree build. Bounds both the
+    /// transfer and the bloom; past this the tail is noise that costs bytes on
+    /// every request.
+    pub second_degree_cap: usize,
+
     /// Builds allowed to run at once. Almost all of a build is waiting -- on
     /// someone else's PDS during a backfill, or on ClickHouse -- so overlapping
     /// them costs little and stops one slow viewer stalling the queue.
@@ -99,6 +107,9 @@ impl Config {
             max_set_size: parse("LENS_MAX_SET_SIZE", 200_000)?,
 
             metrics_port: parse("METRICS_PORT", 9090)?,
+
+            second_degree_top_k: parse("LENS_SECOND_DEGREE_TOP_K", 20_000)?,
+            second_degree_cap: parse("LENS_SECOND_DEGREE_CAP", 500_000)?,
 
             concurrency: parse("LENS_BUILD_CONCURRENCY", 8)?,
             drain_timeout: Duration::from_secs(parse("LENS_BUILD_DRAIN_SECONDS", 30)?),

--- a/crates/graze-lens-builder/src/config.rs
+++ b/crates/graze-lens-builder/src/config.rs
@@ -46,6 +46,13 @@ pub struct Config {
 
     pub metrics_port: u16,
 
+    /// Builds allowed to run at once. Almost all of a build is waiting -- on
+    /// someone else's PDS during a backfill, or on ClickHouse -- so overlapping
+    /// them costs little and stops one slow viewer stalling the queue.
+    pub concurrency: usize,
+    /// How long to let in-flight builds finish on shutdown.
+    pub drain_timeout: Duration,
+
     /// Backfill settings, used when a viewer has no follow history on record.
     /// Deliberately polite: this fans out to other people's PDS hosts, and a
     /// backfill is never urgent — the feed serves unlensed until it lands.
@@ -92,6 +99,9 @@ impl Config {
             max_set_size: parse("LENS_MAX_SET_SIZE", 200_000)?,
 
             metrics_port: parse("METRICS_PORT", 9090)?,
+
+            concurrency: parse("LENS_BUILD_CONCURRENCY", 8)?,
+            drain_timeout: Duration::from_secs(parse("LENS_BUILD_DRAIN_SECONDS", 30)?),
 
             backfill_request_timeout: Duration::from_secs(parse(
                 "LENS_BOOTSTRAP_REQUEST_TIMEOUT",

--- a/crates/graze-lens-builder/src/config.rs
+++ b/crates/graze-lens-builder/src/config.rs
@@ -45,6 +45,14 @@ pub struct Config {
     pub max_set_size: usize,
 
     pub metrics_port: u16,
+
+    /// Backfill settings, used when a viewer has no follow history on record.
+    /// Deliberately polite: this fans out to other people's PDS hosts, and a
+    /// backfill is never urgent — the feed serves unlensed until it lands.
+    pub backfill_request_timeout: Duration,
+    pub backfill_page_delay: Duration,
+    pub backfill_max_pages: usize,
+    pub plc_directory: Option<String>,
 }
 
 impl Config {
@@ -84,6 +92,14 @@ impl Config {
             max_set_size: parse("LENS_MAX_SET_SIZE", 200_000)?,
 
             metrics_port: parse("METRICS_PORT", 9090)?,
+
+            backfill_request_timeout: Duration::from_secs(parse(
+                "LENS_BOOTSTRAP_REQUEST_TIMEOUT",
+                20,
+            )?),
+            backfill_page_delay: Duration::from_millis(parse("LENS_BOOTSTRAP_PAGE_DELAY_MS", 150)?),
+            backfill_max_pages: parse("LENS_BOOTSTRAP_MAX_PAGES", 600)?,
+            plc_directory: optional("LENS_BOOTSTRAP_PLC_DIRECTORY"),
         })
     }
 }

--- a/crates/graze-lens-builder/src/interner.rs
+++ b/crates/graze-lens-builder/src/interner.rs
@@ -1,0 +1,154 @@
+//! Shared DID interner: `did:plc:… -> u32`.
+//!
+//! Not ours. This is the same mapping, in the same Redis, under the same keys
+//! that `rust-smasher` and `membership-service` already use — 4.8M DIDs deep in
+//! production at time of writing. Sharing it means a lens map and a
+//! membership-service bitmap speak about the same accounts by the same ids, and
+//! anything either side publishes stays interpretable by the other. Allocating
+//! a private id space here would have been easier and would have quietly made
+//! the two incomparable forever.
+//!
+//! # Why intern at all
+//!
+//! Scored lens maps are (id, weight) pairs. As raw DIDs a second-degree map is
+//! ~35 bytes per entry; as u32 ids it is 6. At 250k entries that is 8.75 MB
+//! versus 1.5 MB, per viewer, on a Redis the serve path reads.
+//!
+//! # Instance
+//!
+//! The interner lives on the **cache** Redis (`REDIS_URL`), while lens blobs
+//! live on the **personalization** Redis. That split is deliberate: the interner
+//! is a shared asset of several services and moving it would break them, so the
+//! builder simply holds both connections.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use deadpool_redis::Pool;
+
+/// Hash mapping `did -> u32`. Hash-tagged so the get-or-create script, which
+/// touches both keys, stays on one Cluster slot.
+pub const DIDINT_MAP: &str = "didint:{didint}:map";
+/// Monotonic id sequence.
+pub const DIDINT_SEQ: &str = "didint:{didint}:seq";
+
+/// Bound on DIDs per Lua call, so the script does not hold the Redis slot long.
+const INTERN_CHUNK: usize = 1000;
+
+/// Atomic get-or-create. Two processes interning the same new DID concurrently
+/// still agree on its id, which a read-then-write from the client would not
+/// guarantee.
+const LUA_GETSET: &str = r#"
+local ids = {}
+for i = 1, #ARGV do
+    local id = redis.call('HGET', KEYS[1], ARGV[i])
+    if not id then
+        id = redis.call('INCR', KEYS[2])
+        redis.call('HSET', KEYS[1], ARGV[i], id)
+    end
+    ids[i] = id
+end
+return ids
+"#;
+
+pub struct Interner {
+    redis: Pool,
+    /// Repeated interning during one rebuild should not re-hit Redis; a
+    /// viewer's second-degree map revisits the same accounts constantly.
+    cache: Arc<DashMap<String, u32>>,
+}
+
+impl Interner {
+    pub fn new(redis: Pool) -> Self {
+        Self {
+            redis,
+            cache: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Ids for every DID given, allocating for any that are new.
+    ///
+    /// Order is not preserved; the caller gets a map, because every caller here
+    /// wants lookup rather than position.
+    pub async fn intern_many(&self, dids: &[String]) -> anyhow::Result<HashMap<String, u32>> {
+        let mut out = HashMap::with_capacity(dids.len());
+        let mut missing: Vec<String> = Vec::new();
+
+        for did in dids {
+            match self.cache.get(did) {
+                Some(id) => {
+                    out.insert(did.clone(), *id);
+                }
+                None => missing.push(did.clone()),
+            }
+        }
+        if missing.is_empty() {
+            return Ok(out);
+        }
+
+        let mut conn = self.redis.get().await?;
+        for chunk in missing.chunks(INTERN_CHUNK) {
+            let mut script = deadpool_redis::redis::cmd("EVAL");
+            script
+                .arg(LUA_GETSET)
+                .arg(2)
+                .arg(DIDINT_MAP)
+                .arg(DIDINT_SEQ);
+            for did in chunk {
+                script.arg(did);
+            }
+            let ids: Vec<i64> = script.query_async(&mut conn).await?;
+            if ids.len() != chunk.len() {
+                anyhow::bail!(
+                    "interner returned {} ids for {} dids",
+                    ids.len(),
+                    chunk.len()
+                );
+            }
+            for (did, id) in chunk.iter().zip(ids) {
+                // Ids are allocated by INCR from 1 and will not exceed u32 for
+                // the foreseeable network; a negative or oversized id means the
+                // shared counter has been tampered with, and silently wrapping
+                // it would corrupt every consumer of this id space.
+                let id = u32::try_from(id)
+                    .map_err(|_| anyhow::anyhow!("interner id {id} out of u32 range"))?;
+                self.cache.insert(did.clone(), id);
+                out.insert(did.clone(), id);
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// These key strings are the interoperability contract with rust-smasher
+    /// and membership-service. Production holds ~4.8M entries under exactly
+    /// these names; a typo here allocates a fresh, empty, incompatible id space
+    /// and nothing would report an error.
+    #[test]
+    fn keys_match_the_shared_id_space() {
+        assert_eq!(DIDINT_MAP, "didint:{didint}:map");
+        assert_eq!(DIDINT_SEQ, "didint:{didint}:seq");
+    }
+
+    /// The hash tag must be present and identical on both keys, or the
+    /// get-or-create script spans two Cluster slots and fails.
+    #[test]
+    fn both_keys_share_one_hash_tag() {
+        assert!(DIDINT_MAP.contains("{didint}"));
+        assert!(DIDINT_SEQ.contains("{didint}"));
+    }
+
+    /// Get-or-create must be one atomic script. A client-side read-then-write
+    /// lets two processes allocate different ids for the same new DID.
+    #[test]
+    fn allocation_is_atomic() {
+        assert!(LUA_GETSET.contains("HGET"));
+        assert!(LUA_GETSET.contains("INCR"));
+        assert!(LUA_GETSET.contains("HSET"));
+    }
+}

--- a/crates/graze-lens-builder/src/lib.rs
+++ b/crates/graze-lens-builder/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod interner;
 pub mod queue;
 pub mod scored;
+pub mod second_degree;
 
 pub use builder::{BuildOutcome, Builder};
 pub use completeness::CompletenessStore;

--- a/crates/graze-lens-builder/src/lib.rs
+++ b/crates/graze-lens-builder/src/lib.rs
@@ -8,9 +8,12 @@
 pub mod builder;
 pub mod completeness;
 pub mod config;
+pub mod interner;
 pub mod queue;
+pub mod scored;
 
 pub use builder::{BuildOutcome, Builder};
 pub use completeness::CompletenessStore;
 pub use config::Config;
+pub use interner::Interner;
 pub use queue::{BuildRequest, Delivery, Queue};

--- a/crates/graze-lens-builder/src/lib.rs
+++ b/crates/graze-lens-builder/src/lib.rs
@@ -6,9 +6,11 @@
 //! for an hour and feeds keep serving, unlensed.
 
 pub mod builder;
+pub mod completeness;
 pub mod config;
 pub mod queue;
 
 pub use builder::{BuildOutcome, Builder};
+pub use completeness::CompletenessStore;
 pub use config::Config;
 pub use queue::{BuildRequest, Delivery, Queue};

--- a/crates/graze-lens-builder/src/lib.rs
+++ b/crates/graze-lens-builder/src/lib.rs
@@ -6,7 +6,6 @@
 //! for an hour and feeds keep serving, unlensed.
 
 pub mod builder;
-pub mod completeness;
 pub mod config;
 pub mod interner;
 pub mod queue;
@@ -14,7 +13,8 @@ pub mod scored;
 pub mod second_degree;
 
 pub use builder::{BuildOutcome, Builder};
-pub use completeness::CompletenessStore;
+// Re-exported from graze-lens-bootstrap, where the backfill it records lives.
 pub use config::Config;
+pub use graze_lens_bootstrap::CompletenessStore;
 pub use interner::Interner;
 pub use queue::{BuildRequest, Delivery, Queue};

--- a/crates/graze-lens-builder/src/main.rs
+++ b/crates/graze-lens-builder/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
     );
     queue.ensure_group().await.context("consumer group")?;
 
-    let builder = Arc::new(Builder::new(pool, config.clone()).context("builder")?);
+    let builder = Arc::new(Builder::with_backfill(pool, config.clone()).context("builder")?);
 
     let mut shutdown = Box::pin(signal::ctrl_c());
     let block_ms = config.block.as_millis() as u64;
@@ -67,6 +67,12 @@ async fn main() -> anyhow::Result<()> {
                 Ok(BuildOutcome::Published) => info!(viewer, facet, "lens published"),
                 Ok(BuildOutcome::Empty) => info!(viewer, facet, "viewer follows nobody"),
                 Ok(BuildOutcome::TooLarge) => warn!(viewer, facet, "lens over size budget"),
+                Ok(BuildOutcome::NeedsBackfill) => {
+                    warn!(
+                        viewer,
+                        facet, "no follow history and no way to backfill; not publishing"
+                    )
+                }
                 Err(e) => error!(error = %e, viewer, facet, "lens build failed"),
             }
 

--- a/crates/graze-lens-builder/src/main.rs
+++ b/crates/graze-lens-builder/src/main.rs
@@ -37,6 +37,8 @@ async fn main() -> anyhow::Result<()> {
     queue.ensure_group().await.context("consumer group")?;
 
     let builder = Arc::new(Builder::with_backfill(pool, config.clone()).context("builder")?);
+    let queue = Arc::new(queue);
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(config.concurrency.max(1)));
 
     let mut shutdown = Box::pin(signal::ctrl_c());
     let block_ms = config.block.as_millis() as u64;
@@ -59,32 +61,66 @@ async fn main() -> anyhow::Result<()> {
             },
         };
 
+        // Builds run concurrently, bounded by a semaphore.
+        //
+        // Serially, one slow build stalls every other viewer behind it: a whale
+        // backfill is ~2 minutes of paging someone else's PDS (measured at
+        // 35,092 follows), during which nobody else's lens gets built at all.
+        // The work is almost entirely waiting on other people's servers and on
+        // ClickHouse, so overlapping it costs us nothing and removes the
+        // head-of-line stall.
+        //
+        // Two builds for the same viewer may overlap. That is safe rather than
+        // merely tolerable: publishing stages into a temporary key and RENAMEs,
+        // so a reader sees one complete set or the other, never a mixture.
         for delivery in deliveries {
-            let viewer = delivery.request.viewer_did.clone();
-            let facet = delivery.request.facet.clone();
-
-            match builder.build(&viewer, &facet).await {
-                Ok(BuildOutcome::Published) => info!(viewer, facet, "lens published"),
-                Ok(BuildOutcome::Empty) => info!(viewer, facet, "viewer follows nobody"),
-                Ok(BuildOutcome::TooLarge) => warn!(viewer, facet, "lens over size budget"),
-                Ok(BuildOutcome::NeedsBackfill) => {
-                    warn!(
-                        viewer,
-                        facet, "no follow history and no way to backfill; not publishing"
-                    )
+            let permit = match semaphore.clone().acquire_owned().await {
+                Ok(p) => p,
+                Err(e) => {
+                    error!(error = %e, "build semaphore closed");
+                    break;
                 }
-                Err(e) => error!(error = %e, viewer, facet, "lens build failed"),
-            }
+            };
+            let builder = builder.clone();
+            let queue = queue.clone();
 
-            // Acknowledged either way. A failed build leaves `lensmeta` unset or
-            // `failed`, so the serve path will re-enqueue on the viewer's next
-            // request; keeping it pending here would just re-run the same
-            // failing query on a timer.
-            if let Err(e) = queue.ack(&delivery.id).await {
-                warn!(error = %e, id = %delivery.id, "ack failed");
-            }
+            tokio::spawn(async move {
+                let _permit = permit;
+                let viewer = delivery.request.viewer_did.clone();
+                let facet = delivery.request.facet.clone();
+
+                match builder.build(&viewer, &facet).await {
+                    Ok(BuildOutcome::Published) => info!(viewer, facet, "lens published"),
+                    Ok(BuildOutcome::Empty) => info!(viewer, facet, "viewer follows nobody"),
+                    Ok(BuildOutcome::TooLarge) => warn!(viewer, facet, "lens over size budget"),
+                    Ok(BuildOutcome::NeedsBackfill) => {
+                        warn!(
+                            viewer,
+                            facet, "no follow history and no way to backfill; not publishing"
+                        )
+                    }
+                    Err(e) => error!(error = %e, viewer, facet, "lens build failed"),
+                }
+
+                // Acknowledged either way. A failed build leaves `lensmeta`
+                // unset or `failed`, so the serve path re-enqueues on the
+                // viewer's next request; keeping it pending would just re-run
+                // the same failing query on a timer.
+                if let Err(e) = queue.ack(&delivery.id).await {
+                    warn!(error = %e, id = %delivery.id, "ack failed");
+                }
+            });
         }
     }
+
+    // Let in-flight builds finish rather than abandoning a half-done backfill.
+    // Acquiring every permit means every task has released one.
+    info!("draining in-flight builds");
+    let _ = tokio::time::timeout(
+        config.drain_timeout,
+        semaphore.acquire_many(config.concurrency as u32),
+    )
+    .await;
 
     Ok(())
 }

--- a/crates/graze-lens-builder/src/main.rs
+++ b/crates/graze-lens-builder/src/main.rs
@@ -36,7 +36,36 @@ async fn main() -> anyhow::Result<()> {
     );
     queue.ensure_group().await.context("consumer group")?;
 
-    let builder = Arc::new(Builder::with_backfill(pool, config.clone()).context("builder")?);
+    // The shared DID interner lives on the *cache* Redis, a different instance
+    // from the one lens blobs are published to. Optional: without it the
+    // builder still serves v1 sets, it just cannot build v2 or follows².
+    let interner_pool = match std::env::var("REDIS_URL").ok().filter(|u| !u.is_empty()) {
+        Some(url) => {
+            let built = RedisConfig::from_url(url)
+                .builder()
+                .map_err(anyhow::Error::from)
+                .and_then(|b| {
+                    b.max_size(4)
+                        .runtime(Runtime::Tokio1)
+                        .build()
+                        .map_err(anyhow::Error::from)
+                });
+            match built {
+                Ok(p) => Some(p),
+                Err(e) => {
+                    warn!(error = %e, "interner redis unavailable; v2 and follows2 disabled");
+                    None
+                }
+            }
+        }
+        None => {
+            warn!("REDIS_URL unset; v2 and follows2 disabled");
+            None
+        }
+    };
+
+    let builder =
+        Arc::new(Builder::with_backfill(pool, interner_pool, config.clone()).context("builder")?);
     let queue = Arc::new(queue);
     let semaphore = Arc::new(tokio::sync::Semaphore::new(config.concurrency.max(1)));
 

--- a/crates/graze-lens-builder/src/main.rs
+++ b/crates/graze-lens-builder/src/main.rs
@@ -122,6 +122,9 @@ async fn main() -> anyhow::Result<()> {
                     Ok(BuildOutcome::Published) => info!(viewer, facet, "lens published"),
                     Ok(BuildOutcome::Empty) => info!(viewer, facet, "viewer follows nobody"),
                     Ok(BuildOutcome::TooLarge) => warn!(viewer, facet, "lens over size budget"),
+                    Ok(BuildOutcome::UnknownFacet) => {
+                        warn!(viewer, facet, "unknown facet; nothing built")
+                    }
                     Ok(BuildOutcome::NeedsBackfill) => {
                         warn!(
                             viewer,

--- a/crates/graze-lens-builder/src/scored.rs
+++ b/crates/graze-lens-builder/src/scored.rs
@@ -97,9 +97,11 @@ pub fn header(blob: &[u8]) -> Option<Header> {
         return None;
     }
     let count = u32::from_le_bytes(blob[8..12].try_into().ok()?);
-    // A count that disagrees with the byte length means truncation or
-    // corruption; trusting it would read past the end or silently drop members.
-    if blob.len() != HEADER_LEN + count as usize * ENTRY_LEN {
+    // A blob shorter than its declared entries is truncation or corruption;
+    // trusting the count would read past the end. Longer is legal: the space
+    // after the entries belongs to optional trailers (the bloom), which the
+    // entries section — being exactly sized by `count` — safely delimits.
+    if blob.len() < HEADER_LEN + count as usize * ENTRY_LEN {
         return None;
     }
     Some(Header {
@@ -129,6 +131,101 @@ pub fn weight_of(blob: &[u8], id: u32) -> Option<u16> {
     }
     None
 }
+
+// ---------------------------------------------------------------------------
+// Bloom trailer: the approximate tail of a lens.
+//
+// The scored entries carry the top-K, but second degree runs to hundreds of
+// thousands of members, and shipping them all defeats the size budget. The
+// bloom answers "is this author in the lens AT ALL" for everyone past the
+// top-K, at ~1 byte per member.
+//
+// The error direction is what makes an approximation acceptable here: a bloom
+// has false POSITIVES only. A stranger occasionally passes the lens with
+// epsilon weight and ranks last — an extra post shown. It can never hide a
+// genuinely-followed author, because membership never reads false for a real
+// member. Inclusive errors degrade gracefully; exclusive ones would not.
+//
+// Hashing is FNV-1a/splitmix double-hashing implemented inline, because the
+// bits are read by feeder-rs in another repo and std's SipHash keys are
+// deliberately unstable across processes.
+// ---------------------------------------------------------------------------
+
+pub const BLOOM_MAGIC: &[u8; 4] = b"BLM1";
+/// Bits per member. 8 → ~2.1% false positives with k=6, chosen over 10 bits/1%
+/// because the marginal 60KB per viewer buys almost nothing at epsilon weight.
+pub const BLOOM_BITS_PER_MEMBER: usize = 8;
+pub const BLOOM_K: u32 = 6;
+
+fn fnv1a(id: u32) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in id.to_le_bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+fn splitmix(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9e3779b97f4a7c15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
+    x ^ (x >> 31)
+}
+
+/// Append a bloom of `members` to an encoded blob.
+pub fn append_bloom(blob: &mut Vec<u8>, members: &[u32]) {
+    let m_bits = (members.len().max(1) * BLOOM_BITS_PER_MEMBER).next_power_of_two() as u32;
+    let mut bits = vec![0u8; m_bits as usize / 8];
+    for &id in members {
+        let (h1, h2) = (fnv1a(id), splitmix(id as u64));
+        for i in 0..BLOOM_K as u64 {
+            let bit = (h1.wrapping_add(i.wrapping_mul(h2)) % m_bits as u64) as usize;
+            bits[bit / 8] |= 1 << (bit % 8);
+        }
+    }
+    blob.extend_from_slice(BLOOM_MAGIC);
+    blob.extend_from_slice(&m_bits.to_le_bytes());
+    blob.extend_from_slice(&BLOOM_K.to_le_bytes());
+    blob.extend_from_slice(&bits);
+}
+
+/// Where the bloom trailer starts, if the blob carries one.
+fn bloom_at(blob: &[u8]) -> Option<usize> {
+    let h = header(blob)?;
+    let at = HEADER_LEN + h.count as usize * ENTRY_LEN;
+    if blob.len() >= at + 12 && &blob[at..at + 4] == BLOOM_MAGIC {
+        Some(at)
+    } else {
+        None
+    }
+}
+
+/// Approximate membership via the bloom trailer.
+///
+/// `None` means "no bloom present" — distinct from `Some(false)`, so a caller
+/// can fall back to exact-only behaviour on blobs built without one.
+pub fn bloom_contains(blob: &[u8], id: u32) -> Option<bool> {
+    let at = bloom_at(blob)?;
+    let m_bits = u32::from_le_bytes(blob[at + 4..at + 8].try_into().ok()?);
+    let k = u32::from_le_bytes(blob[at + 8..at + 12].try_into().ok()?);
+    let bits = &blob[at + 12..];
+    if m_bits as usize / 8 > bits.len() || m_bits == 0 {
+        return None;
+    }
+    let (h1, h2) = (fnv1a(id), splitmix(id as u64));
+    for i in 0..k as u64 {
+        let bit = (h1.wrapping_add(i.wrapping_mul(h2)) % m_bits as u64) as usize;
+        if bits[bit / 8] & (1 << (bit % 8)) == 0 {
+            return Some(false);
+        }
+    }
+    Some(true)
+}
+
+// The layout of the header means the entries section is self-delimiting, so a
+// v2 reader that predates blooms simply never looks past the entries — the
+// trailer is backward compatible by construction.
 
 #[cfg(test)]
 mod tests {
@@ -224,6 +321,106 @@ mod tests {
         assert_eq!(header(&blob).unwrap().count, 2);
         assert!(weight_of(&blob, 7).is_some());
         assert_eq!(weight_of(&blob, 9), Some(30));
+    }
+
+    /// The bloom must never produce a false negative — that would hide a
+    /// genuinely-followed author, the one error direction we cannot accept.
+    #[test]
+    fn bloom_has_no_false_negatives() {
+        let members: Vec<u32> = (0..50_000u32).map(|i| i.wrapping_mul(2654435761)).collect();
+        let mut blob = encode(FACET_FOLLOWS2, 0, vec![(1, 1)]);
+        append_bloom(&mut blob, &members);
+        for &m in &members {
+            assert_eq!(
+                bloom_contains(&blob, m),
+                Some(true),
+                "false negative for {m}"
+            );
+        }
+    }
+
+    /// And its false-positive rate must be near the design point (~2.1% at 8
+    /// bits/member, k=6). Well above that means the sizing math is wrong and
+    /// strangers pour through the lens.
+    #[test]
+    fn bloom_false_positive_rate_is_near_design() {
+        let members: Vec<u32> = (0..100_000u32).map(|i| i * 7 + 1).collect();
+        let mut blob = encode(FACET_FOLLOWS2, 0, vec![(1, 1)]);
+        append_bloom(&mut blob, &members);
+        let mut fp = 0u32;
+        let trials = 100_000u32;
+        for i in 0..trials {
+            let candidate = 1_000_000_000u32 + i; // disjoint from members
+            if bloom_contains(&blob, candidate) == Some(true) {
+                fp += 1;
+            }
+        }
+        let rate = fp as f64 / trials as f64;
+        assert!(
+            rate < 0.035,
+            "fp rate {rate:.4} far above the ~2.1% design point"
+        );
+        assert!(
+            rate > 0.001,
+            "fp rate {rate:.4} suspiciously low; bloom likely broken"
+        );
+    }
+
+    /// A blob without a trailer answers None — "no bloom", not "not a member" —
+    /// so readers can distinguish exact-only blobs from misses.
+    #[test]
+    fn absent_bloom_is_none_not_false() {
+        let blob = golden();
+        assert_eq!(bloom_contains(&blob, 42), None);
+    }
+
+    /// A blob with a bloom must still serve exact lookups: the trailer cannot
+    /// break the entries section it follows.
+    #[test]
+    fn entries_survive_a_bloom_trailer() {
+        let mut blob = golden();
+        append_bloom(&mut blob, &[9, 10, 11]);
+        assert_eq!(weight_of(&blob, 700_530), Some(WEIGHT_MAX));
+        assert_eq!(weight_of(&blob, 999), None);
+        assert!(header(&blob).is_some());
+        assert_eq!(bloom_contains(&blob, 9), Some(true));
+    }
+
+    /// Serve-path cost check: both lookups must be far under a microsecond, so
+    /// a 30-post page costs tens of microseconds, invisible next to a 28ms p99.
+    #[test]
+    fn lookups_are_sub_microsecond() {
+        let entries: Vec<(u32, u16)> = (0..20_000u32).map(|i| (i * 13, 1u16)).collect();
+        let members: Vec<u32> = (0..250_000u32).map(|i| i * 11).collect();
+        let mut blob = encode(FACET_FOLLOWS2, 0, entries);
+        append_bloom(&mut blob, &members);
+
+        let start = std::time::Instant::now();
+        let mut hits = 0u64;
+        for i in 0..1_000_000u32 {
+            if weight_of(&blob, i).is_some() {
+                hits += 1;
+            }
+        }
+        let per_search = start.elapsed().as_nanos() / 1_000_000;
+
+        let start = std::time::Instant::now();
+        for i in 0..1_000_000u32 {
+            if bloom_contains(&blob, i) == Some(true) {
+                hits += 1;
+            }
+        }
+        let per_bloom = start.elapsed().as_nanos() / 1_000_000;
+
+        eprintln!(
+            "binary search: {per_search} ns/lookup, bloom: {per_bloom} ns/lookup (hits={hits})"
+        );
+        // Debug builds are ~10x slower than release; 5µs here is ~200-500ns released.
+        assert!(
+            per_search < 5_000,
+            "binary search {per_search} ns is too slow"
+        );
+        assert!(per_bloom < 5_000, "bloom probe {per_bloom} ns is too slow");
     }
 
     #[test]

--- a/crates/graze-lens-builder/src/scored.rs
+++ b/crates/graze-lens-builder/src/scored.rs
@@ -1,0 +1,244 @@
+//! The v2 scored lens blob.
+//!
+//! A v1 lens was a Redis SET of DIDs: membership, yes or no. That cannot express
+//! "this author is in your second degree, reached by 40 of the people you
+//! follow" — and without a degree of belief there is nothing to rank by, so a
+//! feed can only be filtered, never gracefully degraded. Scores are what let a
+//! lens fall back instead of failing.
+//!
+//! # Layout
+//!
+//! ```text
+//! header, 16 bytes
+//!   0..4    magic  b"GLZ2"
+//!   4       version = 2
+//!   5       facet id
+//!   6..8    reserved (zero)
+//!   8..12   entry count, u32 LE
+//!   12..16  built_at, u32 LE unix seconds
+//! entries, 6 bytes each, SORTED ASCENDING BY ID
+//!   +0..4   didint, u32 LE
+//!   +4..6   weight, u16 LE fixed-point (65535 == 1.0)
+//! ```
+//!
+//! Two choices worth defending:
+//!
+//! **Sorted, so the reader never decodes.** The serve path binary-searches the
+//! bytes as they came out of Redis — no allocation, no HashMap construction, no
+//! deserialization step on the request path. Decoding a 250k-entry map per cache
+//! miss would cost more than the lookup it enables.
+//!
+//! **u16 fixed-point weights, not f32/f16.** Weights only ever rank; two bytes
+//! give ~4½ digits of usable precision, which is far more than a ranking needs,
+//! and it avoids both a half-float dependency and the NaN ordering questions
+//! that come with floats in a sorted structure.
+//!
+//! # Cross-repo
+//!
+//! feeder-rs decodes this in another repository. The layout above and
+//! `GOLDEN_VECTOR` in the tests are the contract; both sides assert the same
+//! bytes.
+
+pub const MAGIC: &[u8; 4] = b"GLZ2";
+pub const VERSION: u8 = 2;
+pub const HEADER_LEN: usize = 16;
+pub const ENTRY_LEN: usize = 6;
+
+/// Facet ids. Stored as one byte in the header so a reader can reject a blob
+/// built for a different signal rather than silently ranking by the wrong one.
+pub const FACET_FOLLOWS: u8 = 1;
+pub const FACET_FOLLOWS2: u8 = 2;
+
+/// The full-confidence weight. A first-degree follow is exactly this.
+pub const WEIGHT_MAX: u16 = u16::MAX;
+
+/// Turn a 0.0–1.0 confidence into the stored fixed-point weight.
+///
+/// Clamped rather than wrapping: a scorer that hands us 1.4 has a bug, and
+/// wrapping would turn its strongest signal into its weakest.
+pub fn weight_from_f32(v: f32) -> u16 {
+    let clamped = v.clamp(0.0, 1.0);
+    (clamped * WEIGHT_MAX as f32).round() as u16
+}
+
+/// Encode entries into a blob. Input need not be sorted; output always is.
+pub fn encode(facet: u8, built_at: u32, mut entries: Vec<(u32, u16)>) -> Vec<u8> {
+    entries.sort_unstable_by_key(|(id, _)| *id);
+    entries.dedup_by_key(|(id, _)| *id);
+
+    let mut out = Vec::with_capacity(HEADER_LEN + entries.len() * ENTRY_LEN);
+    out.extend_from_slice(MAGIC);
+    out.push(VERSION);
+    out.push(facet);
+    out.extend_from_slice(&[0u8, 0u8]);
+    out.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+    out.extend_from_slice(&built_at.to_le_bytes());
+    for (id, weight) in entries {
+        out.extend_from_slice(&id.to_le_bytes());
+        out.extend_from_slice(&weight.to_le_bytes());
+    }
+    out
+}
+
+/// A blob's header, once validated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Header {
+    pub facet: u8,
+    pub count: u32,
+    pub built_at: u32,
+}
+
+/// Validate and read the header, or `None` if this is not a v2 blob.
+///
+/// Returns `None` rather than erroring for a v1 set or truncated value, so a
+/// reader can fall back instead of failing.
+pub fn header(blob: &[u8]) -> Option<Header> {
+    if blob.len() < HEADER_LEN || &blob[0..4] != MAGIC || blob[4] != VERSION {
+        return None;
+    }
+    let count = u32::from_le_bytes(blob[8..12].try_into().ok()?);
+    // A count that disagrees with the byte length means truncation or
+    // corruption; trusting it would read past the end or silently drop members.
+    if blob.len() != HEADER_LEN + count as usize * ENTRY_LEN {
+        return None;
+    }
+    Some(Header {
+        facet: blob[5],
+        count,
+        built_at: u32::from_le_bytes(blob[12..16].try_into().ok()?),
+    })
+}
+
+/// The weight for one id, by binary search over the raw bytes.
+///
+/// No decoding, no allocation. `None` means the author is not in this lens.
+pub fn weight_of(blob: &[u8], id: u32) -> Option<u16> {
+    let h = header(blob)?;
+    let (mut lo, mut hi) = (0usize, h.count as usize);
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        let at = HEADER_LEN + mid * ENTRY_LEN;
+        let candidate = u32::from_le_bytes(blob[at..at + 4].try_into().ok()?);
+        match candidate.cmp(&id) {
+            std::cmp::Ordering::Less => lo = mid + 1,
+            std::cmp::Ordering::Greater => hi = mid,
+            std::cmp::Ordering::Equal => {
+                return Some(u16::from_le_bytes(blob[at + 4..at + 6].try_into().ok()?));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bytes feeder-rs must agree on. If this changes, the other repo's
+    /// decoder changes with it or lenses silently stop matching.
+    const GOLDEN_FACET: u8 = FACET_FOLLOWS;
+    const GOLDEN_BUILT_AT: u32 = 1_788_000_000;
+
+    fn golden() -> Vec<u8> {
+        encode(
+            GOLDEN_FACET,
+            GOLDEN_BUILT_AT,
+            vec![(700_530, WEIGHT_MAX), (42, 1000), (4_875_165, 32_768)],
+        )
+    }
+
+    #[test]
+    fn golden_vector_is_stable() {
+        let blob = golden();
+        assert_eq!(&blob[0..4], MAGIC);
+        assert_eq!(blob[4], VERSION);
+        assert_eq!(blob[5], FACET_FOLLOWS);
+        assert_eq!(blob.len(), HEADER_LEN + 3 * ENTRY_LEN);
+        let h = header(&blob).expect("valid header");
+        assert_eq!(h.count, 3);
+        assert_eq!(h.built_at, GOLDEN_BUILT_AT);
+    }
+
+    /// Entries must come out ascending regardless of input order — the reader's
+    /// binary search is only correct on sorted data, and an unsorted blob would
+    /// return wrong answers rather than errors.
+    #[test]
+    fn entries_are_sorted_regardless_of_input_order() {
+        let blob = golden();
+        let mut prev = 0u32;
+        for i in 0..3 {
+            let at = HEADER_LEN + i * ENTRY_LEN;
+            let id = u32::from_le_bytes(blob[at..at + 4].try_into().unwrap());
+            assert!(id > prev, "ids must ascend: {id} after {prev}");
+            prev = id;
+        }
+    }
+
+    #[test]
+    fn lookups_find_every_member_and_reject_others() {
+        let blob = golden();
+        assert_eq!(weight_of(&blob, 700_530), Some(WEIGHT_MAX));
+        assert_eq!(weight_of(&blob, 42), Some(1000));
+        assert_eq!(weight_of(&blob, 4_875_165), Some(32_768));
+        assert_eq!(weight_of(&blob, 999), None);
+        assert_eq!(weight_of(&blob, 0), None);
+        assert_eq!(weight_of(&blob, u32::MAX), None);
+    }
+
+    /// A v1 SET value or any other junk must read as "not a v2 blob" so the
+    /// caller can fall back, never as an empty lens — an empty lens would
+    /// filter the reader's feed to nothing.
+    #[test]
+    fn foreign_values_are_rejected_not_misread() {
+        assert!(header(b"did:plc:abc").is_none());
+        assert!(header(b"").is_none());
+        assert!(header(b"GLZ2").is_none());
+        assert!(weight_of(b"did:plc:abc", 42).is_none());
+    }
+
+    /// A truncated blob must be rejected outright. Trusting the header's count
+    /// would read past the end of the buffer.
+    #[test]
+    fn truncated_blobs_are_rejected() {
+        let mut blob = golden();
+        blob.truncate(blob.len() - 1);
+        assert!(header(&blob).is_none());
+        assert!(weight_of(&blob, 42).is_none());
+    }
+
+    /// A weight above full confidence is a scorer bug; clamping keeps the
+    /// strongest signal strongest, where wrapping would make it the weakest.
+    #[test]
+    fn out_of_range_weights_clamp_rather_than_wrap() {
+        assert_eq!(weight_from_f32(1.0), WEIGHT_MAX);
+        assert_eq!(weight_from_f32(1.4), WEIGHT_MAX);
+        assert_eq!(weight_from_f32(0.0), 0);
+        assert_eq!(weight_from_f32(-3.0), 0);
+    }
+
+    /// Duplicate ids would break binary search's assumption of a unique key and
+    /// waste space; the encoder collapses them.
+    #[test]
+    fn duplicate_ids_are_collapsed() {
+        let blob = encode(FACET_FOLLOWS, 0, vec![(7, 10), (7, 20), (9, 30)]);
+        assert_eq!(header(&blob).unwrap().count, 2);
+        assert!(weight_of(&blob, 7).is_some());
+        assert_eq!(weight_of(&blob, 9), Some(30));
+    }
+
+    #[test]
+    fn empty_map_round_trips() {
+        let blob = encode(FACET_FOLLOWS, 5, vec![]);
+        let h = header(&blob).expect("empty is still a valid blob");
+        assert_eq!(h.count, 0);
+        assert_eq!(weight_of(&blob, 1), None);
+    }
+
+    /// Scale sanity: the size claim that justified interning at all.
+    #[test]
+    fn size_is_six_bytes_per_entry() {
+        let blob = encode(FACET_FOLLOWS2, 0, (0..250_000).map(|i| (i, 1u16)).collect());
+        assert_eq!(blob.len(), HEADER_LEN + 250_000 * 6);
+        assert!(blob.len() < 1_600_000, "250k entries should be ~1.5 MB");
+    }
+}

--- a/crates/graze-lens-builder/src/second_degree.rs
+++ b/crates/graze-lens-builder/src/second_degree.rs
@@ -1,0 +1,240 @@
+//! The `follows²` facet: who the people you follow follow.
+//!
+//! This is the facet that makes lenses usable. Measured on real feeds, 94% of
+//! (feed, reader) pairs had *zero* first-degree overlap — the lens matched
+//! nothing and the page came back unfiltered, which reads to a user as a toggle
+//! that does nothing. Second degree turns one viewer's 1,182-author lens into
+//! ~286,000 authors, ranked, which is the difference between a filter that
+//! usually fires and one that usually doesn't.
+//!
+//! # The score is the product
+//!
+//! `reach` is how many of *your own follows* also follow this author. On real
+//! data it discriminates sharply: the top author for one viewer was followed by
+//! 596 of their 1,182, tailing smoothly from there. That is exactly the
+//! "network statistic with the logged-in user as the distance subject" the
+//! requirements asked for, and it falls out of the same query that produces
+//! membership — aggregated rather than flattened.
+//!
+//! # Why it queries the projection
+//!
+//! Against `follow_edges` this same query read the entire table: 636 MB and
+//! 424–874 ms on real data. Against `follow_graph_int` it reads 11.87 MB in
+//! 34–37 ms. Two rules keep it there, and both are easy to lose:
+//!
+//! * **Literal seed ids, never `IN (subquery)`.** A subquery defeats
+//!   primary-key index analysis and full-scans. We already hold first degree.
+//! * **Never against `follow_edges`.** That table is keyed for per-viewer
+//!   lookups and partitioned for fold correctness, neither of which helps a
+//!   multi-seed traversal.
+
+use graze_lens_fold::project::{seed_list, LIVE_TABLE};
+use tracing::{debug, warn};
+
+use crate::scored::{self, FACET_FOLLOWS2};
+
+/// A built second-degree map, before publishing.
+pub struct SecondDegree {
+    /// Top-K, scored and sorted by id, ready to encode.
+    pub entries: Vec<(u32, u16)>,
+    /// Every id reached, for the bloom tail.
+    pub all_ids: Vec<u32>,
+    pub max_reach: u32,
+}
+
+impl SecondDegree {
+    pub fn is_empty(&self) -> bool {
+        self.all_ids.is_empty()
+    }
+
+    /// Encode as a v2 blob: scored top-K plus a bloom over the whole tail.
+    pub fn encode(&self, built_at: u32) -> Vec<u8> {
+        let mut blob = scored::encode(FACET_FOLLOWS2, built_at, self.entries.clone());
+        scored::append_bloom(&mut blob, &self.all_ids);
+        blob
+    }
+}
+
+/// Parse the projection's TSV response into a scored map.
+///
+/// Rows arrive ordered by reach descending, so the first `top_k` are the
+/// strongest signals; everything else still contributes to the bloom, which is
+/// what lets a lens degrade smoothly past the top-K instead of falling off a
+/// cliff.
+pub fn parse_reach_tsv(text: &str, top_k: usize) -> SecondDegree {
+    let mut entries: Vec<(u32, u16)> = Vec::with_capacity(top_k.min(1024));
+    let mut all_ids: Vec<u32> = Vec::new();
+    let mut max_reach = 0u32;
+
+    for line in text.lines() {
+        let mut cols = line.split('\t');
+        let (Some(id), Some(reach)) = (cols.next(), cols.next()) else {
+            continue;
+        };
+        let (Ok(id), Ok(reach)) = (id.trim().parse::<u32>(), reach.trim().parse::<u32>()) else {
+            continue;
+        };
+        if max_reach == 0 {
+            // First row is the largest, since the query orders by reach desc.
+            max_reach = reach;
+        }
+        all_ids.push(id);
+        if entries.len() < top_k {
+            // Normalised against this viewer's own maximum rather than a global
+            // constant: reach is only meaningful relative to how many people
+            // this particular viewer follows. A viewer with 40 follows and one
+            // with 4,000 should both get a full-strength top signal.
+            let w = if max_reach == 0 {
+                0.0
+            } else {
+                reach as f32 / max_reach as f32
+            };
+            entries.push((id, scored::weight_from_f32(w)));
+        }
+    }
+
+    SecondDegree {
+        entries,
+        all_ids,
+        max_reach,
+    }
+}
+
+/// The traversal query, with seeds inlined.
+///
+/// `cap` bounds both the transfer and the bloom: a viewer with a very wide
+/// network yields hundreds of thousands of rows, and past some point the tail
+/// is noise that costs bytes on the serve path's critical read.
+pub fn reach_query(database: &str, seeds: &[u32], cap: usize) -> String {
+    format!(
+        "SELECT followee_int, count() AS reach \
+         FROM {database}.{LIVE_TABLE} \
+         WHERE follower_int IN ({}) \
+         GROUP BY followee_int \
+         ORDER BY reach DESC, followee_int ASC \
+         LIMIT {cap} \
+         FORMAT TabSeparated",
+        seed_list(seeds)
+    )
+}
+
+/// Drop the viewer's own first degree from a second-degree map.
+///
+/// Someone you already follow is not a second-degree discovery, and leaving
+/// them in would let `follows²` quietly restate `follows` at a lower weight —
+/// making a blend of the two look like it was working when it was double
+/// counting one signal.
+pub fn exclude_first_degree(map: &mut SecondDegree, first_degree: &[u32]) {
+    if first_degree.is_empty() {
+        return;
+    }
+    let mut sorted = first_degree.to_vec();
+    sorted.sort_unstable();
+    let before = map.all_ids.len();
+    map.all_ids.retain(|id| sorted.binary_search(id).is_err());
+    map.entries
+        .retain(|(id, _)| sorted.binary_search(id).is_err());
+    debug!(
+        removed = before - map.all_ids.len(),
+        "excluded first degree from second"
+    );
+}
+
+/// Warn when a viewer's network is too small for this facet to mean anything.
+///
+/// Not an error: a genuinely small network is a real answer, and the blend
+/// handles it by falling through to weaker signals. But it is worth seeing in
+/// logs, because it is also what a broken backfill looks like.
+pub fn warn_if_thin(viewer: &str, seeds: usize, reached: usize) {
+    if seeds < 10 || reached < 100 {
+        warn!(
+            viewer,
+            seeds, reached, "second degree is thin; lens will lean on fallbacks"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_reach_rows_and_normalises_to_the_viewers_own_max() {
+        let tsv = "100\t596\n200\t300\n300\t150\n";
+        let m = parse_reach_tsv(tsv, 10);
+        assert_eq!(m.max_reach, 596);
+        assert_eq!(m.all_ids, vec![100, 200, 300]);
+        // Top entry is full confidence; the rest scale against it.
+        assert_eq!(m.entries[0].1, scored::WEIGHT_MAX);
+        assert!(m.entries[1].1 < m.entries[0].1);
+        assert!(m.entries[2].1 < m.entries[1].1);
+    }
+
+    /// Everything past top-K must still reach the bloom — that tail is the
+    /// whole reason the lens degrades smoothly rather than cutting off.
+    #[test]
+    fn tail_beyond_top_k_still_feeds_the_bloom() {
+        let tsv: String = (0..500).map(|i| format!("{i}\t{}\n", 500 - i)).collect();
+        let m = parse_reach_tsv(&tsv, 50);
+        assert_eq!(m.entries.len(), 50, "scored entries are capped");
+        assert_eq!(m.all_ids.len(), 500, "but the bloom sees everything");
+
+        let blob = m.encode(0);
+        // An id past the top-K is absent from entries but present in the bloom.
+        assert_eq!(scored::weight_of(&blob, 400), None);
+        assert_eq!(scored::bloom_contains(&blob, 400), Some(true));
+        // And one inside the top-K is in both.
+        assert!(scored::weight_of(&blob, 0).is_some());
+        assert_eq!(scored::bloom_contains(&blob, 0), Some(true));
+    }
+
+    /// The seed list must be inlined. `IN (subquery)` reads the whole table —
+    /// this is the difference between 11 MB and 636 MB.
+    #[test]
+    fn query_inlines_literal_seeds() {
+        let q = reach_query("default", &[7, 8, 9], 1000);
+        assert!(q.contains("IN (7,8,9)"));
+        assert!(!q.to_uppercase().contains("IN (SELECT"));
+        assert!(q.contains("follow_graph_int"), "must use the projection");
+        assert!(
+            !q.contains("follow_edges"),
+            "must never traverse the fold table"
+        );
+    }
+
+    /// Ordering must be deterministic. Ties broken only by reach would make the
+    /// top-K cut arbitrary between rebuilds, so a viewer's lens would churn
+    /// members for no reason.
+    #[test]
+    fn ordering_is_deterministic() {
+        let q = reach_query("default", &[1], 10);
+        assert!(q.contains("ORDER BY reach DESC, followee_int ASC"));
+    }
+
+    /// People you already follow are not second-degree discoveries; leaving
+    /// them in would let follows² restate follows at lower weight.
+    #[test]
+    fn first_degree_is_excluded() {
+        let tsv = "100\t50\n200\t40\n300\t30\n";
+        let mut m = parse_reach_tsv(tsv, 10);
+        exclude_first_degree(&mut m, &[200]);
+        assert_eq!(m.all_ids, vec![100, 300]);
+        assert!(m.entries.iter().all(|(id, _)| *id != 200));
+    }
+
+    #[test]
+    fn malformed_rows_are_skipped_not_fatal() {
+        let tsv = "100\t50\ngarbage\n\n200\tnope\n300\t30\n";
+        let m = parse_reach_tsv(tsv, 10);
+        assert_eq!(m.all_ids, vec![100, 300]);
+    }
+
+    #[test]
+    fn empty_result_is_empty_not_a_panic() {
+        let m = parse_reach_tsv("", 10);
+        assert!(m.is_empty());
+        assert_eq!(m.max_reach, 0);
+        let blob = m.encode(0);
+        assert!(scored::header(&blob).is_some());
+    }
+}

--- a/crates/graze-lens-fold/Cargo.toml
+++ b/crates/graze-lens-fold/Cargo.toml
@@ -15,6 +15,11 @@ path = "src/main.rs"
 name = "graze-lens-rev-rebuild"
 path = "src/bin/rev_rebuild.rs"
 
+# Rebuilds the u32 traversal projection that second-degree queries read.
+[[bin]]
+name = "graze-lens-project"
+path = "src/bin/project_rebuild.rs"
+
 [lib]
 name = "graze_lens_fold"
 path = "src/lib.rs"

--- a/crates/graze-lens-fold/src/bin/project_rebuild.rs
+++ b/crates/graze-lens-fold/src/bin/project_rebuild.rs
@@ -1,0 +1,84 @@
+//! graze-lens-project: rebuilds the u32 traversal projection for 2-hop queries.
+//!
+//! Runs on a timer, after the follow graph has moved enough to matter. Safe at
+//! any time: it builds into staging and swaps, so a run that dies partway
+//! leaves the live projection untouched.
+
+use anyhow::Context;
+use deadpool_redis::{Config as RedisConfig, Runtime};
+use graze_common::ClickHouseConfig;
+use graze_lens_fold::project::Projector;
+use std::time::Duration;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let clickhouse = ClickHouseConfig {
+        host: require("CLICKHOUSE_HOST")?,
+        port: parse("CLICKHOUSE_PORT", 443)?,
+        database: default_env("CLICKHOUSE_DATABASE", "default"),
+        user: require("CLICKHOUSE_USER")?,
+        password: require("CLICKHOUSE_PASSWORD")?,
+        secure: parse("CLICKHOUSE_SECURE", true)?,
+    };
+
+    // The interner lives on the CACHE redis, shared with rust-smasher and
+    // membership-service — not on the personalization instance where lens blobs
+    // live. Two different connections on purpose; see project.rs.
+    let redis_url = require("REDIS_URL")?;
+    let pool = RedisConfig::from_url(redis_url)
+        .builder()?
+        .max_size(parse("LENS_PROJECT_REDIS_POOL", 4)?)
+        .runtime(Runtime::Tokio1)
+        .build()
+        .context("interner redis pool")?;
+
+    let max_execution = parse("LENS_PROJECT_MAX_EXECUTION_SECONDS", 1_800)?;
+    let projector = Projector::new(
+        clickhouse,
+        pool,
+        Duration::from_secs(max_execution + 60),
+        max_execution,
+        parse("LENS_PROJECT_MAX_INTERN", 2_000_000)?,
+        parse("LENS_PROJECT_MIN_RATIO", 0.5)?,
+        parse("LENS_PROJECT_FORCE", false)?,
+    )
+    .context("projector")?;
+
+    info!("rebuilding traversal projection");
+    let r = projector.run().await.context("rebuild")?;
+    info!(
+        interned = r.interned,
+        before = r.before,
+        after = r.after,
+        "traversal projection rebuild complete"
+    );
+    Ok(())
+}
+
+fn optional(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+fn default_env(name: &str, fallback: &str) -> String {
+    optional(name).unwrap_or_else(|| fallback.to_string())
+}
+fn require(name: &str) -> anyhow::Result<String> {
+    optional(name).ok_or_else(|| anyhow::anyhow!("{name} is required but unset"))
+}
+fn parse<T>(name: &str, fallback: T) -> anyhow::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match optional(name) {
+        None => Ok(fallback),
+        Some(raw) => raw
+            .parse()
+            .map_err(|e| anyhow::anyhow!("{name} is not a valid value ({raw}): {e}")),
+    }
+}

--- a/crates/graze-lens-fold/src/lib.rs
+++ b/crates/graze-lens-fold/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cursor;
 pub mod delta;
 pub mod event;
 pub mod metrics;
+pub mod project;
 pub mod rev;
 pub mod sink;
 pub mod streamer;

--- a/crates/graze-lens-fold/src/project.rs
+++ b/crates/graze-lens-fold/src/project.rs
@@ -1,0 +1,350 @@
+//! Rebuilding the traversal projection.
+//!
+//! Second-degree queries do not run against `follow_edges`. They run here, and
+//! the reason is measured rather than aesthetic: on a 1B-row table the same
+//! scored 2-hop read 311M rows at the default granularity, 39M partitioned at
+//! granularity 1024, and 6–9M unpartitioned. The projection exists to be the
+//! third of those.
+//!
+//! Three properties carry that, and all three are easy to undo by accident:
+//!
+//! * **u32 keys.** Which is why the DID interner has to be mirrored into
+//!   ClickHouse at all — a query cannot reach into Redis to resolve them.
+//! * **`index_granularity = 1024`.** A linear factor on every seed seek.
+//! * **No partitioning.** Counter-intuitive, and the biggest single win:
+//!   partitioning charges every seed a boundary granule in *every* partition,
+//!   which was nearly all of the 39M rows read in the partitioned case.
+//!
+//! Callers must also pass literal seed lists rather than `IN (subquery)`; a
+//! subquery defeats index analysis and full-scans. The builder always has first
+//! degree in hand, so this costs it nothing.
+//!
+//! # Interner growth
+//!
+//! Roughly 39% of accounts in the graph are not yet interned (measured by
+//! sampling). Interning them grows a hash *shared with rust-smasher and
+//! membership-service*, on the cache Redis, which is NOEVICTION. At today's
+//! scale that is ~580k entries (~35 MB) and unremarkable. At full-network scale
+//! it would be ~25M entries and something like 1.8 GB on an instance where
+//! depth is an outage budget — so `max_intern_per_run` bounds each pass, and
+//! that threshold is the point at which a dedicated id space should be
+//! considered instead.
+
+use std::time::Duration;
+
+use deadpool_redis::Pool;
+use graze_common::ClickHouseConfig;
+use tracing::{info, warn};
+
+pub const LIVE_TABLE: &str = "follow_graph_int";
+pub const STAGING_TABLE: &str = "follow_graph_int_next";
+pub const MAP_TABLE: &str = "didint_map";
+
+/// Interner keys — the shared id space. See `graze-lens-builder::interner`.
+const DIDINT_MAP: &str = "didint:{didint}:map";
+const DIDINT_SEQ: &str = "didint:{didint}:seq";
+const INTERN_CHUNK: usize = 1000;
+
+const LUA_GETSET: &str = r#"
+local ids = {}
+for i = 1, #ARGV do
+    local id = redis.call('HGET', KEYS[1], ARGV[i])
+    if not id then
+        id = redis.call('INCR', KEYS[2])
+        redis.call('HSET', KEYS[1], ARGV[i], id)
+    end
+    ids[i] = id
+end
+return ids
+"#;
+
+pub struct Projector {
+    http: reqwest::Client,
+    clickhouse: ClickHouseConfig,
+    redis: Pool,
+    timeout: Duration,
+    max_execution_seconds: u64,
+    max_intern_per_run: usize,
+    min_ratio: f64,
+    force: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProjectReport {
+    pub interned: usize,
+    pub before: u64,
+    pub after: u64,
+}
+
+impl Projector {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        clickhouse: ClickHouseConfig,
+        redis: Pool,
+        timeout: Duration,
+        max_execution_seconds: u64,
+        max_intern_per_run: usize,
+        min_ratio: f64,
+        force: bool,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            http: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(10))
+                .build()?,
+            clickhouse,
+            redis,
+            timeout,
+            max_execution_seconds,
+            max_intern_per_run,
+            min_ratio,
+            force,
+        })
+    }
+
+    pub async fn run(&self) -> anyhow::Result<ProjectReport> {
+        let interned = self.extend_interner().await?;
+        let report = self.rebuild(interned).await?;
+        Ok(report)
+    }
+
+    /// Give an id to every account in the graph that lacks one.
+    ///
+    /// Without this the projection silently drops edges: a join against the
+    /// mirror simply loses rows whose DID was never interned, and a lens built
+    /// on the result would be quietly short of members with nothing erroring.
+    async fn extend_interner(&self) -> anyhow::Result<usize> {
+        let db = &self.clickhouse.database;
+        let mut total = 0usize;
+
+        loop {
+            let remaining = self.max_intern_per_run.saturating_sub(total);
+            if remaining == 0 {
+                warn!(
+                    total,
+                    "hit max_intern_per_run; projection will be incomplete until the next run"
+                );
+                break;
+            }
+            let batch = remaining.min(50_000);
+
+            let sql = format!(
+                "SELECT did FROM (
+                     SELECT follower AS did FROM {db}.follow_edges
+                     UNION ALL
+                     SELECT followee AS did FROM {db}.follow_edges WHERE followee != ''
+                 ) AS g
+                 LEFT ANTI JOIN {db}.{MAP_TABLE} AS m ON g.did = m.did
+                 GROUP BY did LIMIT {batch}"
+            );
+            let text = self.exec(&sql).await?;
+            let dids: Vec<String> = text
+                .lines()
+                .map(str::trim)
+                .filter(|l| l.starts_with("did:"))
+                .map(str::to_string)
+                .collect();
+            if dids.is_empty() {
+                break;
+            }
+
+            let pairs = self.intern(&dids).await?;
+            self.write_map(&pairs).await?;
+            total += pairs.len();
+            info!(interned = total, "interner extended");
+        }
+        Ok(total)
+    }
+
+    async fn intern(&self, dids: &[String]) -> anyhow::Result<Vec<(String, u32)>> {
+        let mut conn = self.redis.get().await?;
+        let mut out = Vec::with_capacity(dids.len());
+        for chunk in dids.chunks(INTERN_CHUNK) {
+            let mut script = deadpool_redis::redis::cmd("EVAL");
+            script
+                .arg(LUA_GETSET)
+                .arg(2)
+                .arg(DIDINT_MAP)
+                .arg(DIDINT_SEQ);
+            for d in chunk {
+                script.arg(d);
+            }
+            let ids: Vec<i64> = script.query_async(&mut conn).await?;
+            for (d, id) in chunk.iter().zip(ids) {
+                out.push((
+                    d.clone(),
+                    u32::try_from(id)
+                        .map_err(|_| anyhow::anyhow!("interner id {id} out of u32 range"))?,
+                ));
+            }
+        }
+        Ok(out)
+    }
+
+    async fn write_map(&self, pairs: &[(String, u32)]) -> anyhow::Result<()> {
+        let db = &self.clickhouse.database;
+        let body: String = pairs
+            .iter()
+            .map(|(d, i)| format!("{d}\t{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let query = format!("INSERT INTO {db}.{MAP_TABLE} (did, id) FORMAT TabSeparated");
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.timeout)
+            .query(&[("query", query.as_str())])
+            .body(body)
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let t = response.text().await.unwrap_or_default();
+            anyhow::bail!("map insert failed ({status}): {}", &t[..t.len().min(400)]);
+        }
+        Ok(())
+    }
+
+    /// Build into staging and swap.
+    ///
+    /// Same reasoning as the reverse index: the projection is derived, so it is
+    /// replaced wholesale rather than mutated, and readers see the old contents
+    /// until the instant they see the new ones.
+    async fn rebuild(&self, interned: usize) -> anyhow::Result<ProjectReport> {
+        let db = &self.clickhouse.database;
+
+        self.exec(&format!(
+            "CREATE TABLE IF NOT EXISTS {db}.{STAGING_TABLE} AS {db}.{LIVE_TABLE}"
+        ))
+        .await?;
+        self.exec(&format!("TRUNCATE TABLE {db}.{STAGING_TABLE}"))
+            .await?;
+
+        // The `op` filter runs outside the FINAL subquery: filtering first would
+        // keep the create row of an unfollowed pair and resurrect a dead edge.
+        // Joins are INNER, so an account still lacking an id drops out rather
+        // than projecting to 0 and colliding with a real account.
+        self.exec(&format!(
+            "INSERT INTO {db}.{STAGING_TABLE} (follower_int, followee_int)
+             SELECT m1.id, m2.id
+             FROM (
+                 SELECT follower, followee FROM (
+                     SELECT follower, followee, op FROM {db}.follow_edges FINAL
+                 ) WHERE op = 'create' AND followee != ''
+             ) AS e
+             INNER JOIN {db}.{MAP_TABLE} AS m1 ON e.follower = m1.did
+             INNER JOIN {db}.{MAP_TABLE} AS m2 ON e.followee = m2.did"
+        ))
+        .await?;
+
+        let before = self.count(LIVE_TABLE).await?;
+        let after = self.count(STAGING_TABLE).await?;
+
+        // Same anti-wipe guard as the reverse index: EXCHANGE is instant and
+        // total, so a rebuild that silently produced nothing would replace the
+        // projection with an empty table and every second-degree lens would
+        // quietly return nobody.
+        if before > 0 {
+            let ratio = after as f64 / before as f64;
+            if ratio < self.min_ratio && !self.force {
+                anyhow::bail!(
+                    "refusing to swap: rebuilt {after} rows vs {before} live ({:.1}%, floor {:.0}%). \
+                     Re-run with LENS_PROJECT_FORCE=true if this shrinkage is expected.",
+                    ratio * 100.0,
+                    self.min_ratio * 100.0
+                );
+            }
+        } else if after == 0 {
+            anyhow::bail!("refusing to swap: both live and rebuilt projections are empty");
+        }
+
+        self.exec(&format!(
+            "EXCHANGE TABLES {db}.{LIVE_TABLE} AND {db}.{STAGING_TABLE}"
+        ))
+        .await?;
+        self.exec(&format!("TRUNCATE TABLE {db}.{STAGING_TABLE}"))
+            .await?;
+
+        info!(before, after, interned, "traversal projection swapped in");
+        Ok(ProjectReport {
+            interned,
+            before,
+            after,
+        })
+    }
+
+    async fn count(&self, table: &str) -> anyhow::Result<u64> {
+        let db = &self.clickhouse.database;
+        let t = self
+            .exec(&format!("SELECT count() FROM {db}.{table}"))
+            .await?;
+        Ok(t.trim().parse().unwrap_or(0))
+    }
+
+    async fn exec(&self, sql: &str) -> anyhow::Result<String> {
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.timeout)
+            .query(&[
+                ("max_execution_time", self.max_execution_seconds.to_string()),
+                ("cancel_http_readonly_queries_on_client_close", "1".into()),
+            ])
+            .body(sql.to_string())
+            .send()
+            .await?;
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!(
+                "projection query failed ({status}): {}\nSQL: {}",
+                &text[..text.len().min(500)],
+                &sql[..sql.len().min(200)]
+            );
+        }
+        Ok(text)
+    }
+}
+
+/// Render a literal seed list for a 2-hop query.
+///
+/// Exists as its own function to make the rule enforceable by test: callers
+/// must inline the ids. `IN (subquery)` reads the whole table.
+pub fn seed_list(ids: &[u32]) -> String {
+    ids.iter()
+        .map(|i| i.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_list_is_literal_integers() {
+        assert_eq!(seed_list(&[3, 1, 2]), "3,1,2");
+        assert_eq!(seed_list(&[]), "");
+        // No quoting, no subquery: the two things that would defeat the index.
+        let s = seed_list(&[7, 8]);
+        assert!(!s.contains('\''));
+        assert!(!s.to_uppercase().contains("SELECT"));
+    }
+
+    /// The projection must never be written in place; a partial rebuild visible
+    /// to readers is a lens that silently loses members.
+    #[test]
+    fn live_and_staging_are_distinct() {
+        assert_ne!(LIVE_TABLE, STAGING_TABLE);
+        assert!(STAGING_TABLE.starts_with(LIVE_TABLE));
+    }
+
+    #[test]
+    fn interner_keys_match_the_shared_space() {
+        assert_eq!(DIDINT_MAP, "didint:{didint}:map");
+        assert_eq!(DIDINT_SEQ, "didint:{didint}:seq");
+    }
+}

--- a/kube/lens-bootstrap-hop1-job.yaml
+++ b/kube/lens-bootstrap-hop1-job.yaml
@@ -52,7 +52,7 @@ spec:
         - name: bootstrap
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:fba7efdda8fdc929fc5318f3df530ef41ec42d1b127c2d8039faff15fa901b62
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:7dbb7c38aba0e165aebb93d9f0bf0d4d9b8ee8e5a291f5123acf867c18d035f7
           command: ["/app/graze-lens-bootstrap"]
           args: ["--file", "/config/dids.txt"]
           resources:
@@ -78,8 +78,14 @@ spec:
             # hub rather than a person: its follows add reach noise to second
             # degree and cost minutes each to page. Capping is a feature here,
             # not a compromise -- the design wanted hub-capping anyway.
+            # The code default, deliberately not the 50 this job first ran with.
+            # A run that stops at max_pages returns a PREFIX of an account's
+            # follows, and truncated accounts are now left without a completeness
+            # marker on purpose — so a low cap does not just truncate the biggest
+            # graphs, it condemns exactly those accounts to being re-walked from
+            # their PDS on every lens request, forever.
             - name: LENS_BOOTSTRAP_MAX_PAGES
-              value: "50"
+              value: "600"
             - name: RUST_LOG
               value: "info"
           volumeMounts:

--- a/kube/lens-bootstrap-hop1-job.yaml
+++ b/kube/lens-bootstrap-hop1-job.yaml
@@ -1,0 +1,104 @@
+# graze-lens-bootstrap — backfills historical follow edges for a set of accounts.
+#
+# `graze-lens-fold` only sees follows from the moment it connects; this fills in
+# the history behind it, reading each account's follow records from its PDS.
+#
+# IDEMPOTENT. Rows are versioned by the record's own TID, so re-running writes
+# identical (follower, rkey, seq) tuples and ReplacingMergeTree collapses them.
+# Re-run freely — that is also the recovery procedure.
+#
+# Prereqs (created out of band):
+#   * secret `app-secrets` — CLICKHOUSE_{HOST,USER,PASSWORD}
+#   * ClickHouse tables — `feed-processor/scripts/create_follow_edges_tables.py`
+#   * ConfigMap `graze-beta-cohort` (key `dids.txt`) — the shared beta cohort,
+#     not a lens-specific list. Source of truth is `cohorts/beta.txt`; see its
+#     header for how to regenerate the ConfigMap after editing.
+#
+# Scope note: this is the per-account path, and it is what M0 needs — it covers
+# exactly the accounts that asked for a lens, over public unauthenticated
+# endpoints. Warming the *global* graph is a different job, blocked on a
+# bsky.network archive token plus a decoder for the .jss segment format; when
+# that lands, this remains the repair path for history the archive predates.
+#
+# Dry run first on a new DID list:
+#   kubectl set env job/graze-lens-bootstrap LENS_BOOTSTRAP_DRY_RUN=true
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: graze-lens-bootstrap-hop1
+  labels:
+    app: graze-lens
+    component: bootstrap
+spec:
+  # No retries. The job is re-runnable by hand, and an automatic retry of a
+  # partially-succeeded backfill just re-walks every PDS for no benefit.
+  backoffLimit: 0
+  # ~4h ceiling: a 50k-follow account is ~500 paged requests, and the default
+  # concurrency of 4 is deliberately polite to other people's servers.
+  activeDeadlineSeconds: 21600
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: graze-lens
+        component: bootstrap
+    spec:
+      restartPolicy: Never
+      # Required: the default service account carries no pull secrets, so
+      # without this the pod fails with ImagePullBackOff against DOCR.
+      imagePullSecrets:
+        - name: docr-graze-social-labs
+      containers:
+        - name: bootstrap
+          # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
+          # the short-SHA tag are mutable on DOCR.
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:fba7efdda8fdc929fc5318f3df530ef41ec42d1b127c2d8039faff15fa901b62
+          command: ["/app/graze-lens-bootstrap"]
+          args: ["--file", "/config/dids.txt"]
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              # Edges buffer in memory until a batch fills; a very large DID list
+              # of whales is the case that needs the headroom.
+              memory: "2Gi"
+              cpu: "1"
+          envFrom:
+            - secretRef:
+                name: app-secrets
+          env:
+            - name: LENS_BOOTSTRAP_CONCURRENCY
+              value: "12"
+            - name: LENS_BOOTSTRAP_PAGE_DELAY_MS
+              value: "150"
+            - name: LENS_BOOTSTRAP_INSERT_BATCH
+              value: "20000"
+            # Hub cap. 50 pages = 5,000 follows, past which an account is a
+            # hub rather than a person: its follows add reach noise to second
+            # degree and cost minutes each to page. Capping is a feature here,
+            # not a compromise -- the design wanted hub-capping anyway.
+            - name: LENS_BOOTSTRAP_MAX_PAGES
+              value: "50"
+            - name: RUST_LOG
+              value: "info"
+          volumeMounts:
+            - name: dids
+              mountPath: /config
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      securityContext:
+        # Numeric, not a name: distroless nonroot has no /etc/passwd entry.
+        runAsUser: 65532
+        runAsGroup: 65532
+      volumes:
+        - name: dids
+          configMap:
+            # The shared beta cohort, so "who is in the beta" stays one decision
+            # in one place rather than a per-feature allowlist.
+            name: lens-hop1-cohort

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:f27d73fb112798f7cfa57b9c8fdaaa66a25eb1c8d129c182258a0f3f3d995456
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:96d6ea3f361c3a31be9ff243c909c7dc0491a2b46d01d35dfdb9a37d0ea3048d
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:03f7834205eb6b259b49297131e5586c785e4ea3a72d946aa9f9478d22dc013a
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:7dbb7c38aba0e165aebb93d9f0bf0d4d9b8ee8e5a291f5123acf867c18d035f7
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:fba7efdda8fdc929fc5318f3df530ef41ec42d1b127c2d8039faff15fa901b62
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:f27d73fb112798f7cfa57b9c8fdaaa66a25eb1c8d129c182258a0f3f3d995456
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:96d6ea3f361c3a31be9ff243c909c7dc0491a2b46d01d35dfdb9a37d0ea3048d
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:03f7834205eb6b259b49297131e5586c785e4ea3a72d946aa9f9478d22dc013a
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               # Built from commit 1a835eb (feat/lens-completeness-guard).
               # Digest-pinned: both `latest` and the short-SHA tag are mutable
               # on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:03f7834205eb6b259b49297131e5586c785e4ea3a72d946aa9f9478d22dc013a
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:7dbb7c38aba0e165aebb93d9f0bf0d4d9b8ee8e5a291f5123acf867c18d035f7
               command: ["/app/graze-lens-project"]
               resources:
                 requests:

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -1,0 +1,113 @@
+# graze-lens-project — rebuilds the second-degree traversal projection.
+#
+# `follow_edges` is keyed and partitioned for per-viewer lookups, which is the
+# wrong shape for a multi-seed traversal: measured on real data, the follows²
+# query against it read the entire table — 636 MB, 424-874 ms, with cold-read
+# variance on top. Against `follow_graph_int` the same query reads 11.87 MB in
+# 34-37 ms. That 54x is not tuning, it is three structural facts the projection
+# has and the fold table cannot: u32 keys instead of DID strings, index
+# granularity 1024 instead of 8192, and no partitioning at all (partitioning
+# taxes every seed one boundary granule in every partition).
+#
+# So the projection is not a cache of `follow_edges` — it is the only structure
+# the second-degree facet can be served from at all, and this job is what keeps
+# it true. A stale projection does not error: it silently serves a lens built
+# from last week's graph.
+#
+# The rebuild also *extends the interner* before projecting. Only 61% of graph
+# accounts were interned when this was written, and an INNER JOIN would have
+# dropped the rest — producing short lenses for real viewers with nothing
+# anywhere reporting a problem.
+#
+# Prereqs (created out of band):
+#   * secret `app-secrets` — CLICKHOUSE_{HOST,USER,PASSWORD}, REDIS_URL
+#     (REDIS_URL is the *cache* Redis, which holds the shared didint space)
+#   * ClickHouse tables — `feed-processor/scripts/create_follow_edges_tables.py`
+#
+# Safety: builds into a staging table and EXCHANGEs it in, so a run that dies
+# partway leaves the live projection untouched. It also refuses to swap in a
+# result under LENS_PROJECT_MIN_RATIO (default 0.5) of the current row count —
+# without that guard, one bad run would replace the projection with an almost
+# empty table and every second-degree lens would quietly go thin rather than
+# fail. Override deliberately with LENS_PROJECT_FORCE=true when a genuine shrink
+# is expected.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: graze-lens-project
+  labels:
+    app: graze-lens
+    component: project
+spec:
+  # Nightly, offset from the reverse-index rebuild so the two full-table passes
+  # do not overlap on the shared ClickHouse. Second-degree membership is a
+  # deliberate approximation — the requirement is near-real-time for the *store*
+  # and the first-degree delta path, not for a 286k-member reach map — so daily
+  # is the intended freshness, not a compromise.
+  schedule: "43 10 * * *" # 10:43 UTC ≈ 03:43 sfo3
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  # Skip a missed run rather than queueing it: a day-stale projection is
+  # survivable, two concurrent rebuilds fighting over the staging table are not.
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 10800 # 3h; the measured rebuild took 89s
+      template:
+        metadata:
+          labels:
+            app: graze-lens
+            component: project
+        spec:
+          restartPolicy: Never
+          # Required: the default service account carries no pull secrets, so
+          # without this the pod fails with ImagePullBackOff against DOCR.
+          imagePullSecrets:
+            - name: docr-graze-social-labs
+          containers:
+            - name: project
+              # Built from commit 870ef35 (feat/lens-completeness-guard).
+              # Digest-pinned: both `latest` and the short-SHA tag are mutable
+              # on DOCR.
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:96d6ea3f361c3a31be9ff243c909c7dc0491a2b46d01d35dfdb9a37d0ea3048d
+              command: ["/app/graze-lens-project"]
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "200m"
+                limits:
+                  # The join and the write happen inside ClickHouse; this
+                  # process issues SQL and interns DIDs in chunks.
+                  memory: "1Gi"
+                  cpu: "1000m"
+              envFrom:
+                - secretRef:
+                    name: app-secrets
+              env:
+                - name: LENS_PROJECT_MAX_EXECUTION_SECONDS
+                  value: "1800"
+                - name: LENS_PROJECT_MIN_RATIO
+                  value: "0.5"
+                # Bounds how many new accounts one pass may add to the shared
+                # interner. That id space lives on a NOEVICTION Redis shared
+                # with rust-smasher and membership-service, so unbounded growth
+                # here is someone else's outage. ~1.5M entries is ~90 MB; the
+                # full network would be ~25M (~1.8 GB), which is the point at
+                # which lenses need their own id space rather than this one.
+                - name: LENS_PROJECT_MAX_INTERN
+                  value: "2000000"
+                - name: RUST_LOG
+                  value: "info"
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+          securityContext:
+            # Numeric, not a name: distroless nonroot has no /etc/passwd entry.
+            runAsUser: 65532
+            runAsGroup: 65532

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -69,10 +69,10 @@ spec:
             - name: docr-graze-social-labs
           containers:
             - name: project
-              # Built from commit 870ef35 (feat/lens-completeness-guard).
+              # Built from commit 1a835eb (feat/lens-completeness-guard).
               # Digest-pinned: both `latest` and the short-SHA tag are mutable
               # on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:96d6ea3f361c3a31be9ff243c909c7dc0491a2b46d01d35dfdb9a37d0ea3048d
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:03f7834205eb6b259b49297131e5586c785e4ea3a72d946aa9f9478d22dc013a
               command: ["/app/graze-lens-project"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -57,9 +57,9 @@ spec:
             - name: docr-graze-social-labs
           containers:
             - name: rev-rebuild
-              # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
-              # the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:fba7efdda8fdc929fc5318f3df530ef41ec42d1b127c2d8039faff15fa901b62
+              # Built from commit 870ef35 (feat/lens-completeness-guard). Digest-pinned:
+              # both `latest` and the short-SHA tag are mutable on DOCR.
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:96d6ea3f361c3a31be9ff243c909c7dc0491a2b46d01d35dfdb9a37d0ea3048d
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: rev-rebuild
               # Built from commit 1a835eb (feat/lens-completeness-guard). Digest-pinned:
               # both `latest` and the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:03f7834205eb6b259b49297131e5586c785e4ea3a72d946aa9f9478d22dc013a
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:7dbb7c38aba0e165aebb93d9f0bf0d4d9b8ee8e5a291f5123acf867c18d035f7
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -57,9 +57,9 @@ spec:
             - name: docr-graze-social-labs
           containers:
             - name: rev-rebuild
-              # Built from commit 870ef35 (feat/lens-completeness-guard). Digest-pinned:
+              # Built from commit 1a835eb (feat/lens-completeness-guard). Digest-pinned:
               # both `latest` and the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:96d6ea3f361c3a31be9ff243c909c7dc0491a2b46d01d35dfdb9a37d0ea3048d
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:03f7834205eb6b259b49297131e5586c785e4ea3a72d946aa9f9478d22dc013a
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:


### PR DESCRIPTION
Two related holes in the completeness guard, found by checking why a
successful-looking bootstrap Job had left only 6 markers behind.

## The bulk Job never wrote markers at all

Only the builder's inline repair path did. A 9,423-account run left **6** markers,
so every one of those accounts gets re-walked from its PDS the first time it asks
for a lens — the warming bought the cohort nothing but a slow first request each,
and put 9,423 needless walks on other people's servers.

## Both paths marked a *truncated* backfill complete

This is the worse one. Stopping at `max_pages` yields a prefix of an account's
follows, not their graph, and a marker makes that prefix permanent: every later
build trusts it and skips the walk. It is the original silent-wrong-lens bug
wearing a disguise, and harder to spot, because the backfill genuinely ran.

The hop-1 Job ran with `max_pages=50` against a default of 600, truncating at
5,000 edges — exactly the accounts whose graphs matter most. Truncated results
are now left unmarked: it costs a re-walk for a handful of very large accounts
and buys the chance to get them whole once the limit rises.

## Ordering

Markers are written only after the batch carrying an account's edges is durable.
Marking on task completion would race the flush, and a crash in between leaves a
marker whose edges were never written — which the next build trusts, skipping the
backfill to publish a lens from a graph that does not exist. That is precisely
the failure the marker was introduced to prevent.

## Mechanics

`CompletenessStore` moves to `graze-lens-bootstrap`, where the backfill it records
lives, and gains a batched writer: one INSERT per account across thousands is the
tiny-insert pattern that drives this cluster's cost. `backfilled_at` is sent
explicitly because it is the ReplacingMergeTree version column and has no DEFAULT
— omitting it writes epoch zero, which destroys the audit trail and loses every
dedup race for that viewer.

Verified live: the re-run is writing `source='bootstrap'` markers as batches land.