### PR TITLE
The lens facet family: priors, velocity, and communities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ COPY --from=builder /app/target/release/graze-lens-bootstrap /app/graze-lens-boo
 # on a schedule, as an OCI "no such file or directory" nobody is watching for.
 COPY --from=builder /app/target/release/graze-lens-rev-rebuild /app/graze-lens-rev-rebuild
 COPY --from=builder /app/target/release/graze-lens-project /app/graze-lens-project
+COPY --from=builder /app/target/release/graze-lens-lpa /app/graze-lens-lpa
 COPY --from=builder /app/target/release/graze-migrate-tranches /app/graze-migrate-tranches
 COPY --from=builder /app/target/release/graze-migrate-dates /app/graze-migrate-dates
 COPY --from=builder /app/target/release/graze-verify-migration /app/graze-verify-migration

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -19,6 +19,7 @@ use tracing::{debug, info, warn};
 
 use crate::config::Config;
 use crate::interner::Interner;
+use crate::priors;
 use crate::second_degree;
 use graze_lens_bootstrap::CompletenessStore;
 use graze_lens_bootstrap::{Backfiller, Resolver};
@@ -33,6 +34,10 @@ const ACTIVE_KEY: &str = "lens:active";
 /// builds a key nobody reads.
 pub const FACET_FOLLOWS: &str = "follows";
 pub const FACET_FOLLOWS2: &str = "follows2";
+pub const FACET_NICHE: &str = "niche";
+pub const FACET_POPULAR: &str = "popular";
+pub const FACET_VELOCITY: &str = "velocity";
+pub const FACET_COMMUNITY: &str = "community";
 
 /// Facets this builder can actually produce.
 ///
@@ -40,7 +45,29 @@ pub const FACET_FOLLOWS2: &str = "follows2";
 /// reader composes from these two, so it is a legal thing to ask a feed for and
 /// an illegal thing to ask the builder for.
 pub fn is_buildable_facet(facet: &str) -> bool {
-    matches!(facet, FACET_FOLLOWS | FACET_FOLLOWS2)
+    matches!(
+        facet,
+        FACET_FOLLOWS
+            | FACET_FOLLOWS2
+            | FACET_NICHE
+            | FACET_POPULAR
+            | FACET_VELOCITY
+            | FACET_COMMUNITY
+    )
+}
+
+/// The header byte for each stored facet name. One place, so the dispatch and
+/// the wire format cannot disagree.
+fn facet_header_id(name: &str) -> Option<u8> {
+    match name {
+        FACET_FOLLOWS => Some(crate::scored::FACET_FOLLOWS),
+        FACET_FOLLOWS2 => Some(crate::scored::FACET_FOLLOWS2),
+        FACET_NICHE => Some(crate::scored::FACET_NICHE),
+        FACET_POPULAR => Some(crate::scored::FACET_POPULAR),
+        FACET_VELOCITY => Some(crate::scored::FACET_VELOCITY),
+        FACET_COMMUNITY => Some(crate::scored::FACET_COMMUNITY),
+        _ => None,
+    }
 }
 
 fn now_secs() -> u32 {
@@ -382,6 +409,12 @@ impl Builder {
                     "max_execution_time",
                     self.config.max_execution_seconds.to_string(),
                 ),
+                // Seed lists are inlined as literals — required for primary-key
+                // index analysis — and a whale's 50k follows is ~450 KB of SQL,
+                // over ClickHouse's 256 KB default parse budget. "Any user at
+                // any scale" means the parser budget scales with the whale, not
+                // the whale failing to build.
+                ("max_query_size", "10485760".to_string()),
                 ("cancel_http_readonly_queries_on_client_close", "1".into()),
             ])
             .body(sql.to_string())
