### PR TITLE
Add winsorized scroll depth as a denser secondary outcome

### DIFF
--- a/analysis/experiments/follow_seed.yaml
+++ b/analysis/experiments/follow_seed.yaml
@@ -60,6 +60,21 @@ guardrails:
   - metric: request_less_rate
     max: 0.0
 
+# Denser secondary outcome. The primary is starved -- ~1,065 likes against 31,182 impressions -- so
+# impressions-per-user is reported alongside it. Density alone does not buy power here: raw, its MDE
+# is ~31% of the mean, because 3.3% of users carry 36% of all impressions. Winsorizing at p90 takes
+# that to ~14%.
+#
+# The quantile is declared HERE, up front. It changes the estimand to a capped mean and must not be
+# tuned after seeing a result. The cap is pooled across both arms; a per-arm cap would itself be an
+# outcome of the treatment.
+#
+# SECONDARY, deliberately: more scrolling is not unambiguously better. Zero-seed users were measured
+# paginating at a ~1s cadence, which is scanning, not reading. Treat a move here as a prompt to
+# investigate rather than a result.
+scroll_depth:
+  winsorize_quantile: 0.90
+
 cuped_covariate: pre_period_like_rate
 
 # REQUIRED, and not merely for the usual foreign-traffic reason. An absent JSON field extracts as

--- a/analysis/experiments/personalization_holdout.yaml
+++ b/analysis/experiments/personalization_holdout.yaml
@@ -76,6 +76,21 @@ guardrails:
   - metric: request_less_rate
     max: 0.0
 
+# Denser secondary outcome. The primary is starved -- ~1,065 likes against 31,182 impressions -- so
+# impressions-per-user is reported alongside it. Density alone does not buy power here: raw, its MDE
+# is ~31% of the mean, because 3.3% of users carry 36% of all impressions. Winsorizing at p90 takes
+# that to ~14%.
+#
+# The quantile is declared HERE, up front. It changes the estimand to a capped mean and must not be
+# tuned after seeing a result. The cap is pooled across both arms; a per-arm cap would itself be an
+# outcome of the treatment.
+#
+# SECONDARY, deliberately: more scrolling is not unambiguously better. Zero-seed users were measured
+# paginating at a ~1s cadence, which is scanning, not reading. Treat a move here as a prompt to
+# investigate rather than a result.
+scroll_depth:
+  winsorize_quantile: 0.90
+
 cuped_covariate: pre_period_like_rate
 
 population: "JSONHas(tryBase64Decode(interaction_feed_context), 'algo_id')"

--- a/analysis/graze_analysis/data.py
+++ b/analysis/graze_analysis/data.py
@@ -237,3 +237,52 @@ def rows_from_ab_result(
         numerator=np.array(num, dtype=float),
         denominator=np.array(den, dtype=float),
     )
+
+
+def scroll_depth_sql(spec: ExperimentSpec, quantile: float) -> str:
+    """One row per (unit, arm) carrying that unit's winsorized impression count.
+
+    Shaped as numerator/denominator with a denominator of 1 so the same cluster-robust estimator can
+    consume it: with one row per unit the "rate" is simply the capped count, and the clustered SE
+    reduces to the ordinary one.
+
+    The cap is a POOLED quantile across both arms. Capping per arm would make the cap itself an
+    outcome of the treatment and bias the comparison by construction.
+    """
+    control = spec.arms["control"]
+    treatment = next(a for n, a in spec.arms.items() if n != "control")
+    decoded = "tryBase64Decode(interaction_feed_context)"
+    kind = "Bool" if isinstance(control.value, bool) else "Int"
+    arm_expr = _json_path_expr(decoded, control.field, kind)
+    unit_col = "did" if spec.unit == "user" else "concat(did, '|', toString(occurred))"
+    end_clause = f"AND occurred <= toDateTime('{spec.end:%Y-%m-%d %H:%M:%S}')" if spec.end else ""
+    population = f"AND ({spec.population})" if spec.population else ""
+
+    return f"""
+WITH u AS (
+  SELECT
+    {unit_col} AS unit_id,
+    {arm_expr} AS arm_value,
+    count() AS impressions
+  FROM default.feed_interactions
+  WHERE occurred >= toDateTime('{spec.start:%Y-%m-%d %H:%M:%S}')
+    {end_clause}
+    AND interaction_feed_context != ''
+    {population}
+    AND interaction_event = '{SEEN}'
+  GROUP BY unit_id, arm_value
+  HAVING impressions > 0
+),
+cap AS (
+  SELECT quantile({quantile})(impressions) AS c
+  FROM u
+  WHERE arm_value IN ({_sql_literal(control.value)}, {_sql_literal(treatment.value)})
+)
+SELECT
+  unit_id,
+  arm_value,
+  least(toFloat64(impressions), (SELECT c FROM cap)) AS likes,
+  1 AS seen
+FROM u
+WHERE arm_value IN ({_sql_literal(control.value)}, {_sql_literal(treatment.value)})
+"""

