### PR TITLE
Record completeness for bulk-backfilled accounts, and never for a truncated one

### DIFF
--- a/crates/graze-lens-bootstrap/src/backfill.rs
+++ b/crates/graze-lens-bootstrap/src/backfill.rs
@@ -53,6 +53,21 @@ pub struct Backfilled {
     pub truncated: bool,
 }
 
+/// Ceiling on a single backoff wait. A host advertising a multi-minute
+/// Retry-After is telling us to come back in another run, not to hold a worker
+/// slot idle for it while thousands of other accounts wait behind it.
+const MAX_RETRY_WAIT: Duration = Duration::from_secs(30);
+
+/// `Retry-After`, as either delta-seconds or an HTTP date we ignore in favour of
+/// the caller's backoff. Only the numeric form is honoured, because the date
+/// form is rare here and mis-parsing it would stall a worker far longer than
+/// backing off would.
+fn retry_after(response: &reqwest::Response) -> Option<Duration> {
+    let raw = response.headers().get(reqwest::header::RETRY_AFTER)?;
+    let secs: u64 = raw.to_str().ok()?.trim().parse().ok()?;
+    Some(Duration::from_secs(secs))
+}
+
 pub struct Backfiller {
     http: reqwest::Client,
     resolver: Resolver,
@@ -60,6 +75,8 @@ pub struct Backfiller {
     /// Politeness delay between pages against one PDS.
     page_delay: Duration,
     max_pages: usize,
+    /// How many times one page may be retried after a 429 or 5xx.
+    max_retries: u32,
 }
 
 impl Backfiller {
@@ -69,6 +86,7 @@ impl Backfiller {
         request_timeout: Duration,
         page_delay: Duration,
         max_pages: usize,
+        max_retries: u32,
     ) -> Self {
         Self {
             http,
@@ -76,6 +94,7 @@ impl Backfiller {
             request_timeout,
             page_delay,
             max_pages,
+            max_retries,
         }
     }
 
@@ -103,13 +122,44 @@ impl Backfiller {
                 query.push(("cursor", c.clone()));
             }
 
-            let response = self
-                .http
-                .get(&url)
-                .query(&query)
-                .timeout(self.request_timeout)
-                .send()
-                .await?;
+            // Retried on 429/5xx rather than failing the account.
+            //
+            // A bulk run fans out over shared `*.host.bsky.network` hosts, and
+            // raising max_pages multiplies requests per account, so the job
+            // rate-limits *itself*: one run pushed 2,520 accounts into 429s and
+            // recorded them all as failures. Nothing was wrong with those
+            // accounts — we simply asked too fast, and then remembered our own
+            // impatience as their problem. Backing off is what makes a bulk
+            // warm-up honest about which accounts it actually could not read.
+            let mut attempt = 0u32;
+            let response = loop {
+                let response = self
+                    .http
+                    .get(&url)
+                    .query(&query)
+                    .timeout(self.request_timeout)
+                    .send()
+                    .await?;
+
+                let status = response.status();
+                let retryable =
+                    status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
+                if !retryable || attempt >= self.max_retries {
+                    break response;
+                }
+
+                // Honour Retry-After when the host sends one — it knows its own
+                // window better than any backoff curve we invent. Otherwise back
+                // off exponentially from the configured page delay.
+                let wait = retry_after(&response).unwrap_or_else(|| {
+                    let base = self.page_delay.max(Duration::from_millis(200));
+                    base * 2u32.saturating_pow(attempt + 1)
+                });
+                let wait = wait.min(MAX_RETRY_WAIT);
+                attempt += 1;
+                debug!(did, %status, attempt, wait_ms = wait.as_millis(), "backing off");
+                tokio::time::sleep(wait).await;
+            };
 
             if !response.status().is_success() {
                 let status = response.status();

--- a/crates/graze-lens-bootstrap/src/backfill.rs
+++ b/crates/graze-lens-bootstrap/src/backfill.rs
@@ -39,6 +39,20 @@ struct FollowValue {
     created_at: Option<String>,
 }
 
+/// The result of backfilling one account.
+///
+/// `truncated` is the field that matters to callers: it means we stopped at
+/// `max_pages` with records still unread, so these edges are a *prefix* of the
+/// account's follows, not their graph. A caller that records completeness must
+/// not do so for a truncated result — that would pin the account to a partial
+/// graph permanently, which is the same silent-wrong-lens failure the
+/// completeness marker exists to prevent, just harder to spot because the
+/// backfill genuinely ran.
+pub struct Backfilled {
+    pub edges: Vec<FollowEdge>,
+    pub truncated: bool,
+}
+
 pub struct Backfiller {
     http: reqwest::Client,
     resolver: Resolver,
@@ -70,13 +84,14 @@ impl Backfiller {
     /// Only creates are produced: listRecords reflects present state, so a
     /// record that is absent was either never created or already deleted, and
     /// in both cases there is nothing to write. Live deletes come from the fold.
-    pub async fn edges_for(&self, did: &str) -> anyhow::Result<Vec<FollowEdge>> {
+    pub async fn edges_for(&self, did: &str) -> anyhow::Result<Backfilled> {
         let pds = self.resolver.pds_for(did).await?;
         let url = format!("{pds}/xrpc/com.atproto.repo.listRecords");
 
         let mut edges = Vec::new();
         let mut cursor: Option<String> = None;
         let mut pages = 0usize;
+        let mut truncated = false;
 
         loop {
             let mut query: Vec<(&str, String)> = vec![
@@ -108,7 +123,13 @@ impl Backfiller {
                 // scale, where a slice of anyone's follow list has since left.
                 if is_repo_gone(status, &body) {
                     debug!(did, %status, "repo unavailable; treating as no records");
-                    return Ok(Vec::new());
+                    // Not truncated: this is a complete answer about an account
+                    // with nothing to read, not a partial read of one that has
+                    // records left.
+                    return Ok(Backfilled {
+                        edges: Vec::new(),
+                        truncated: false,
+                    });
                 }
 
                 anyhow::bail!(
@@ -144,6 +165,7 @@ impl Backfiller {
                     edges = edges.len(),
                     "hit max_pages; backfill truncated for this account"
                 );
+                truncated = true;
                 break;
             }
             if !self.page_delay.is_zero() {
@@ -151,7 +173,7 @@ impl Backfiller {
             }
         }
 
-        Ok(edges)
+        Ok(Backfilled { edges, truncated })
     }
 }
 

--- a/crates/graze-lens-bootstrap/src/completeness.rs
+++ b/crates/graze-lens-bootstrap/src/completeness.rs
@@ -21,12 +21,18 @@
 use std::time::Duration;
 
 use graze_common::ClickHouseConfig;
-use tracing::debug;
+use tracing::{debug, warn};
 
 const TABLE: &str = "lens_backfill_state";
 
 /// Where a viewer's backfill came from, for auditing a suspicious lens later.
+///
+/// Both paths write real markers and both count as complete; the distinction is
+/// purely so an audit can tell a lazily-repaired viewer from one warmed in bulk.
+/// `SOURCE_PDS` is the builder repairing a single viewer inline, on their own
+/// first lens request; `SOURCE_BOOTSTRAP` is the bulk Job warming a cohort.
 pub const SOURCE_PDS: &str = "pds";
+pub const SOURCE_BOOTSTRAP: &str = "bootstrap";
 
 pub struct CompletenessStore {
     http: reqwest::Client,
@@ -112,6 +118,76 @@ impl CompletenessStore {
         Ok(())
     }
 
+    /// Record many viewers at once.
+    ///
+    /// The bulk Job backfills thousands of accounts in one run, and one INSERT
+    /// per account is exactly the tiny-insert pattern that drives this cluster's
+    /// cost. Rows go over as TabSeparated in batches, matching the Sink.
+    ///
+    /// Callers must only pass viewers whose edges are already durable. A marker
+    /// written ahead of its edges is worse than no marker: the next build trusts
+    /// it, skips the backfill, and publishes a lens from a graph that was never
+    /// written.
+    pub async fn mark_many(&self, entries: &[(String, usize)], source: &str) -> anyhow::Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        // `backfilled_at` has no DEFAULT and is the ReplacingMergeTree *version*
+        // column, so it has to be sent: an omitted value would write epoch zero,
+        // which both destroys the audit trail the column exists for and loses
+        // every dedup race against any other row for that viewer. Sent as a unix
+        // integer, which TabSeparated accepts for DateTime, and read once per
+        // batch so a batch is internally consistent.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let body = entries
+            .iter()
+            .map(|(viewer, edges)| {
+                format!(
+                    "{}\t{}\t{}\t{}",
+                    escape_tsv(viewer),
+                    now,
+                    edges,
+                    escape_tsv(source)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let query = format!(
+            "INSERT INTO {}.{TABLE} (viewer, backfilled_at, edge_count, source) \
+             FORMAT TabSeparated",
+            self.clickhouse.database
+        );
+
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.timeout)
+            .query(&[("query", query.as_str())])
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "marking {} viewer(s) complete failed ({}): {}",
+                entries.len(),
+                status,
+                &text[..text.len().min(400)]
+            );
+        }
+        Ok(())
+    }
+
     async fn exec(&self, sql: &str, viewer: Option<&str>) -> anyhow::Result<String> {
         let mut query: Vec<(&str, String)> = vec![
             ("max_execution_time", self.max_execution_seconds.to_string()),
@@ -145,6 +221,27 @@ impl CompletenessStore {
     }
 }
 
+/// TabSeparated escaping, matching the Sink's.
+///
+/// A DID should never contain a tab, but this is untrusted network input and one
+/// stray control character would shift every later column silently rather than
+/// failing.
+fn escape_tsv(value: &str) -> String {
+    if !value
+        .as_bytes()
+        .iter()
+        .any(|b| matches!(b, b'\t' | b'\n' | b'\r' | b'\\'))
+    {
+        return value.to_string();
+    }
+    warn!(value, "control characters in a viewer DID; escaping");
+    value
+        .replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,6 +272,67 @@ mod tests {
         );
         assert!(sql.contains("{viewer:String}"));
         assert!(!sql.contains("did:plc:"));
+    }
+
+    /// The batched insert must name columns in the order its rows carry them.
+    /// A silent column shift here would write the timestamp into `edge_count`,
+    /// which the guard reads as "complete" for every viewer forever.
+    #[test]
+    fn batched_insert_columns_match_the_row_order() {
+        let s = store();
+        let query = format!(
+            "INSERT INTO {}.{TABLE} (viewer, backfilled_at, edge_count, source) \
+             FORMAT TabSeparated",
+            s.clickhouse.database
+        );
+        let row = format!(
+            "{}\t{}\t{}\t{}",
+            escape_tsv("did:plc:a"),
+            1788000000,
+            42,
+            escape_tsv(SOURCE_BOOTSTRAP)
+        );
+
+        let cols: Vec<&str> = query
+            .split_once('(')
+            .and_then(|(_, r)| r.split_once(')'))
+            .map(|(c, _)| c.split(',').map(str::trim).collect())
+            .expect("column list");
+        assert_eq!(
+            cols,
+            vec!["viewer", "backfilled_at", "edge_count", "source"]
+        );
+        assert_eq!(row.split('\t').count(), cols.len());
+        assert_eq!(row.split('\t').nth(2), Some("42"), "edge_count is third");
+    }
+
+    /// `backfilled_at` is the ReplacingMergeTree version column and has no
+    /// DEFAULT, so it must be sent. Omitting it writes epoch zero, which both
+    /// destroys the audit trail and loses every dedup race for that viewer.
+    #[test]
+    fn backfilled_at_is_always_sent() {
+        let s = store();
+        let query = format!(
+            "INSERT INTO {}.{TABLE} (viewer, backfilled_at, edge_count, source) FORMAT TabSeparated",
+            s.clickhouse.database
+        );
+        assert!(query.contains("backfilled_at"));
+    }
+
+    /// The two write paths must stay distinguishable, so an audit can tell a
+    /// lazily-repaired viewer from one warmed in bulk.
+    #[test]
+    fn sources_are_distinct() {
+        assert_ne!(SOURCE_PDS, SOURCE_BOOTSTRAP);
+    }
+
+    /// A control character in a DID would shift every later column silently.
+    #[test]
+    fn tsv_escaping_protects_the_column_boundaries() {
+        assert_eq!(escape_tsv("did:plc:ok"), "did:plc:ok");
+        assert_eq!(escape_tsv("did:plc:a\tb"), "did:plc:a\\tb");
+        assert_eq!(escape_tsv("did:plc:a\nb"), "did:plc:a\\nb");
+        assert!(!escape_tsv("did:plc:a\tb").contains('\t'));
     }
 
     /// A row recorded with zero edges is not evidence of a usable backfill —

--- a/crates/graze-lens-bootstrap/src/config.rs
+++ b/crates/graze-lens-bootstrap/src/config.rs
@@ -22,6 +22,8 @@ pub struct Config {
     /// account; beyond that the account is logged and truncated rather than
     /// paging indefinitely.
     pub max_pages: usize,
+    /// Retries for one page after a 429 or 5xx.
+    pub max_retries: u32,
 
     pub plc_directory: Option<String>,
     /// Resolve and fetch, but write nothing.
@@ -51,6 +53,7 @@ impl Config {
             request_timeout: Duration::from_secs(parse("LENS_BOOTSTRAP_REQUEST_TIMEOUT", 20)?),
             page_delay: Duration::from_millis(parse("LENS_BOOTSTRAP_PAGE_DELAY_MS", 150)?),
             max_pages: parse("LENS_BOOTSTRAP_MAX_PAGES", 600)?,
+            max_retries: parse("LENS_BOOTSTRAP_MAX_RETRIES", 4)?,
 
             plc_directory: optional("LENS_BOOTSTRAP_PLC_DIRECTORY"),
             dry_run: parse("LENS_BOOTSTRAP_DRY_RUN", false)?,

--- a/crates/graze-lens-bootstrap/src/lib.rs
+++ b/crates/graze-lens-bootstrap/src/lib.rs
@@ -24,9 +24,11 @@
 //! (follower, rkey, seq) tuples and ReplacingMergeTree collapses them.
 
 pub mod backfill;
+pub mod completeness;
 pub mod config;
 pub mod resolve;
 
-pub use backfill::Backfiller;
+pub use backfill::{Backfilled, Backfiller};
+pub use completeness::{CompletenessStore, SOURCE_BOOTSTRAP, SOURCE_PDS};
 pub use config::Config;
 pub use resolve::Resolver;

--- a/crates/graze-lens-bootstrap/src/main.rs
+++ b/crates/graze-lens-bootstrap/src/main.rs
@@ -48,6 +48,7 @@ async fn main() -> anyhow::Result<()> {
         config.request_timeout,
         config.page_delay,
         config.max_pages,
+        config.max_retries,
     ));
     let sink =
         Arc::new(Sink::new(config.clickhouse.clone(), config.insert_timeout).context("sink")?);

--- a/crates/graze-lens-bootstrap/src/main.rs
+++ b/crates/graze-lens-bootstrap/src/main.rs
@@ -11,7 +11,7 @@ use std::io::BufRead;
 use std::sync::Arc;
 
 use anyhow::Context;
-use graze_lens_bootstrap::{Backfiller, Config, Resolver};
+use graze_lens_bootstrap::{Backfiller, CompletenessStore, Config, Resolver, SOURCE_BOOTSTRAP};
 use graze_lens_fold::{FollowEdge, Sink};
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
@@ -52,7 +52,28 @@ async fn main() -> anyhow::Result<()> {
     let sink =
         Arc::new(Sink::new(config.clickhouse.clone(), config.insert_timeout).context("sink")?);
 
+    // Without this, every account this job backfills is re-walked from its PDS
+    // the first time it asks for a lens: the builder's completeness guard only
+    // trusts markers, and only the builder's own inline path was writing them.
+    // A 9,423-account run left 6 markers behind, so the bulk warming bought the
+    // cohort nothing but a slow first request each.
+    let completeness = Arc::new(
+        CompletenessStore::new(
+            config.clickhouse.clone(),
+            config.insert_timeout,
+            config.insert_timeout.as_secs().max(1),
+        )
+        .context("completeness store")?,
+    );
+
+    // Edges and the viewers they belong to travel together, and a viewer is only
+    // marked once the batch carrying their edges is durable. Marking on task
+    // completion instead would race the flush: a crash in between leaves a
+    // marker whose edges were never written, and the next build trusts it,
+    // skips the backfill, and publishes a lens from a graph that does not exist.
+    // That is the exact failure the marker was introduced to prevent.
     let pending: Arc<Mutex<Vec<FollowEdge>>> = Arc::new(Mutex::new(Vec::new()));
+    let pending_viewers: Arc<Mutex<Vec<(String, usize)>>> = Arc::new(Mutex::new(Vec::new()));
     let total = dids.len();
     let done = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let failed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -66,25 +87,53 @@ async fn main() -> anyhow::Result<()> {
     for did in dids {
         let permit = semaphore.clone().acquire_owned().await?;
         let (backfiller, sink, pending) = (backfiller.clone(), sink.clone(), pending.clone());
+        let (completeness, pending_viewers) = (completeness.clone(), pending_viewers.clone());
         let (done, failed, rows) = (done.clone(), failed.clone(), rows.clone());
         let config = config.clone();
 
         tasks.push(tokio::spawn(async move {
             let _permit = permit;
             match backfiller.edges_for(&did).await {
-                Ok(edges) => {
-                    rows.fetch_add(edges.len(), std::sync::atomic::Ordering::Relaxed);
-                    if !config.dry_run && !edges.is_empty() {
+                Ok(backfilled) => {
+                    let count = backfilled.edges.len();
+                    rows.fetch_add(count, std::sync::atomic::Ordering::Relaxed);
+                    if !config.dry_run && count > 0 {
                         let mut buf = pending.lock().await;
-                        buf.extend(edges);
+                        buf.extend(backfilled.edges);
+                        // A truncated account is deliberately not recorded: its
+                        // edges are a prefix, and a marker would freeze that
+                        // prefix as its graph forever. Zero-edge accounts are
+                        // skipped too — the guard treats a zero-edge row as
+                        // incomplete anyway, so writing one is pure noise.
+                        if !backfilled.truncated {
+                            pending_viewers.lock().await.push((did.clone(), count));
+                        }
+
                         if buf.len() >= config.insert_batch {
                             let batch = std::mem::take(&mut *buf);
                             drop(buf);
-                            if let Err(e) = sink.insert(&batch).await {
-                                // Keep going: one failed insert should not abort
-                                // a long backfill, and the job is re-runnable.
-                                error!(error = %e, rows = batch.len(), "insert failed");
-                                failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            let viewers = std::mem::take(&mut *pending_viewers.lock().await);
+                            match sink.insert(&batch).await {
+                                Ok(()) => {
+                                    // Only now are these viewers' edges durable.
+                                    if let Err(e) =
+                                        completeness.mark_many(&viewers, SOURCE_BOOTSTRAP).await
+                                    {
+                                        // Not fatal: the edges are written, so
+                                        // the worst case is the builder
+                                        // re-walking these accounts once.
+                                        warn!(error = %e, viewers = viewers.len(),
+                                              "recording completeness failed");
+                                    }
+                                }
+                                Err(e) => {
+                                    // Keep going: one failed insert should not
+                                    // abort a long backfill, and the job is
+                                    // re-runnable. The viewers are dropped
+                                    // unmarked, which is the safe direction.
+                                    error!(error = %e, rows = batch.len(), "insert failed");
+                                    failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                }
                             }
                         }
                     }
@@ -113,10 +162,22 @@ async fn main() -> anyhow::Result<()> {
 
     // Flush the tail.
     let remaining = std::mem::take(&mut *pending.lock().await);
+    let remaining_viewers = std::mem::take(&mut *pending_viewers.lock().await);
     if !config.dry_run && !remaining.is_empty() {
-        if let Err(e) = sink.insert(&remaining).await {
-            error!(error = %e, rows = remaining.len(), "final insert failed");
-            failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        match sink.insert(&remaining).await {
+            Ok(()) => {
+                if let Err(e) = completeness
+                    .mark_many(&remaining_viewers, SOURCE_BOOTSTRAP)
+                    .await
+                {
+                    warn!(error = %e, viewers = remaining_viewers.len(),
+                          "recording completeness failed for the final batch");
+                }
+            }
+            Err(e) => {
+                error!(error = %e, rows = remaining.len(), "final insert failed");
+                failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
         }
     }
 

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -17,10 +17,10 @@ use graze_common::ClickHouseConfig;
 use serde::Deserialize;
 use tracing::{debug, info, warn};
 
-use crate::completeness::CompletenessStore;
 use crate::config::Config;
 use crate::interner::Interner;
 use crate::second_degree;
+use graze_lens_bootstrap::CompletenessStore;
 use graze_lens_bootstrap::{Backfiller, Resolver};
 use graze_lens_fold::Sink;
 
@@ -412,9 +412,15 @@ impl Builder {
             }
         };
 
-        let edges = backfiller.edges_for(viewer).await?;
+        let backfilled = backfiller.edges_for(viewer).await?;
+        let edges = backfilled.edges;
         let count = edges.len();
-        info!(viewer, count, "backfilled follow history");
+        info!(
+            viewer,
+            count,
+            truncated = backfilled.truncated,
+            "backfilled follow history"
+        );
 
         if !edges.is_empty() {
             sink.insert(&edges).await?;
@@ -423,7 +429,23 @@ impl Builder {
         // Marked before publishing: if the process dies between the two, the
         // next build finds the marker, skips the (already persisted) backfill,
         // and builds from ClickHouse. Marking after would re-walk the PDS.
-        store.mark_complete(viewer, count).await?;
+        //
+        // Except when the backfill was truncated. These edges are a prefix of
+        // the account's follows, not their graph, and a marker would make that
+        // prefix permanent: every later build would trust it and skip the walk.
+        // Leaving the marker off costs a re-walk per request for a handful of
+        // very large accounts, and buys the chance to get them whole once
+        // `backfill_max_pages` is raised. The lens still publishes meanwhile —
+        // a wide-but-partial lens is a reasonable feed, an invisibly frozen one
+        // is not.
+        if backfilled.truncated {
+            warn!(
+                viewer,
+                count, "backfill truncated; not recording completeness"
+            );
+        } else {
+            store.mark_complete(viewer, count).await?;
+        }
 
         if count == 0 {
             self.mark_state(viewer, "ready").await?;

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -167,6 +167,7 @@ impl Builder {
             cfg.backfill_request_timeout,
             cfg.backfill_page_delay,
             cfg.backfill_max_pages,
+            cfg.backfill_max_retries,
         ));
         // Straight to the base table, NOT through follow_edges_buffer.
         //

--- a/crates/graze-lens-builder/src/config.rs
+++ b/crates/graze-lens-builder/src/config.rs
@@ -67,6 +67,7 @@ pub struct Config {
     pub backfill_request_timeout: Duration,
     pub backfill_page_delay: Duration,
     pub backfill_max_pages: usize,
+    pub backfill_max_retries: u32,
     pub plc_directory: Option<String>,
 }
 
@@ -120,6 +121,7 @@ impl Config {
             )?),
             backfill_page_delay: Duration::from_millis(parse("LENS_BOOTSTRAP_PAGE_DELAY_MS", 150)?),
             backfill_max_pages: parse("LENS_BOOTSTRAP_MAX_PAGES", 600)?,
+            backfill_max_retries: parse("LENS_BOOTSTRAP_MAX_RETRIES", 4)?,
             plc_directory: optional("LENS_BOOTSTRAP_PLC_DIRECTORY"),
         })
     }

--- a/crates/graze-lens-builder/src/lib.rs
+++ b/crates/graze-lens-builder/src/lib.rs
@@ -6,7 +6,6 @@
 //! for an hour and feeds keep serving, unlensed.
 
 pub mod builder;
-pub mod completeness;
 pub mod config;
 pub mod interner;
 pub mod queue;
@@ -14,7 +13,8 @@ pub mod scored;
 pub mod second_degree;
 
 pub use builder::{BuildOutcome, Builder};
-pub use completeness::CompletenessStore;
+// Re-exported from graze-lens-bootstrap, where the backfill it records lives.
 pub use config::Config;
+pub use graze_lens_bootstrap::CompletenessStore;
 pub use interner::Interner;
 pub use queue::{BuildRequest, Delivery, Queue};

--- a/kube/lens-bootstrap-hop1-job.yaml
+++ b/kube/lens-bootstrap-hop1-job.yaml
@@ -52,7 +52,7 @@ spec:
         - name: bootstrap
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:fba7efdda8fdc929fc5318f3df530ef41ec42d1b127c2d8039faff15fa901b62
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:7dbb7c38aba0e165aebb93d9f0bf0d4d9b8ee8e5a291f5123acf867c18d035f7
           command: ["/app/graze-lens-bootstrap"]
           args: ["--file", "/config/dids.txt"]
           resources:
@@ -78,8 +78,14 @@ spec:
             # hub rather than a person: its follows add reach noise to second
             # degree and cost minutes each to page. Capping is a feature here,
             # not a compromise -- the design wanted hub-capping anyway.
+            # The code default, deliberately not the 50 this job first ran with.
+            # A run that stops at max_pages returns a PREFIX of an account's
+            # follows, and truncated accounts are now left without a completeness
+            # marker on purpose — so a low cap does not just truncate the biggest
+            # graphs, it condemns exactly those accounts to being re-walked from
+            # their PDS on every lens request, forever.
             - name: LENS_BOOTSTRAP_MAX_PAGES
-              value: "50"
+              value: "600"
             - name: RUST_LOG
               value: "info"
           volumeMounts:

--- a/kube/lens-bootstrap-hop1-remaining-job.yaml
+++ b/kube/lens-bootstrap-hop1-remaining-job.yaml
@@ -1,0 +1,133 @@
+# graze-lens-bootstrap-hop1-remaining — the repair pass over accounts the full
+# cohort run could not read.
+#
+# Split out from the full-cohort Job rather than re-running that one, for two
+# reasons. Re-walking 9,423 accounts to reach ~2,800 puts thousands of pointless
+# requests on other people's PDS hosts. And the accounts that need this pass are
+# precisely the ones that rate-limited us last time, so hitting them alongside
+# everything else is how they got starved in the first place.
+#
+# Concurrency is halved and the page delay raised against the full-cohort
+# settings: that run pushed 2,520 accounts into 429s and recorded them all as
+# failures, when nothing was wrong with the accounts and we had simply asked too
+# fast. Paired with the retry/backoff in the backfiller, this pass saw 181.
+#
+# The DID list is generated, not hand-maintained:
+#   cohort DIDs  MINUS  viewers in lens_backfill_state with edge_count > 0
+# then loaded with `kubectl create configmap --from-file` — NOT `apply`, whose
+# last-applied annotation runs into the 256KB annotation limit on a list this
+# size.
+# graze-lens-bootstrap — backfills historical follow edges for a set of accounts.
+#
+# `graze-lens-fold` only sees follows from the moment it connects; this fills in
+# the history behind it, reading each account's follow records from its PDS.
+#
+# IDEMPOTENT. Rows are versioned by the record's own TID, so re-running writes
+# identical (follower, rkey, seq) tuples and ReplacingMergeTree collapses them.
+# Re-run freely — that is also the recovery procedure.
+#
+# Prereqs (created out of band):
+#   * secret `app-secrets` — CLICKHOUSE_{HOST,USER,PASSWORD}
+#   * ClickHouse tables — `feed-processor/scripts/create_follow_edges_tables.py`
+#   * ConfigMap `graze-beta-cohort` (key `dids.txt`) — the shared beta cohort,
+#     not a lens-specific list. Source of truth is `cohorts/beta.txt`; see its
+#     header for how to regenerate the ConfigMap after editing.
+#
+# Scope note: this is the per-account path, and it is what M0 needs — it covers
+# exactly the accounts that asked for a lens, over public unauthenticated
+# endpoints. Warming the *global* graph is a different job, blocked on a
+# bsky.network archive token plus a decoder for the .jss segment format; when
+# that lands, this remains the repair path for history the archive predates.
+#
+# Dry run first on a new DID list:
+#   kubectl set env job/graze-lens-bootstrap LENS_BOOTSTRAP_DRY_RUN=true
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: graze-lens-bootstrap-hop1-remaining
+  labels:
+    app: graze-lens
+    component: bootstrap
+spec:
+  # No retries. The job is re-runnable by hand, and an automatic retry of a
+  # partially-succeeded backfill just re-walks every PDS for no benefit.
+  backoffLimit: 0
+  # ~4h ceiling: a 50k-follow account is ~500 paged requests, and the default
+  # concurrency of 4 is deliberately polite to other people's servers.
+  activeDeadlineSeconds: 21600
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: graze-lens
+        component: bootstrap
+    spec:
+      restartPolicy: Never
+      # Required: the default service account carries no pull secrets, so
+      # without this the pod fails with ImagePullBackOff against DOCR.
+      imagePullSecrets:
+        - name: docr-graze-social-labs
+      containers:
+        - name: bootstrap
+          # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
+          # the short-SHA tag are mutable on DOCR.
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:a2323c023a77806943dd99379932e363829cb276eb9338e3770261d5d67133f0
+          command: ["/app/graze-lens-bootstrap"]
+          args: ["--file", "/config/dids.txt"]
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              # Edges buffer in memory until a batch fills; a very large DID list
+              # of whales is the case that needs the headroom.
+              memory: "2Gi"
+              cpu: "1"
+          envFrom:
+            - secretRef:
+                name: app-secrets
+          env:
+            # Halved, and paired with retry/backoff. The full-cohort run at 12
+            # rate-limited itself into 2,520 self-inflicted 429s.
+            - name: LENS_BOOTSTRAP_CONCURRENCY
+              value: "6"
+            - name: LENS_BOOTSTRAP_PAGE_DELAY_MS
+              value: "250"
+            - name: LENS_BOOTSTRAP_MAX_RETRIES
+              value: "5"
+            - name: LENS_BOOTSTRAP_INSERT_BATCH
+              value: "20000"
+            # Hub cap. 50 pages = 5,000 follows, past which an account is a
+            # hub rather than a person: its follows add reach noise to second
+            # degree and cost minutes each to page. Capping is a feature here,
+            # not a compromise -- the design wanted hub-capping anyway.
+            # The code default, deliberately not the 50 this job first ran with.
+            # A run that stops at max_pages returns a PREFIX of an account's
+            # follows, and truncated accounts are now left without a completeness
+            # marker on purpose — so a low cap does not just truncate the biggest
+            # graphs, it condemns exactly those accounts to being re-walked from
+            # their PDS on every lens request, forever.
+            - name: LENS_BOOTSTRAP_MAX_PAGES
+              value: "600"
+            - name: RUST_LOG
+              value: "info"
+          volumeMounts:
+            - name: dids
+              mountPath: /config
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      securityContext:
+        # Numeric, not a name: distroless nonroot has no /etc/passwd entry.
+        runAsUser: 65532
+        runAsGroup: 65532
+      volumes:
+        - name: dids
+          configMap:
+            # The shared beta cohort, so "who is in the beta" stays one decision
+            # in one place rather than a per-feature allowlist.
+            name: lens-hop1-remaining

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:03f7834205eb6b259b49297131e5586c785e4ea3a72d946aa9f9478d22dc013a
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:7dbb7c38aba0e165aebb93d9f0bf0d4d9b8ee8e5a291f5123acf867c18d035f7
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               # Built from commit 1a835eb (feat/lens-completeness-guard).
               # Digest-pinned: both `latest` and the short-SHA tag are mutable
               # on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:03f7834205eb6b259b49297131e5586c785e4ea3a72d946aa9f9478d22dc013a
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:7dbb7c38aba0e165aebb93d9f0bf0d4d9b8ee8e5a291f5123acf867c18d035f7
               command: ["/app/graze-lens-project"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: rev-rebuild
               # Built from commit 1a835eb (feat/lens-completeness-guard). Digest-pinned:
               # both `latest` and the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:03f7834205eb6b259b49297131e5586c785e4ea3a72d946aa9f9478d22dc013a
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:7dbb7c38aba0e165aebb93d9f0bf0d4d9b8ee8e5a291f5123acf867c18d035f7
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:


### PR DESCRIPTION
Found by asking why a successful-looking bootstrap Job had left only **6**
completeness markers behind.

## The bulk Job never wrote markers at all

Only the builder's inline repair path did. So a 9,423-account run left 6 markers,
and every one of those accounts was due a full PDS re-walk the first time it asked
for a lens — the bulk warming bought the cohort nothing but a slow first request
each, and put 9,423 needless walks on other people's servers.

## Both paths marked a *truncated* backfill complete

The worse one. Stopping at `max_pages` yields a prefix of an account's follows,
not their graph, and a marker makes that prefix permanent: every later build
trusts it and skips the walk. It is the original silent-wrong-lens bug wearing a
disguise, and harder to spot because the backfill genuinely ran. The hop-1 Job ran
with `max_pages=50` against a default of 600 — truncating at 5,000 edges, on
exactly the accounts whose graphs matter most. Truncated results are now left
unmarked.

## Ordering

Markers are written only after the batch carrying an account's edges is durable.
Marking on task completion would race the flush; a crash in between leaves a
marker whose edges were never written, which the next build trusts — skipping the
backfill to publish a lens from a graph that does not exist. Precisely the failure
the marker was introduced to prevent.

## Backing off instead of blaming the accounts

Re-running uncapped rate-limited us against the shared bsky.network hosts: 2,520
of 2,534 "failures" were 429s. Nothing was wrong with those accounts — we asked
too fast and then recorded our own impatience as their problem. Pages are now
retried on 429/5xx honouring `Retry-After`, capped at 30s so one loaded host
cannot hold a worker while thousands of accounts queue behind it.

## Result

| | before | after |
|---|---|---|
| completeness markers | 6 | **8,868** of 9,423 (94.1%) |
| follow edges | 4,890,378 | 7,836,550 |
| largest marked graph | 35,092 | 42,969 |
| 429 failures per run | 2,520 | 181 |

The 555 still unmarked are accounted for: **525 have no edges at all** (deleted,
deactivated, or follow nobody) and are correctly unmarked, since a zero-edge row
was never evidence of a usable backfill; the remaining **35** are partial reads
that hit a 429 mid-pagination — exactly the case that must not be marked.

`CompletenessStore` moves to `graze-lens-bootstrap`, where the backfill it records
lives, and gains a batched writer: one INSERT per account across thousands is the
tiny-insert pattern that drives this cluster's cost. `backfilled_at` is sent
explicitly because it is the ReplacingMergeTree version column with no DEFAULT —
omitting it writes epoch zero, destroying the audit trail and losing every dedup
race for that viewer.