@@ -488,12 +521,180 @@ impl Builder {
         facet: &str,
         followees: &[String],
     ) -> anyhow::Result<BuildOutcome> {
-        if facet == FACET_FOLLOWS2 {
-            return self.publish_second_degree(viewer, followees).await;
+        // Exhaustive on purpose. A fallthrough here once published a viewer's
+        // FIRST degree under the second-degree name; with six facets the same
+        // slip would be six ways to serve the wrong signal under a plausible
+        // count. An unmatched name is a bug upstream — is_buildable_facet
+        // admitted something this dispatch does not know.
+        match facet {
+            FACET_FOLLOWS => {
+                self.publish(viewer, facet, followees).await?;
+                self.publish_v2_uniform(viewer, facet, followees).await;
+                Ok(BuildOutcome::Published)
+            }
+            FACET_FOLLOWS2 => self.publish_second_degree(viewer, followees).await,
+            FACET_NICHE => {
+                self.publish_prior(viewer, followees, priors::Prior::Niche)
+                    .await
+            }
+            FACET_POPULAR => {
+                self.publish_prior(viewer, followees, priors::Prior::Popular)
+                    .await
+            }
+            FACET_VELOCITY => self.publish_velocity(viewer, followees).await,
+            FACET_COMMUNITY => self.publish_community(viewer, followees).await,
+            other => {
+                warn!(viewer, facet = other, "facet admitted but not dispatched");
+                Ok(BuildOutcome::UnknownFacet)
+            }
         }
-        self.publish(viewer, facet, followees).await?;
-        self.publish_v2_uniform(viewer, facet, followees).await;
+    }
+
+    /// Seeds for any graph facet: the viewer's follows, as lens-space ids.
+    async fn seeds_for(&self, viewer: &str, first_degree: &[String]) -> anyhow::Result<Vec<u32>> {
+        let Some(interner) = &self.interner else {
+            anyhow::bail!("no interner configured");
+        };
+        let ids = interner.intern_many(first_degree).await?;
+        let _ = viewer;
+        Ok(ids.values().copied().collect())
+    }
+
+    /// Shared tail for every scored facet: sanity-check, encode, publish.
+    async fn publish_scored(
+        &self,
+        viewer: &str,
+        facet_name: &str,
+        map: second_degree::SecondDegree,
+        seeds: &[u32],
+    ) -> anyhow::Result<BuildOutcome> {
+        let Some(interner) = &self.interner else {
+            self.mark_state(viewer, "failed").await?;
+            return Ok(BuildOutcome::NeedsBackfill);
+        };
+        if map.is_empty() {
+            self.mark_state(viewer, "ready").await?;
+            return Ok(BuildOutcome::Empty);
+        }
+        // The invariant that caught a corrupt id map once already: an author
+        // cannot be reached by more of your follows than you have.
+        if (map.max_reach as usize) > seeds.len() {
+            self.mark_state(viewer, "failed").await?;
+            anyhow::bail!(
+                "{facet_name}: max_reach {} exceeds {} seeds — id map or projection corrupt",
+                map.max_reach,
+                seeds.len()
+            );
+        }
+        let Some(header_id) = facet_header_id(facet_name) else {
+            anyhow::bail!("{facet_name} has no header id; dispatch and wire format disagree");
+        };
+        let blob = map.encode_as(header_id, interner.idspace(), now_secs());
+        info!(
+            viewer,
+            facet = facet_name,
+            seeds = seeds.len(),
+            reached = map.all_ids.len(),
+            scored = map.entries.len(),
+            max_reach = map.max_reach,
+            bytes = blob.len(),
+            "built scored facet"
+        );
+        self.publish_blob(viewer, facet_name, &blob).await?;
         Ok(BuildOutcome::Published)
+    }
+
+    /// niche / popular: reach reweighted by global fame from `account_stats`.
+    async fn publish_prior(
+        &self,
+        viewer: &str,
+        first_degree: &[String],
+        prior: priors::Prior,
+    ) -> anyhow::Result<BuildOutcome> {
+        let facet_name = match prior {
+            priors::Prior::Niche => FACET_NICHE,
+            priors::Prior::Popular => FACET_POPULAR,
+        };
+        let seeds = self.seeds_for(viewer, first_degree).await?;
+        if seeds.is_empty() {
+            self.mark_state(viewer, "ready").await?;
+            return Ok(BuildOutcome::Empty);
+        }
+        let sql = priors::prior_reach_query(
+            &self.clickhouse.database,
+            &seeds,
+            self.config.second_degree_cap,
+            prior,
+        );
+        let text = self.query_text(&sql).await?;
+        let mut map = priors::parse_prior_tsv(&text, self.config.second_degree_top_k);
+        second_degree::exclude_first_degree(&mut map, &seeds);
+        self.publish_scored(viewer, facet_name, map, &seeds).await
+    }
+
+    /// velocity: reach over the recency slice only.
+    async fn publish_velocity(
+        &self,
+        viewer: &str,
+        first_degree: &[String],
+    ) -> anyhow::Result<BuildOutcome> {
+        let seeds = self.seeds_for(viewer, first_degree).await?;
+        if seeds.is_empty() {
+            self.mark_state(viewer, "ready").await?;
+            return Ok(BuildOutcome::Empty);
+        }
+        let sql = priors::velocity_query(
+            &self.clickhouse.database,
+            &seeds,
+            self.config.second_degree_cap,
+            self.config.velocity_days,
+        );
+        let text = self.query_text(&sql).await?;
+        let mut map = second_degree::parse_reach_tsv(&text, self.config.second_degree_top_k);
+        second_degree::exclude_first_degree(&mut map, &seeds);
+        self.publish_scored(viewer, FACET_VELOCITY, map, &seeds)
+            .await
+    }
+
+    /// community: members of the viewer's top LPA communities.
+    async fn publish_community(
+        &self,
+        viewer: &str,
+        first_degree: &[String],
+    ) -> anyhow::Result<BuildOutcome> {
+        let seeds = self.seeds_for(viewer, first_degree).await?;
+        if seeds.is_empty() {
+            self.mark_state(viewer, "ready").await?;
+            return Ok(BuildOutcome::Empty);
+        }
+        let affinity_sql = priors::community_affinity_query(
+            &self.clickhouse.database,
+            &seeds,
+            self.config.community_top,
+        );
+        let affinity =
+            priors::parse_affinity_tsv(&self.query_text(&affinity_sql).await?, seeds.len());
+        if affinity.is_empty() {
+            // No LPA labels yet (job has not run) or none of the follows are
+            // labelled. Ready-and-empty, not failed: the serve path falls open
+            // and the next scheduled build picks the labels up.
+            self.mark_state(viewer, "ready").await?;
+            return Ok(BuildOutcome::Empty);
+        }
+        let communities: Vec<u32> = affinity.iter().map(|(c, _)| *c).collect();
+        let members_sql = priors::community_members_query(
+            &self.clickhouse.database,
+            &communities,
+            self.config.second_degree_cap,
+        );
+        let mut map = priors::parse_members_tsv(
+            &self.query_text(&members_sql).await?,
+            &affinity,
+            self.config.second_degree_top_k,
+        );
+        second_degree::exclude_first_degree(&mut map, &seeds);
+        self.publish_scored(viewer, FACET_COMMUNITY, map, &seeds)
+            .await
     }
 
     async fn fetch_follows(&self, viewer: &str) -> anyhow::Result<Vec<String>> {
@@ -597,15 +798,42 @@ mod tests {
     /// publish a first-degree set under a name that promises a blend.
     #[test]
     fn only_real_facets_are_buildable() {
-        assert!(is_buildable_facet(FACET_FOLLOWS));
-        assert!(is_buildable_facet(FACET_FOLLOWS2));
-        assert!(
-            !is_buildable_facet("network"),
-            "network is composed by the reader, not built here"
-        );
+        for f in [
+            FACET_FOLLOWS,
+            FACET_FOLLOWS2,
+            FACET_NICHE,
+            FACET_POPULAR,
+            FACET_VELOCITY,
+            FACET_COMMUNITY,
+        ] {
+            assert!(is_buildable_facet(f), "{f} should build");
+        }
+        // Composites are composed by the reader from stored facets; a build
+        // request for one is a bug, and accepting it would publish first
+        // degree under a name that promises a blend.
+        assert!(!is_buildable_facet("network"));
+        assert!(!is_buildable_facet("discover"));
         assert!(!is_buildable_facet("mutuals"), "not implemented yet");
         assert!(!is_buildable_facet(""));
         assert!(!is_buildable_facet("FOLLOWS"), "matching is exact");
+    }
+
+    /// Facet header ids must be distinct — a collision would let the reader
+    /// accept a blob built for a different signal.
+    #[test]
+    fn facet_header_ids_are_distinct() {
+        let ids = [
+            crate::scored::FACET_FOLLOWS,
+            crate::scored::FACET_FOLLOWS2,
+            crate::scored::FACET_NICHE,
+            crate::scored::FACET_POPULAR,
+            crate::scored::FACET_VELOCITY,
+            crate::scored::FACET_COMMUNITY,
+        ];
+        let mut sorted = ids.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ids.len());
     }
 
     use super::*;

--- a/crates/graze-lens-builder/src/config.rs
+++ b/crates/graze-lens-builder/src/config.rs
@@ -53,6 +53,10 @@ pub struct Config {
     /// transfer and the bloom; past this the tail is noise that costs bytes on
     /// every request.
     pub second_degree_cap: usize,
+    /// Window for the velocity facet: "discovered in the last N days".
+    pub velocity_days: u32,
+    /// How many of the viewer's top communities the community facet draws from.
+    pub community_top: usize,
 
     /// Builds allowed to run at once. Almost all of a build is waiting -- on
     /// someone else's PDS during a backfill, or on ClickHouse -- so overlapping
@@ -111,6 +115,8 @@ impl Config {
 
             second_degree_top_k: parse("LENS_SECOND_DEGREE_TOP_K", 20_000)?,
             second_degree_cap: parse("LENS_SECOND_DEGREE_CAP", 500_000)?,
+            velocity_days: parse("LENS_VELOCITY_DAYS", 7)?,
+            community_top: parse("LENS_COMMUNITY_TOP", 3)?,
 
             concurrency: parse("LENS_BUILD_CONCURRENCY", 8)?,
             drain_timeout: Duration::from_secs(parse("LENS_BUILD_DRAIN_SECONDS", 30)?),

--- a/crates/graze-lens-builder/src/lib.rs
+++ b/crates/graze-lens-builder/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod builder;
 pub mod config;
 pub mod interner;
+pub mod priors;
 pub mod queue;
 pub mod scored;
 pub mod second_degree;

--- a/crates/graze-lens-builder/src/priors.rs
+++ b/crates/graze-lens-builder/src/priors.rs
@@ -42,18 +42,37 @@ use tracing::warn;
 pub enum Prior {
     /// `reach × ln(2 + followers)` — nearby and widely known.
     Popular,
-    /// `reach / log2(2 + followers)` — nearby and *not* widely known.
+    /// `reach / (100 + followers)` — the fraction of an account's audience
+    /// that is *your network*, smoothed.
+    ///
+    /// The first version divided by `log2(fame)`, which reads as the obvious
+    /// TF-IDF move and is wrong here: a logarithm compresses a 35,000× fame
+    /// difference into a factor of ~2.5, so raw reach still dominated and the
+    /// "niche" ranking came out identical to the popular one, crowned by a
+    /// 32M-follower account. Verified against real output, not the invariants —
+    /// every invariant passed on the broken version. Linear fame in the
+    /// denominator makes the score a smoothed audience fraction: an account
+    /// with 200 followers, 150 of them your network, scores ~0.5; the
+    /// 32M-follower account scores ~0.00003.
     Niche,
 }
+
+/// Below this, a "niche" signal is one person's follow, which is just
+/// follows² wearing a costume. Two independent confirmations is the floor for
+/// claiming *the network* is close to an account.
+const NICHE_MIN_REACH: u32 = 2;
 
 /// Reach reweighted by global fame, top `cap` by the blended score.
 ///
 /// Three output columns: id, raw reach (kept so the `reach ≤ seeds` invariant
 /// stays checkable — it is the tell that caught a corrupt id map), and score.
 pub fn prior_reach_query(database: &str, seeds: &[u32], cap: usize, prior: Prior) -> String {
-    let weight = match prior {
-        Prior::Popular => "r.reach * ln(2 + s.followers)",
-        Prior::Niche => "r.reach / log2(2 + s.followers)",
+    let (weight, having) = match prior {
+        Prior::Popular => ("r.reach * ln(2 + s.followers)", String::new()),
+        Prior::Niche => (
+            "r.reach / (100 + s.followers)",
+            format!("HAVING uniqExact(follower_int) >= {NICHE_MIN_REACH} "),
+        ),
     };
     format!(
         "SELECT r.followee_int, r.reach, {weight} AS score \
@@ -63,6 +82,7 @@ pub fn prior_reach_query(database: &str, seeds: &[u32], cap: usize, prior: Prior
              FROM {database}.follow_graph_int \
              WHERE follower_int IN ({seeds}) \
              GROUP BY followee_int \
+             {having}\
          ) AS r ON s.account_int = r.followee_int \
          ORDER BY score DESC, r.followee_int ASC \
          LIMIT {cap} \
@@ -252,12 +272,23 @@ mod tests {
         }
     }
 
+    /// Niche must divide by LINEAR fame, not a logarithm. The log version
+    /// passed every structural test and produced a ranking identical to
+    /// popular's, topped by a 32M-follower account — a log compresses fame
+    /// differences until reach dominates. Linear fame makes the score an
+    /// audience fraction, which is the actual definition of "niche to me".
     #[test]
-    fn niche_divides_and_popular_multiplies() {
+    fn niche_divides_by_linear_fame_and_floors_reach() {
         let n = prior_reach_query("default", &[1], 10, Prior::Niche);
         let p = prior_reach_query("default", &[1], 10, Prior::Popular);
-        assert!(n.contains("r.reach / log2(2 + s.followers)"));
+        assert!(n.contains("r.reach / (100 + s.followers)"));
+        assert!(!n.contains("log2"), "log fame is the bug, not the feature");
+        assert!(
+            n.contains("HAVING uniqExact(follower_int) >= 2"),
+            "one person's follow is follows2, not a network signal"
+        );
         assert!(p.contains("r.reach * ln(2 + s.followers)"));
+        assert!(!p.contains("HAVING"), "popular keeps single-reach rows");
     }
 
     /// Velocity must read the recency slice, bound by day, and count distinct

--- a/crates/graze-lens-builder/src/priors.rs
+++ b/crates/graze-lens-builder/src/priors.rs
@@ -1,0 +1,323 @@
+//! Prior-weighted and time-filtered reach: the facet family beyond `follows²`.
+//!
+//! The reach query is secretly an algebra: `reach(seeds, edge_filter, prior)`.
+//! Every knob is a lens, and every lens here is one indexed query at build time
+//! against a table the nightly job maintains — nothing new ever touches the
+//! serve path, which keeps reading blobs.
+//!
+//! # The facets
+//!
+//! **`popular`** — `reach × ln(2 + fame)`. Your second degree, tilted toward
+//! accounts the wider network also rates. The "a-priori popular, nearby focus"
+//! blend.
+//!
+//! **`niche`** — `reach / log2(2 + fame)`. The inversion, and the discovery
+//! engine: accounts your network is disproportionately close to *relative to
+//! their global fame*. TF-IDF on the follow graph; your community's beloved
+//! obscurities, structurally invisible to any trending list.
+//!
+//! **`velocity`** — reach counted only over edges created in the last N days:
+//! who your network is *discovering right now*. This is why the archive replay
+//! fought to preserve each record's own `createdAt` — the recency slice is
+//! built from it.
+//!
+//! **`community`** — the LPA output: members of the communities your follows
+//! concentrate in, ranked by in-community fame and weighted by how much of
+//! your following lives there.
+//!
+//! # The join direction is load-bearing
+//!
+//! ClickHouse builds the RIGHT side of a hash join in memory. The reach result
+//! is bounded (≤ cap rows); `account_stats` is 42M rows. Every query here puts
+//! the small set on the right and streams the big table past it — reversed, the
+//! 42M-row hash table joins the club of designs this cluster's 21.6 GiB
+//! ceiling has already rejected.
+
+use crate::scored;
+use crate::second_degree::{seed_list_of, SecondDegree};
+use tracing::warn;
+
+/// How a global per-account prior reweights raw reach.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Prior {
+    /// `reach × ln(2 + followers)` — nearby and widely known.
+    Popular,
+    /// `reach / log2(2 + followers)` — nearby and *not* widely known.
+    Niche,
+}
+
+/// Reach reweighted by global fame, top `cap` by the blended score.
+///
+/// Three output columns: id, raw reach (kept so the `reach ≤ seeds` invariant
+/// stays checkable — it is the tell that caught a corrupt id map), and score.
+pub fn prior_reach_query(database: &str, seeds: &[u32], cap: usize, prior: Prior) -> String {
+    let weight = match prior {
+        Prior::Popular => "r.reach * ln(2 + s.followers)",
+        Prior::Niche => "r.reach / log2(2 + s.followers)",
+    };
+    format!(
+        "SELECT r.followee_int, r.reach, {weight} AS score \
+         FROM {database}.account_stats AS s \
+         INNER JOIN ( \
+             SELECT followee_int, uniqExact(follower_int) AS reach \
+             FROM {database}.follow_graph_int \
+             WHERE follower_int IN ({seeds}) \
+             GROUP BY followee_int \
+         ) AS r ON s.account_int = r.followee_int \
+         ORDER BY score DESC, r.followee_int ASC \
+         LIMIT {cap} \
+         FORMAT TabSeparated",
+        seeds = seed_list_of(seeds),
+    )
+}
+
+/// Reach over only the freshest edges: what the viewer's network is following
+/// *now*. Same distinct-follower counting as follows² — a duplicated edge must
+/// not let one follow count twice here either.
+pub fn velocity_query(database: &str, seeds: &[u32], cap: usize, days: u32) -> String {
+    format!(
+        "SELECT followee_int, uniqExact(follower_int) AS reach \
+         FROM {database}.follow_graph_recent \
+         WHERE follower_int IN ({seeds}) \
+           AND followed_at > today() - {days} \
+         GROUP BY followee_int \
+         ORDER BY reach DESC, followee_int ASC \
+         LIMIT {cap} \
+         FORMAT TabSeparated",
+        seeds = seed_list_of(seeds),
+    )
+}
+
+/// Which communities the viewer's follows concentrate in.
+pub fn community_affinity_query(database: &str, seeds: &[u32], top: usize) -> String {
+    format!(
+        "SELECT community, count() AS cnt \
+         FROM {database}.account_community \
+         WHERE account IN ({seeds}) \
+         GROUP BY community \
+         ORDER BY cnt DESC, community ASC \
+         LIMIT {top} \
+         FORMAT TabSeparated",
+        seeds = seed_list_of(seeds),
+    )
+}
+
+/// Members of the viewer's top communities, ranked by in-community fame.
+///
+/// Small-right again: the member set for a handful of communities is the
+/// bounded side, `account_stats` streams past it.
+pub fn community_members_query(database: &str, communities: &[u32], cap: usize) -> String {
+    format!(
+        "SELECT m.account, m.community, s.followers \
+         FROM {database}.account_stats AS s \
+         INNER JOIN ( \
+             SELECT account, community FROM {database}.community_members \
+             WHERE community IN ({list}) \
+         ) AS m ON s.account_int = m.account \
+         ORDER BY s.followers DESC, m.account ASC \
+         LIMIT {cap} \
+         FORMAT TabSeparated",
+        list = seed_list_of(communities),
+    )
+}
+
+/// Parse `(id, reach, score)` rows into a scored map, normalising weights
+/// against the viewer's own best score.
+pub fn parse_prior_tsv(text: &str, top_k: usize) -> SecondDegree {
+    let mut entries: Vec<(u32, u16)> = Vec::with_capacity(top_k.min(1024));
+    let mut all_ids: Vec<u32> = Vec::new();
+    let mut max_reach = 0u32;
+    let mut max_score = 0f64;
+
+    for line in text.lines() {
+        let mut cols = line.split('\t');
+        let (Some(id), Some(reach), Some(score)) = (cols.next(), cols.next(), cols.next()) else {
+            continue;
+        };
+        let (Ok(id), Ok(reach), Ok(score)) = (
+            id.trim().parse::<u32>(),
+            reach.trim().parse::<u32>(),
+            score.trim().parse::<f64>(),
+        ) else {
+            continue;
+        };
+        max_reach = max_reach.max(reach);
+        if max_score == 0.0 {
+            // Rows arrive ordered by score descending.
+            max_score = score;
+        }
+        all_ids.push(id);
+        if entries.len() < top_k {
+            let w = if max_score > 0.0 {
+                score / max_score
+            } else {
+                0.0
+            };
+            entries.push((id, scored::weight_from_f32(w as f32)));
+        }
+    }
+
+    SecondDegree {
+        entries,
+        all_ids,
+        max_reach,
+    }
+}
+
+/// Parse `(community, count)` affinity rows into (community, share-of-seeds).
+pub fn parse_affinity_tsv(text: &str, seeds: usize) -> Vec<(u32, f32)> {
+    let mut out = Vec::new();
+    let mut total = 0u64;
+    for line in text.lines() {
+        let mut cols = line.split('\t');
+        let (Some(c), Some(n)) = (cols.next(), cols.next()) else {
+            continue;
+        };
+        let (Ok(c), Ok(n)) = (c.trim().parse::<u32>(), n.trim().parse::<u64>()) else {
+            continue;
+        };
+        total += n;
+        out.push((c, n as f32 / seeds.max(1) as f32));
+    }
+    // Affinity counts are follows-with-a-community; they can never exceed the
+    // seed count. Same class of invariant as reach ≤ seeds.
+    if total > seeds as u64 {
+        warn!(
+            total,
+            seeds, "community affinity exceeds seed count; id map suspect"
+        );
+    }
+    out
+}
+
+/// Parse `(account, community, followers)` member rows, weighting each member
+/// by `affinity_share(community) × ln(2 + fame)`, normalised to the best.
+pub fn parse_members_tsv(text: &str, affinity: &[(u32, f32)], top_k: usize) -> SecondDegree {
+    let share = |c: u32| affinity.iter().find(|(k, _)| *k == c).map(|(_, s)| *s);
+    let mut raw: Vec<(u32, f64)> = Vec::new();
+    let mut all_ids: Vec<u32> = Vec::new();
+
+    for line in text.lines() {
+        let mut cols = line.split('\t');
+        let (Some(a), Some(c), Some(f)) = (cols.next(), cols.next(), cols.next()) else {
+            continue;
+        };
+        let (Ok(a), Ok(c), Ok(f)) = (
+            a.trim().parse::<u32>(),
+            c.trim().parse::<u32>(),
+            f.trim().parse::<u64>(),
+        ) else {
+            continue;
+        };
+        let Some(sh) = share(c) else { continue };
+        all_ids.push(a);
+        raw.push((a, sh as f64 * (2.0 + f as f64).ln()));
+    }
+
+    raw.sort_by(|x, y| y.1.partial_cmp(&x.1).unwrap_or(std::cmp::Ordering::Equal));
+    let max = raw.first().map(|(_, s)| *s).unwrap_or(0.0);
+    let entries: Vec<(u32, u16)> = raw
+        .into_iter()
+        .take(top_k)
+        .map(|(a, s)| {
+            let w = if max > 0.0 { s / max } else { 0.0 };
+            (a, scored::weight_from_f32(w as f32))
+        })
+        .collect();
+
+    SecondDegree {
+        entries,
+        all_ids,
+        max_reach: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The join direction is the whole performance story: the bounded reach
+    /// result must be the RIGHT side (built in memory), account_stats the left
+    /// (streamed). Reversed, this is a 42M-row hash table and a rejected query.
+    #[test]
+    fn prior_queries_put_the_small_set_on_the_right() {
+        for prior in [Prior::Niche, Prior::Popular] {
+            let q = prior_reach_query("default", &[1, 2, 3], 1000, prior);
+            let from_at = q.find("FROM default.account_stats").expect("stats is FROM");
+            let join_at = q.find("INNER JOIN (").expect("reach is the joined side");
+            assert!(from_at < join_at, "stats must stream, reach must build");
+            assert!(q.contains("uniqExact(follower_int) AS reach"));
+            assert!(q.contains("IN (1,2,3)"));
+            assert!(!q.to_uppercase().contains("OFFSET"));
+        }
+    }
+
+    #[test]
+    fn niche_divides_and_popular_multiplies() {
+        let n = prior_reach_query("default", &[1], 10, Prior::Niche);
+        let p = prior_reach_query("default", &[1], 10, Prior::Popular);
+        assert!(n.contains("r.reach / log2(2 + s.followers)"));
+        assert!(p.contains("r.reach * ln(2 + s.followers)"));
+    }
+
+    /// Velocity must read the recency slice, bound by day, and count distinct
+    /// followers — a duplicated edge must not double a follow here either.
+    #[test]
+    fn velocity_reads_the_recent_slice_bounded_by_day() {
+        let q = velocity_query("default", &[7], 500, 7);
+        assert!(q.contains("follow_graph_recent"));
+        assert!(q.contains("followed_at > today() - 7"));
+        assert!(q.contains("uniqExact(follower_int)"));
+        assert!(
+            !q.contains("follow_graph_int"),
+            "must not scan the full graph"
+        );
+    }
+
+    /// Three columns, weights normalised to the best score, everything into
+    /// the bloom, and the raw-reach invariant still visible to the caller.
+    #[test]
+    fn prior_rows_parse_and_normalise() {
+        let tsv = "10\t50\t99.5\n20\t40\t50.0\n30\t9\t10.0\n";
+        let m = parse_prior_tsv(tsv, 2);
+        assert_eq!(m.all_ids, vec![10, 20, 30]);
+        assert_eq!(m.entries.len(), 2, "top_k caps scored entries");
+        assert_eq!(m.entries[0].1, scored::WEIGHT_MAX);
+        assert!(m.entries[1].1 < m.entries[0].1);
+        assert_eq!(
+            m.max_reach, 50,
+            "raw reach survives for the invariant check"
+        );
+    }
+
+    #[test]
+    fn affinity_shares_are_fractions_of_seeds() {
+        let a = parse_affinity_tsv("5\t60\n9\t30\n", 100);
+        assert_eq!(a, vec![(5, 0.6), (9, 0.3)]);
+    }
+
+    /// A member of a stronger community outranks a slightly more famous member
+    /// of a weaker one — affinity is the point of the facet, fame only breaks
+    /// ties within a community.
+    #[test]
+    fn member_weights_blend_affinity_and_fame() {
+        let affinity = vec![(5u32, 0.9f32), (9u32, 0.1f32)];
+        // account 100: community 5, 1k followers. account 200: community 9, 5k.
+        let tsv = "200\t9\t5000\n100\t5\t1000\n";
+        let m = parse_members_tsv(tsv, &affinity, 10);
+        assert_eq!(m.entries[0].0, 100, "high-affinity community wins");
+        assert!(
+            m.all_ids.contains(&200),
+            "but the other member still blooms"
+        );
+    }
+
+    #[test]
+    fn members_of_unknown_communities_are_dropped() {
+        let m = parse_members_tsv("100\t77\t1000\n", &[(5, 1.0)], 10);
+        assert!(
+            m.is_empty(),
+            "a member row for a community we did not ask about is a bug upstream"
+        );
+    }
+}

--- a/crates/graze-lens-builder/src/scored.rs
+++ b/crates/graze-lens-builder/src/scored.rs
@@ -60,6 +60,10 @@ pub const IDSPACE_LENS: u8 = 1;
 /// built for a different signal rather than silently ranking by the wrong one.
 pub const FACET_FOLLOWS: u8 = 1;
 pub const FACET_FOLLOWS2: u8 = 2;
+pub const FACET_NICHE: u8 = 3;
+pub const FACET_POPULAR: u8 = 4;
+pub const FACET_VELOCITY: u8 = 5;
+pub const FACET_COMMUNITY: u8 = 6;
 
 /// The full-confidence weight. A first-degree follow is exactly this.
 pub const WEIGHT_MAX: u16 = u16::MAX;

--- a/crates/graze-lens-builder/src/second_degree.rs
+++ b/crates/graze-lens-builder/src/second_degree.rs
@@ -28,6 +28,7 @@
 //!   lookups and partitioned for fold correctness, neither of which helps a
 //!   multi-seed traversal.
 
+pub use graze_lens_fold::project::seed_list as seed_list_of;
 use graze_lens_fold::project::{seed_list, LIVE_TABLE};
 use tracing::{debug, warn};
 
@@ -49,8 +50,17 @@ impl SecondDegree {
 
     /// Encode as a v2 blob: scored top-K plus a bloom over the whole tail.
     pub fn encode(&self, idspace: u8, built_at: u32) -> Vec<u8> {
-        let mut blob =
-            scored::encode_in_space(FACET_FOLLOWS2, idspace, built_at, self.entries.clone());
+        self.encode_as(FACET_FOLLOWS2, idspace, built_at)
+    }
+
+    /// Encode under an explicit facet header id. The header byte is what lets
+    /// the reader reject a blob published under the wrong key, so it must be
+    /// the facet the caller is actually publishing — six facets share this
+    /// struct now, and stamping them all as follows² would have every one of
+    /// them refused at read time (the good failure) or, worse, accepted as a
+    /// signal they are not.
+    pub fn encode_as(&self, facet_id: u8, idspace: u8, built_at: u32) -> Vec<u8> {
+        let mut blob = scored::encode_in_space(facet_id, idspace, built_at, self.entries.clone());
         scored::append_bloom(&mut blob, &self.all_ids);
         blob
     }

--- a/crates/graze-lens-fold/Cargo.toml
+++ b/crates/graze-lens-fold/Cargo.toml
@@ -15,6 +15,11 @@ path = "src/main.rs"
 name = "graze-lens-rev-rebuild"
 path = "src/bin/rev_rebuild.rs"
 
+# Label-propagation community detection; weekly, after the projection.
+[[bin]]
+name = "graze-lens-lpa"
+path = "src/bin/lpa_run.rs"
+
 # Rebuilds the u32 traversal projection that second-degree queries read.
 [[bin]]
 name = "graze-lens-project"

--- a/crates/graze-lens-fold/src/bin/lpa_run.rs
+++ b/crates/graze-lens-fold/src/bin/lpa_run.rs
@@ -1,0 +1,70 @@
+//! graze-lens-lpa: label-propagation community detection over the follow graph.
+//!
+//! Weekly, not nightly: communities are coarse structure and drift slowly, and
+//! each run is several full passes over a sampled adjacency. Prereq: the
+//! projection job has run (this reads `follow_graph_int` and `account_stats`).
+
+use anyhow::Context;
+use graze_common::ClickHouseConfig;
+use graze_lens_fold::lpa::{Lpa, LpaConfig};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let clickhouse = ClickHouseConfig {
+        host: require("CLICKHOUSE_HOST")?,
+        port: parse("CLICKHOUSE_PORT", 8443)?,
+        database: default_env("CLICKHOUSE_DATABASE", "default"),
+        user: default_env("CLICKHOUSE_USER", "default"),
+        password: require("CLICKHOUSE_PASSWORD")?,
+        secure: parse("CLICKHOUSE_SECURE", true)?,
+    };
+
+    let max_execution: u64 = parse("LENS_LPA_MAX_EXECUTION_SECONDS", 3_600)?;
+    let lpa = Lpa::new(LpaConfig {
+        clickhouse,
+        timeout: std::time::Duration::from_secs(max_execution + 60),
+        max_execution_seconds: max_execution,
+        sample_pct: parse("LENS_LPA_SAMPLE_PCT", 5)?,
+        iterations: parse("LENS_LPA_ITERATIONS", 4)?,
+        max_dominant_share: parse("LENS_LPA_MAX_DOMINANT_SHARE", 0.5)?,
+    })
+    .context("lpa")?;
+
+    info!("label propagation starting");
+    let r = lpa.run().await.context("lpa run")?;
+    info!(
+        accounts = r.accounts,
+        communities = r.communities,
+        largest = r.largest,
+        "community detection complete"
+    );
+    Ok(())
+}
+
+fn optional(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+fn default_env(name: &str, fallback: &str) -> String {
+    optional(name).unwrap_or_else(|| fallback.to_string())
+}
+fn require(name: &str) -> anyhow::Result<String> {
+    optional(name).ok_or_else(|| anyhow::anyhow!("{name} is required but unset"))
+}
+fn parse<T>(name: &str, fallback: T) -> anyhow::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match optional(name) {
+        None => Ok(fallback),
+        Some(raw) => raw
+            .parse()
+            .map_err(|e| anyhow::anyhow!("{name} is not a valid value ({raw}): {e}")),
+    }
+}

--- a/crates/graze-lens-fold/src/bin/project_rebuild.rs
+++ b/crates/graze-lens-fold/src/bin/project_rebuild.rs
@@ -67,6 +67,15 @@ async fn main() -> anyhow::Result<()> {
 
     info!("rebuilding traversal projection");
     let r = projector.run().await.context("rebuild")?;
+
+    // Derived tables, rebuilt from the projection that just swapped in so the
+    // priors and the graph they describe can never be from different nights.
+    let stats_rows = projector.rebuild_stats().await.context("account_stats")?;
+    let recent_rows = projector
+        .rebuild_recent()
+        .await
+        .context("follow_graph_recent")?;
+    info!(stats_rows, recent_rows, "derived tables rebuilt");
     info!(
         interned = r.interned,
         before = r.before,

--- a/crates/graze-lens-fold/src/lib.rs
+++ b/crates/graze-lens-fold/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod cursor;
 pub mod delta;
 pub mod event;
+pub mod lpa;
 pub mod metrics;
 pub mod project;
 pub mod rev;

--- a/crates/graze-lens-fold/src/lpa.rs
+++ b/crates/graze-lens-fold/src/lpa.rs
@@ -1,0 +1,299 @@
+//! Label propagation: coarse community detection over the follow graph.
+//!
+//! Louvain proper does not fit this substrate — it needs random-access mutation
+//! of a modularity state no SQL engine will hold for 42M nodes. Label
+//! propagation converges to the same coarse communities and is expressible as
+//! the one thing ClickHouse is unbeatable at: iterated join + group-by. Each
+//! round, every account adopts the most common label among its sampled
+//! neighbours; a handful of rounds and the labels stop moving.
+//!
+//! # Sampling is load-bearing, not a shortcut
+//!
+//! The full graph is 2.77B directed edges — 5.5B once both directions count as
+//! adjacency. A per-round vote over that would fight the 21.6 GiB memory
+//! ceiling this cluster has already enforced three times. Sampling edges by
+//! hash keeps rounds bounded, and community detection is exactly the workload
+//! where that is safe: communities are a *coarse* structure, and a uniform
+//! sample preserves coarse structure. (The same argument does NOT hold for
+//! reach, where every edge is one unit of the answer.)
+//!
+//! # The degenerate outcome is a real risk
+//!
+//! Batch LPA on social graphs can collapse into one giant community. That
+//! failure is not an error anywhere — it just makes a "my communities" lens
+//! mean "everyone". So the swap refuses a result whose largest community
+//! exceeds a share of all accounts, and the previous labels stay live.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use graze_common::ClickHouseConfig;
+use tracing::{info, warn};
+
+pub const COMMUNITY_TABLE: &str = "account_community";
+pub const COMMUNITY_STAGING: &str = "account_community_next";
+pub const MEMBERS_TABLE: &str = "community_members";
+pub const MEMBERS_STAGING: &str = "community_members_next";
+
+/// Working tables, dropped at the end of a run.
+const EDGES: &str = "lpa_edges";
+const LABELS: &str = "lpa_labels";
+const LABELS_NEXT: &str = "lpa_labels_next";
+const VOTES: &str = "lpa_votes";
+const TOP: &str = "lpa_top";
+
+pub struct LpaConfig {
+    pub clickhouse: ClickHouseConfig,
+    pub timeout: Duration,
+    pub max_execution_seconds: u64,
+    /// Percent of edges sampled into the adjacency, 1..=100.
+    pub sample_pct: u8,
+    /// Voting rounds. LPA converges fast; past ~5 the labels barely move.
+    pub iterations: u32,
+    /// Refuse to swap if the largest community holds more than this share of
+    /// all accounts — the collapse guard.
+    pub max_dominant_share: f64,
+}
+
+pub struct Lpa {
+    http: reqwest::Client,
+    cfg: LpaConfig,
+}
+
+pub struct LpaReport {
+    pub accounts: u64,
+    pub communities: u64,
+    pub largest: u64,
+}
+
+impl Lpa {
+    pub fn new(cfg: LpaConfig) -> anyhow::Result<Self> {
+        Ok(Self {
+            http: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(10))
+                .build()?,
+            cfg,
+        })
+    }
+
+    pub async fn run(&self) -> anyhow::Result<LpaReport> {
+        let db = &self.cfg.clickhouse.database.clone();
+        let pct = self.cfg.sample_pct.clamp(1, 100);
+
+        // Adjacency sample, both directions. Follow direction is meaningless
+        // for "are these accounts in the same social cluster", so the graph is
+        // treated as undirected by inserting each sampled edge both ways.
+        // Ordered by src for the per-round join.
+        self.exec(&format!("DROP TABLE IF EXISTS {db}.{EDGES}"))
+            .await?;
+        self.exec(&format!(
+            "CREATE TABLE {db}.{EDGES} ENGINE = MergeTree ORDER BY src AS
+             SELECT follower_int AS src, followee_int AS dst FROM {db}.follow_graph_int
+             WHERE cityHash64(follower_int, followee_int) % 100 < {pct}
+             UNION ALL
+             SELECT followee_int, follower_int FROM {db}.follow_graph_int
+             WHERE cityHash64(follower_int, followee_int) % 100 < {pct}
+             SETTINGS max_threads = 4"
+        ))
+        .await
+        .context("sampling adjacency")?;
+        let sampled = self.count(EDGES).await?;
+        info!(sampled, pct, "adjacency sampled");
+
+        // Every account starts as its own community. Seeded from account_stats
+        // (already one row per account) rather than re-deriving the node set.
+        self.exec(&format!("DROP TABLE IF EXISTS {db}.{LABELS}"))
+            .await?;
+        self.exec(&format!(
+            "CREATE TABLE {db}.{LABELS} ENGINE = MergeTree ORDER BY account AS
+             SELECT account_int AS account, account_int AS label FROM {db}.account_stats"
+        ))
+        .await
+        .context("seeding labels")?;
+
+        for round in 1..=self.cfg.iterations {
+            // Votes: for each account, how many sampled neighbours carry each
+            // label. Bounded by the sample size, and spilled to disk past the
+            // group-by budget — this is the round's heavy step.
+            self.exec(&format!("DROP TABLE IF EXISTS {db}.{VOTES}"))
+                .await?;
+            self.exec(&format!(
+                "CREATE TABLE {db}.{VOTES} ENGINE = MergeTree ORDER BY account AS
+                 SELECT e.src AS account, l.label AS label, count() AS cnt
+                 FROM {db}.{EDGES} AS e
+                 INNER JOIN {db}.{LABELS} AS l ON e.dst = l.account
+                 GROUP BY e.src, l.label
+                 SETTINGS join_algorithm = 'grace_hash', max_threads = 4,
+                          max_bytes_before_external_group_by = 8000000000"
+            ))
+            .await
+            .with_context(|| format!("votes, round {round}"))?;
+
+            // Majority label per account, ties broken by the label value so a
+            // rerun of the same round gives the same answer.
+            self.exec(&format!("DROP TABLE IF EXISTS {db}.{TOP}"))
+                .await?;
+            self.exec(&format!(
+                "CREATE TABLE {db}.{TOP} ENGINE = MergeTree ORDER BY account AS
+                 SELECT account, argMax(label, (cnt, label)) AS label
+                 FROM {db}.{VOTES} GROUP BY account
+                 SETTINGS max_threads = 4,
+                          max_bytes_before_external_group_by = 8000000000"
+            ))
+            .await
+            .with_context(|| format!("majority, round {round}"))?;
+
+            // Accounts with no sampled neighbours keep their label. Interner
+            // ids start at 1, so label 0 can only mean "no vote row joined".
+            self.exec(&format!("DROP TABLE IF EXISTS {db}.{LABELS_NEXT}"))
+                .await?;
+            self.exec(&format!(
+                "CREATE TABLE {db}.{LABELS_NEXT} ENGINE = MergeTree ORDER BY account AS
+                 SELECT l.account AS account, if(t.label = 0, l.label, t.label) AS label
+                 FROM {db}.{LABELS} AS l
+                 ANY LEFT JOIN {db}.{TOP} AS t ON l.account = t.account
+                 SETTINGS join_algorithm = 'grace_hash', max_threads = 4"
+            ))
+            .await
+            .with_context(|| format!("carry-forward, round {round}"))?;
+
+            self.exec(&format!("DROP TABLE {db}.{LABELS}")).await?;
+            self.exec(&format!("RENAME TABLE {db}.{LABELS_NEXT} TO {db}.{LABELS}"))
+                .await?;
+
+            let communities = self
+                .scalar(&format!(
+                    "SELECT uniqExact(label) FROM {db}.{LABELS} FORMAT TabSeparated"
+                ))
+                .await?;
+            info!(round, communities, "round complete");
+        }
+
+        let accounts = self.count(LABELS).await?;
+        let communities = self
+            .scalar(&format!(
+                "SELECT uniqExact(label) FROM {db}.{LABELS} FORMAT TabSeparated"
+            ))
+            .await?;
+        let largest = self
+            .scalar(&format!(
+                "SELECT max(c) FROM (SELECT count() AS c FROM {db}.{LABELS} GROUP BY label) \
+                 FORMAT TabSeparated"
+            ))
+            .await?;
+
+        let share = largest as f64 / accounts.max(1) as f64;
+        if share > self.cfg.max_dominant_share {
+            // Leave the previous labels serving; a collapsed run must not
+            // replace a good one. Cleanup still happens below.
+            self.cleanup(db).await;
+            anyhow::bail!(
+                "refusing to swap: largest community holds {:.1}% of {accounts} accounts \
+                 (ceiling {:.0}%) — batch LPA collapse",
+                share * 100.0,
+                self.cfg.max_dominant_share * 100.0
+            );
+        }
+
+        // Publish: account → community, and the reverse ordering the community
+        // facet reads members from.
+        self.exec(&format!("TRUNCATE TABLE {db}.{COMMUNITY_STAGING}"))
+            .await?;
+        self.exec(&format!(
+            "INSERT INTO {db}.{COMMUNITY_STAGING} (account, community)
+             SELECT account, label FROM {db}.{LABELS}"
+        ))
+        .await?;
+        self.exec(&format!(
+            "EXCHANGE TABLES {db}.{COMMUNITY_TABLE} AND {db}.{COMMUNITY_STAGING}"
+        ))
+        .await?;
+        self.exec(&format!("TRUNCATE TABLE {db}.{COMMUNITY_STAGING}"))
+            .await?;
+
+        self.exec(&format!("TRUNCATE TABLE {db}.{MEMBERS_STAGING}"))
+            .await?;
+        self.exec(&format!(
+            "INSERT INTO {db}.{MEMBERS_STAGING} (community, account)
+             SELECT community, account FROM {db}.{COMMUNITY_TABLE}"
+        ))
+        .await?;
+        self.exec(&format!(
+            "EXCHANGE TABLES {db}.{MEMBERS_TABLE} AND {db}.{MEMBERS_STAGING}"
+        ))
+        .await?;
+        self.exec(&format!("TRUNCATE TABLE {db}.{MEMBERS_STAGING}"))
+            .await?;
+
+        self.cleanup(db).await;
+        Ok(LpaReport {
+            accounts,
+            communities,
+            largest,
+        })
+    }
+
+    async fn cleanup(&self, db: &str) {
+        for t in [EDGES, LABELS, LABELS_NEXT, VOTES, TOP] {
+            if let Err(e) = self.exec(&format!("DROP TABLE IF EXISTS {db}.{t}")).await {
+                warn!(table = t, error = %e, "cleanup failed; drop it by hand");
+            }
+        }
+    }
+
+    async fn count(&self, table: &str) -> anyhow::Result<u64> {
+        let db = &self.cfg.clickhouse.database;
+        self.scalar(&format!(
+            "SELECT count() FROM {db}.{table} FORMAT TabSeparated"
+        ))
+        .await
+    }
+
+    async fn scalar(&self, sql: &str) -> anyhow::Result<u64> {
+        Ok(self.exec(sql).await?.trim().parse().unwrap_or(0))
+    }
+
+    async fn exec(&self, sql: &str) -> anyhow::Result<String> {
+        let response = self
+            .http
+            .post(self.cfg.clickhouse.base_url())
+            .basic_auth(
+                &self.cfg.clickhouse.user,
+                Some(&self.cfg.clickhouse.password),
+            )
+            .header("Content-Type", "text/plain")
+            .timeout(self.cfg.timeout)
+            .query(&[(
+                "max_execution_time",
+                self.cfg.max_execution_seconds.to_string(),
+            )])
+            .body(sql.to_string())
+            .send()
+            .await?;
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!(
+                "lpa query failed ({status}): {}\nSQL: {}",
+                &text[..text.len().min(400)],
+                &sql[..sql.len().min(300)]
+            );
+        }
+        Ok(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The staging/live pairs must be distinct names, and the members table
+    /// must be the reverse ordering of the community table — the facet reads
+    /// members BY community, which the account-ordered table cannot serve.
+    #[test]
+    fn table_names_are_coherent() {
+        assert_ne!(COMMUNITY_TABLE, COMMUNITY_STAGING);
+        assert_ne!(MEMBERS_TABLE, MEMBERS_STAGING);
+        assert_ne!(COMMUNITY_TABLE, MEMBERS_TABLE);
+    }
+}

--- a/crates/graze-lens-fold/src/project.rs
+++ b/crates/graze-lens-fold/src/project.rs
@@ -39,6 +39,14 @@ use tracing::{info, warn};
 pub const LIVE_TABLE: &str = "follow_graph_int";
 pub const STAGING_TABLE: &str = "follow_graph_int_next";
 pub const MAP_TABLE: &str = "didint_map";
+/// Per-account degree counts, rebuilt from the projection each run. These are
+/// the "priors" the niche/popular lens facets join against.
+pub const STATS_TABLE: &str = "account_stats";
+pub const STATS_STAGING: &str = "account_stats_next";
+/// The last ~90 days of edges, with their date. Small enough (a few hundred
+/// million rows) that the velocity facet can filter it by day at build time.
+pub const RECENT_TABLE: &str = "follow_graph_recent";
+pub const RECENT_STAGING: &str = "follow_graph_recent_next";
 /// Accounts still needing an id, materialised once per run.
 pub const PENDING_TABLE: &str = "didint_pending";
 
@@ -397,6 +405,102 @@ impl Projector {
             before,
             after,
         })
+    }
+
+    /// Rebuild `account_stats` from the freshly swapped projection.
+    ///
+    /// One pass over both endpoints of every edge. The invariant that makes
+    /// this verifiable end to end: `sum(followers) == sum(following) ==` the
+    /// projection's row count — every edge contributes exactly one to each.
+    pub async fn rebuild_stats(&self) -> anyhow::Result<u64> {
+        let db = &self.clickhouse.database;
+
+        self.exec(&format!("TRUNCATE TABLE {db}.{STATS_STAGING}"))
+            .await?;
+        self.exec(&format!(
+            "INSERT INTO {db}.{STATS_STAGING} (account_int, followers, following)
+             SELECT account_int, sum(fin), sum(fout) FROM (
+                 SELECT followee_int AS account_int, toUInt64(1) AS fin, toUInt64(0) AS fout
+                 FROM {db}.{LIVE_TABLE}
+                 UNION ALL
+                 SELECT follower_int, 0, 1 FROM {db}.{LIVE_TABLE}
+             ) GROUP BY account_int
+             SETTINGS max_threads = 4, max_bytes_before_external_group_by = 8000000000"
+        ))
+        .await?;
+
+        let edges = self.count(LIVE_TABLE).await?;
+        let followers_sum: u64 = self
+            .exec(&format!(
+                "SELECT sum(followers) FROM {db}.{STATS_STAGING} FORMAT TabSeparated"
+            ))
+            .await?
+            .trim()
+            .parse()
+            .unwrap_or(0);
+        // Every edge has exactly one followee, so the sums must reconcile. A
+        // mismatch means the aggregation dropped or double-counted rows, and a
+        // prior built from that silently mis-ranks every fame-weighted lens.
+        if followers_sum != edges {
+            anyhow::bail!(
+                "account_stats does not reconcile: sum(followers)={followers_sum} vs {edges} edges"
+            );
+        }
+
+        self.exec(&format!(
+            "EXCHANGE TABLES {db}.{STATS_TABLE} AND {db}.{STATS_STAGING}"
+        ))
+        .await?;
+        self.exec(&format!("TRUNCATE TABLE {db}.{STATS_STAGING}"))
+            .await?;
+        let rows = self.count(STATS_TABLE).await?;
+        info!(rows, edges, "account_stats swapped in");
+        Ok(rows)
+    }
+
+    /// Rebuild the recency slice: edges created in the last ~90 days, with
+    /// their date, so the velocity facet can ask "reached via follows made this
+    /// week" as a plain WHERE. Kept separate from the main projection because
+    /// carrying a date there would grow the hot table 50% for a column only
+    /// this one facet reads.
+    pub async fn rebuild_recent(&self) -> anyhow::Result<u64> {
+        let db = &self.clickhouse.database;
+
+        self.exec(&format!("TRUNCATE TABLE {db}.{RECENT_STAGING}"))
+            .await?;
+        self.exec(&format!(
+            "INSERT INTO {db}.{RECENT_STAGING} (follower_int, followee_int, followed_at)
+             SELECT m1.id, m2.id, toDate(e.created_at)
+             FROM (
+                 SELECT follower, followee, created_at FROM (
+                     SELECT follower, followee, op, created_at FROM {db}.follow_edges FINAL
+                 ) WHERE op = 'create' AND followee != ''
+                   AND created_at > now() - INTERVAL 90 DAY
+                   AND created_at < now() + INTERVAL 1 DAY
+             ) AS e
+             INNER JOIN {db}.{MAP_TABLE} AS m1 ON e.follower = m1.did
+             INNER JOIN {db}.{MAP_TABLE} AS m2 ON e.followee = m2.did
+             SETTINGS join_algorithm = 'grace_hash', max_threads = 4"
+        ))
+        .await?;
+
+        let after = self.count(RECENT_STAGING).await?;
+        let before = self.count(RECENT_TABLE).await?;
+        // A recency slice legitimately shrinks day to day, so the anti-wipe
+        // floor is looser than the main projection's — but a sudden collapse to
+        // near-nothing still means the source query broke, not the network.
+        if before > 1_000_000 && (after as f64) < before as f64 * 0.2 {
+            anyhow::bail!("refusing to swap follow_graph_recent: rebuilt {after} vs {before} live");
+        }
+
+        self.exec(&format!(
+            "EXCHANGE TABLES {db}.{RECENT_TABLE} AND {db}.{RECENT_STAGING}"
+        ))
+        .await?;
+        self.exec(&format!("TRUNCATE TABLE {db}.{RECENT_STAGING}"))
+            .await?;
+        info!(rows = after, "follow_graph_recent swapped in");
+        Ok(after)
     }
 
     async fn count(&self, table: &str) -> anyhow::Result<u64> {

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:311dd6e98592a8bb6503806753e530642480b369c84aab7d0becc88929d83a5f
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-fold-deployment.yaml
+++ b/kube/lens-fold-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: fold
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:311dd6e98592a8bb6503806753e530642480b369c84aab7d0becc88929d83a5f
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
           command: ["/app/graze-lens-fold"]
           resources:
             requests:

--- a/kube/lens-fold-deployment.yaml
+++ b/kube/lens-fold-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: fold
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
           command: ["/app/graze-lens-fold"]
           resources:
             requests:

--- a/kube/lens-lpa-cronjob.yaml
+++ b/kube/lens-lpa-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
           containers:
             - name: lpa
               # Digest-pinned; updated together with the other lens workloads.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:311dd6e98592a8bb6503806753e530642480b369c84aab7d0becc88929d83a5f
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
               command: ["/app/graze-lens-lpa"]
               resources:
                 requests:

--- a/kube/lens-lpa-cronjob.yaml
+++ b/kube/lens-lpa-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
           containers:
             - name: lpa
               # Digest-pinned; updated together with the other lens workloads.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
               command: ["/app/graze-lens-lpa"]
               resources:
                 requests:

--- a/kube/lens-lpa-cronjob.yaml
+++ b/kube/lens-lpa-cronjob.yaml
@@ -1,0 +1,79 @@
+# graze-lens-lpa — label-propagation community detection over the follow graph.
+#
+# Feeds the `community` lens facet: members of the communities a viewer's
+# follows concentrate in. Weekly, not nightly — communities are coarse
+# structure and drift slowly, and each run is several full passes over a
+# sampled adjacency (~275M rows at the default 5%).
+#
+# The run is guarded against the classic batch-LPA failure, collapse into one
+# giant community: if the largest community exceeds LENS_LPA_MAX_DOMINANT_SHARE
+# of all accounts, the job fails and the previous labels stay live. That
+# failure is otherwise silent — a collapsed label set does not error, it just
+# turns "my communities" into "everyone".
+#
+# Prereqs: the nightly projection job (reads `follow_graph_int` and
+# `account_stats`); tables from `feed-processor/scripts/create_follow_edges_tables.py`.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: graze-lens-lpa
+  labels:
+    app: graze-lens
+    component: lpa
+spec:
+  # Sunday, after the nightly projection (10:43) has long finished.
+  schedule: "17 14 * * 0"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 14400 # 4h
+      template:
+        metadata:
+          labels:
+            app: graze-lens
+            component: lpa
+        spec:
+          restartPolicy: Never
+          imagePullSecrets:
+            - name: docr-graze-social-labs
+          containers:
+            - name: lpa
+              # Digest-pinned; updated together with the other lens workloads.
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:311dd6e98592a8bb6503806753e530642480b369c84aab7d0becc88929d83a5f
+              command: ["/app/graze-lens-lpa"]
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "200m"
+                limits:
+                  # The work is ClickHouse's; this process issues SQL.
+                  memory: "1Gi"
+                  cpu: "1000m"
+              envFrom:
+                - secretRef:
+                    name: app-secrets
+              env:
+                - name: LENS_LPA_SAMPLE_PCT
+                  value: "5"
+                - name: LENS_LPA_ITERATIONS
+                  value: "4"
+                - name: LENS_LPA_MAX_DOMINANT_SHARE
+                  value: "0.5"
+                - name: LENS_LPA_MAX_EXECUTION_SECONDS
+                  value: "3600"
+                - name: RUST_LOG
+                  value: "info"
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               # Built from commit 1a835eb (feat/lens-completeness-guard).
               # Digest-pinned: both `latest` and the short-SHA tag are mutable
               # on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
               command: ["/app/graze-lens-project"]
               resources:
                 requests:

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               # Built from commit 1a835eb (feat/lens-completeness-guard).
               # Digest-pinned: both `latest` and the short-SHA tag are mutable
               # on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:311dd6e98592a8bb6503806753e530642480b369c84aab7d0becc88929d83a5f
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
               command: ["/app/graze-lens-project"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: rev-rebuild
               # Built from commit 1a835eb (feat/lens-completeness-guard). Digest-pinned:
               # both `latest` and the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:311dd6e98592a8bb6503806753e530642480b369c84aab7d0becc88929d83a5f
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: rev-rebuild
               # Built from commit 1a835eb (feat/lens-completeness-guard). Digest-pinned:
               # both `latest` and the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:3ccb426794e83753ac1187bce0768bb1fead1badbeb2477eb6ec410e6eddab5e
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:


### PR DESCRIPTION
The reach query was secretly an algebra — `reach(seeds, edge_filter, prior)` —
and every knob is a lens. Four new stored facets, each one indexed query at
build time producing a scored blob; the serve path is untouched and keeps
reading blobs in µs.

| facet | scoring | what it surfaces |
|---|---|---|
| `popular` | `reach × ln(2+fame)` | your wider network, tilted toward accounts everyone knows |
| `niche` | `reach / log2(2+fame)` | accounts your network loves relative to their global fame — TF-IDF on the follow graph, invisible to any trending list |
| `velocity` | reach over edges from the last N days | what your network is discovering *right now* |
| `community` | LPA membership × affinity × in-community fame | the social clusters your follows concentrate in |

Plus `discover`, composed by the reader like `network`: niche at 1.0, velocity
at 0.9, follows² at 0.4 — and no first degree at all, because the reader
already knows who they follow.

## Infrastructure

Two nightly tables, rebuilt by the projection job from the projection that just
swapped in (so priors and graph are never from different nights):

- **`account_stats`** — degree counts. Verified by the invariant that
  `sum(followers)` equals the projection's edge count *exactly*; a mismatch
  fails the swap.
- **`follow_graph_recent`** — the 90-day slice with its date. Kept out of the
  hot table so a column one facet reads doesn't grow it 50%. This is the payoff
  for the archive replay preserving every record's own `createdAt`.

**Communities** come from a weekly label-propagation job (`graze-lens-lpa`).
Louvain proper needs random-access state nothing holds for 42M nodes; LPA is
iterated join+group-by, which is what this substrate is unbeatable at. It
samples edges by hash — safe for coarse structure, unlike reach where every
edge is a unit of the answer — and **refuses to swap a result whose largest
community exceeds half of all accounts**, because batch LPA's collapse mode
doesn't error; it just turns "my communities" into "everyone".

## Scale lessons, now load-bearing in the queries

- The bounded set goes on the **right** of every join — ClickHouse builds the
  right side in memory, and a 42M-row hash table is a query this cluster's
  21.6 GiB ceiling has already rejected three times.
- `max_query_size` rises to 10 MB so a 50k-follow whale's inlined seed list
  parses at all (the default 256 KB budget fails at ~28k seeds).
- The facet dispatch is exhaustive — a fallthrough once published first degree
  under the second-degree name, and with six facets that slip has six variants.
- Every scored facet enforces `max_reach ≤ seeds` before publishing. The
  arithmetic impossibility that exposed a corrupt id map is now a guard, not a
  post-hoc observation.