--- a/analysis/graze_analysis/runner.py
+++ b/analysis/graze_analysis/runner.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from .data import (
     METRIC_EVENTS,
+    scroll_depth_sql,
     ClickHouseReader,
     ab_rows_sql,
     cuped_covariate_sql,
@@ -110,6 +111,7 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
         _, reduction = cuped_adjust(per_unit_rate, cov)
         lines.append(f"  CUPED variance reduction: {reduction:.1%}")
 
+    lines.extend(_scroll_depth_lines(spec, reader))
     lines.extend(_guardrail_lines(spec, reader))
 
     agree = primary.significant == (perm.p_value < 0.05)
@@ -119,6 +121,32 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
         "NOT SIGNIFICANT"
     )
     return Readout(spec.id, verdict, lines)
+
+
+def _scroll_depth_lines(spec: ExperimentSpec, reader: ClickHouseReader) -> list[str]:
+    """Winsorized impressions-per-user, reported ALONGSIDE the primary and never in place of it.
+
+    It exists because the primary is starved: ~1,065 likes against 31,182 impressions. But density
+    is not power on its own -- raw impressions/user has an MDE of ~31% of the mean because 3.3% of
+    users carry 36% of the impressions. Winsorizing at the declared quantile is what makes it
+    usable, taking the MDE to roughly 14-18%.
+
+    This is a SECONDARY outcome. More scrolling is not unambiguously better: this codebase already
+    measured zero-seed users paginating at a ~1s cadence, which is scanning rather than reading. A
+    move here is a prompt to investigate, not a result on its own.
+    """
+    if spec.scroll_depth is None:
+        return []
+    q = spec.scroll_depth.winsorize_quantile
+    rows = rows_from_ab_result(reader.query(scroll_depth_sql(spec, q)), spec)
+    if len(rows) == 0:
+        return [f"  scroll_depth (winsorized p{int(q * 100)}): no rows"]
+    est = cluster_robust_rate_diff(rows.unit_ids, rows.arm, rows.numerator, rows.denominator)
+    return [
+        f"  scroll_depth (winsorized p{int(q * 100)}, impressions/user): {est.describe()}",
+        f"    (secondary outcome; cap declared in the spec, pooled across arms, "
+        f"units={len(rows):,})",
+    ]
 
 
 def _guardrail_lines(spec: ExperimentSpec, reader: ClickHouseReader) -> list[str]:

--- a/analysis/graze_analysis/spec.py
+++ b/analysis/graze_analysis/spec.py
@@ -72,6 +72,28 @@ class NegativeControl:
 
 
 @dataclass(frozen=True)
+class ScrollDepth:
+    """Winsorized impressions-per-user: a denser secondary outcome than a like rate.
+
+    Measured 2026-08-30: impressions are ~29x denser than likes (31,182 against 1,065), but density
+    alone buys almost nothing here because the variance scales with it -- sd 41 on a mean of 19 with
+    a median of 7, and 3.3% of users carrying 36% of all impressions. Raw, its minimum detectable
+    effect is ~31% of the mean.
+
+    Winsorizing caps how much any single user can move the estimate. Measured on the same data:
+    p95 takes the MDE to 18%, p90 to 14%. That is legitimate variance reduction, not a trick -- but
+    it changes the estimand to a *capped* mean, so the quantile is declared here in the spec and must
+    NOT be tuned after seeing a result.
+
+    The cap is computed across BOTH arms pooled. A per-arm cap would differ between arms and bias
+    the comparison by construction.
+    """
+
+    #: Quantile at which per-user impressions are capped. 0.90 was the measured sweet spot.
+    winsorize_quantile: float = 0.90
+
+
+@dataclass(frozen=True)
 class Guardrail:
     """A metric that must not regress, independent of the primary outcome."""
 
@@ -93,6 +115,8 @@ class ExperimentSpec:
     negative_controls: tuple[NegativeControl, ...]
     end: _dt.datetime | None = None
     guardrails: tuple[Guardrail, ...] = ()
+    #: Optional denser secondary outcome. Reported alongside the primary, never in place of it.
+    scroll_depth: ScrollDepth | None = None
     cuped_covariate: str | None = None
     post_treatment_fields: tuple[str, ...] = DEFAULT_POST_TREATMENT_FIELDS
     #: SQL restricting rows to the population the experiment can possibly apply to.
@@ -192,6 +216,15 @@ def spec_from_dict(raw: dict[str, Any], source: str = "<dict>") -> ExperimentSpe
         Guardrail(metric=g["metric"], max=g.get("max"), min=g.get("min"))
         for g in raw.get("guardrails", [])
     )
+    # `is not None`, not truthiness: an empty `scroll_depth:` block in YAML parses to `{}`, which is
+    # falsy, so a truthiness check would silently disable the metric for someone who had explicitly
+    # asked for it with defaults. Declaring the key means on.
+    sd_raw = raw.get("scroll_depth")
+    scroll_depth = (
+        ScrollDepth(winsorize_quantile=float((sd_raw or {}).get("winsorize_quantile", 0.90)))
+        if sd_raw is not None
+        else None
+    )
 
     return ExperimentSpec(
         id=str(require("id")),
@@ -203,6 +236,7 @@ def spec_from_dict(raw: dict[str, Any], source: str = "<dict>") -> ExperimentSpe
         arms=arms,
         negative_controls=controls,
         guardrails=guardrails,
+        scroll_depth=scroll_depth,
         cuped_covariate=raw.get("cuped_covariate"),
         population=raw.get("population"),
         post_treatment_fields=tuple(

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:3bcd3c2630886ca5ef935685d43c84bb836745898ac250c0ea66fe61ae00596e
+              image: dgaff/graze-analysis@sha256:c7557ee198451aa4f613df4a6ac294bf889a0af07c7d7ecb5dc1c52197000964
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job

--- a/analysis/kube/coverage-cronjob.yaml
+++ b/analysis/kube/coverage-cronjob.yaml
@@ -210,7 +210,7 @@ spec:
                 name: personalization-coverage-src
           containers:
             - name: coverage
-              image: dgaff/graze-analysis@sha256:3bcd3c2630886ca5ef935685d43c84bb836745898ac250c0ea66fe61ae00596e
+              image: dgaff/graze-analysis@sha256:c7557ee198451aa4f613df4a6ac294bf889a0af07c7d7ecb5dc1c52197000964
               command: ["python", "/src/coverage.py"]
               volumeMounts:
                 - name: src

--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -145,7 +145,7 @@ spec:
                 name: personalization-dose-check-src
           containers:
             - name: dose
-              image: dgaff/graze-analysis@sha256:3bcd3c2630886ca5ef935685d43c84bb836745898ac250c0ea66fe61ae00596e
+              image: dgaff/graze-analysis@sha256:c7557ee198451aa4f613df4a6ac294bf889a0af07c7d7ecb5dc1c52197000964
               command: ["python", "/src/dose.py"]
               volumeMounts:
                 - name: src

--- a/analysis/tests/test_runner_gates.py
+++ b/analysis/tests/test_runner_gates.py
@@ -237,3 +237,56 @@ def test_contract_handles_nested_params_paths():
     assert not field_is_present("params.not_written", top, nested)
     # A nested path under anything other than `params` is a spec error, not a lookup.
     assert not field_is_present("source.nope", {"source"}, {"nope"})
+
+
+def _scroll_spec(**over):
+    return _spec(scroll_depth={"winsorize_quantile": 0.9}, **over)
+
+
+def _scroll_spec_from(sd):
+    """Same base spec, with an arbitrary scroll_depth block."""
+    return _spec(scroll_depth=sd)
+
+
+def test_scroll_depth_is_parsed_and_defaults_are_explicit():
+    s = _scroll_spec()
+    assert s.scroll_depth is not None
+    assert s.scroll_depth.winsorize_quantile == 0.9
+    # Absent means absent -- it must not silently default to being on.
+    assert _spec().scroll_depth is None
+    # An empty dict still gets the documented default rather than crashing.
+    assert _scroll_spec_from(dict()).scroll_depth.winsorize_quantile == 0.9
+
+
+def test_scroll_depth_sql_pools_the_cap_across_arms():
+    """A per-arm cap would itself be an outcome of the treatment and bias the comparison."""
+    from graze_analysis.data import scroll_depth_sql
+
+    sql = scroll_depth_sql(_scroll_spec(), 0.9)
+    cap = sql[sql.index("cap AS ("): sql.index("SELECT\n  unit_id")]
+    assert "quantile(0.9)" in cap
+    assert "arm_value IN (10000, 250)" in cap, "cap must be computed over BOTH arms"
+    # The cast matters: least() on UInt64 and Float64 is an illegal-type error in ClickHouse.
+    assert "least(toFloat64(impressions)" in sql
+    # One row per unit, so the clustered SE reduces to the ordinary one.
+    assert "1 AS seen" in sql
+
+
+def test_scroll_depth_is_reported_but_never_replaces_the_primary():
+    primary = _rows(150, 1, 20, 10000) + _rows(150, 3, 20, 250)
+    control = _rows(150, 1, 20, 10000) + _rows(150, 1, 20, 250)
+    scroll = _rows(150, 8, 1, 10000) + _rows(150, 14, 1, 250)
+
+    class R:
+        def query(self, sql):
+            if "cap AS (" in sql:
+                return scroll
+            return primary if "source = 'fallback'" not in sql else control
+
+    readout = analyse_ab(_scroll_spec(), R())
+    joined = "\n".join(readout.lines)
+    assert "scroll_depth (winsorized p90" in joined, joined
+    assert "secondary outcome" in joined, joined
+    # The primary must still be present and still first.
+    assert any("primary" in line for line in readout.lines)
+    assert readout.lines[0].strip().startswith("primary")


### PR DESCRIPTION
`like_rate` is starved: **~1,065 likes against 31,182 impressions**. Impressions-per-user is 29× denser — but density alone buys almost nothing here.

## Why raw impressions do not work

Raw, the MDE is **~31% of the mean**: sd is 41 on a mean of 19 with a **median of 7**, and **3.3% of users carry 36% of all impressions**.

## What winsorizing buys, measured on live data

| | SE | MDE |
|---|---:|---:|
| no cap | 2.16 | 6.04 impressions/user (**31%** of control mean) |
| cap p95 | 1.01 | 2.84 (**18%**) |
| **cap p90** | **0.65** | **1.81 (14%)** |

The quantile is **declared in the spec**, not chosen after seeing a result — it changes the estimand to a capped mean, so tuning it post hoc is exactly the kind of choice this repo's other gates exist to prevent. The cap is **pooled across both arms**; a per-arm cap would itself be an outcome of the treatment.

Reported as **secondary**, never in place of the primary. More scrolling is not unambiguously better — this codebase already measured zero-seed users paginating at a ~1s cadence, which is scanning rather than reading.

## Two things found while building it

- **`interaction_request_id` and `impression_id` are both degenerate** — exactly one distinct value across 31,188 rows. Page counts are **not recoverable from the schema**, so "did they ask for page 2" is not currently answerable. Populating either would open session-level metrics.
- An empty `scroll_depth:` block in YAML parses to `{}`, which is **falsy**. A truthiness check would have silently disabled the metric for someone who explicitly asked for it with defaults, so parsing tests `is not None`. A test pins this.

68 analysis tests passing (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)