### PR TITLE
Refresh published lens facets nightly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ COPY --from=builder /app/target/release/graze-lens-bootstrap /app/graze-lens-boo
 COPY --from=builder /app/target/release/graze-lens-rev-rebuild /app/graze-lens-rev-rebuild
 COPY --from=builder /app/target/release/graze-lens-project /app/graze-lens-project
 COPY --from=builder /app/target/release/graze-lens-lpa /app/graze-lens-lpa
+COPY --from=builder /app/target/release/graze-lens-refresh /app/graze-lens-refresh
 COPY --from=builder /app/target/release/graze-migrate-tranches /app/graze-migrate-tranches
 COPY --from=builder /app/target/release/graze-migrate-dates /app/graze-migrate-dates
 COPY --from=builder /app/target/release/graze-verify-migration /app/graze-verify-migration

--- a/crates/graze-lens-builder/Cargo.toml
+++ b/crates/graze-lens-builder/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 name = "graze-lens-builder"
 path = "src/main.rs"
 
+[[bin]]
+name = "graze-lens-refresh"
+path = "src/bin/refresh.rs"
+
 [lib]
 name = "graze_lens_builder"
 path = "src/lib.rs"

--- a/crates/graze-lens-builder/src/bin/refresh.rs
+++ b/crates/graze-lens-builder/src/bin/refresh.rs
@@ -1,0 +1,83 @@
+//! graze-lens-refresh: re-enqueue builds for every facet a viewer already has.
+//!
+//! Blobs are built on demand and live for the TTL (7 days). That is the right
+//! lifecycle for `follows` — deltas keep it live between builds — but wrong for
+//! the facets whose *content* is time-shaped: `velocity` claims "what my
+//! network discovered this week" and would happily serve week-old "this week"
+//! until its TTL lapsed. A nightly re-enqueue keeps every published facet as
+//! fresh as the tables under it, which the projection job rebuilds nightly.
+//!
+//! Only facets that already exist are refreshed. Enqueuing all six for every
+//! active viewer would make this job the biggest source of build load in the
+//! system for blobs nobody asked for; refreshing what is published keeps the
+//! cost proportional to actual use.
+
+use anyhow::Context;
+use deadpool_redis::redis::AsyncCommands;
+use deadpool_redis::{Config as RedisConfig, Runtime};
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+const ACTIVE_KEY: &str = "lens:active";
+const QUEUE: &str = "queue:lens";
+const FACETS: &[&str] = &[
+    "follows",
+    "follows2",
+    "niche",
+    "popular",
+    "velocity",
+    "community",
+];
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let url = std::env::var("LENS_REDIS_URL")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .context("LENS_REDIS_URL is required")?;
+    let pool = RedisConfig::from_url(url)
+        .builder()?
+        .max_size(4)
+        .runtime(Runtime::Tokio1)
+        .build()
+        .context("redis pool")?;
+    let mut conn = pool.get().await.context("redis conn")?;
+
+    let viewers: Vec<String> = conn.smembers(ACTIVE_KEY).await.context("lens:active")?;
+    info!(viewers = viewers.len(), "refreshing published facets");
+
+    let mut enqueued = 0usize;
+    for viewer in &viewers {
+        for facet in FACETS {
+            let exists: bool = conn
+                .exists(format!("lens:v2:{facet}:{viewer}"))
+                .await
+                .unwrap_or(false);
+            if !exists {
+                continue;
+            }
+            let payload = serde_json::json!({ "viewer_did": viewer, "facet": facet }).to_string();
+            let result: Result<(), _> = deadpool_redis::redis::cmd("XADD")
+                .arg(QUEUE)
+                .arg("MAXLEN")
+                .arg("~")
+                .arg(100_000)
+                .arg("*")
+                .arg("data")
+                .arg(&payload)
+                .query_async(&mut conn)
+                .await;
+            match result {
+                Ok(()) => enqueued += 1,
+                Err(e) => warn!(viewer, facet, error = %e, "enqueue failed"),
+            }
+        }
+    }
+
+    info!(enqueued, "refresh complete");
+    Ok(())
+}

--- a/kube/lens-refresh-cronjob.yaml
+++ b/kube/lens-refresh-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
             - name: docr-graze-social-labs
           containers:
             - name: refresh
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:6dd2e6776768668e187c0667b84a840dd7eec9aa369101fb8ef8510a40a3afcc
               command: ["/app/graze-lens-refresh"]
               resources:
                 requests:

--- a/kube/lens-refresh-cronjob.yaml
+++ b/kube/lens-refresh-cronjob.yaml
@@ -1,0 +1,63 @@
+# graze-lens-refresh — nightly re-enqueue of every published lens facet.
+#
+# Blobs build on demand and live for 7 days, which is right for `follows`
+# (deltas keep it live) and wrong for time-shaped facets: `velocity` claims
+# "what my network discovered this week" and would serve week-old "this week"
+# until its TTL lapsed. This re-enqueues only facets that already exist, so the
+# cost stays proportional to actual use, and it runs after the projection job
+# (10:43) has rebuilt the tables the facets read.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: graze-lens-refresh
+  labels:
+    app: graze-lens
+    component: refresh
+spec:
+  schedule: "13 12 * * *" # after the nightly projection completes
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            app: graze-lens
+            component: refresh
+        spec:
+          restartPolicy: Never
+          imagePullSecrets:
+            - name: docr-graze-social-labs
+          containers:
+            - name: refresh
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
+              command: ["/app/graze-lens-refresh"]
+              resources:
+                requests:
+                  memory: "64Mi"
+                  cpu: "50m"
+                limits:
+                  memory: "256Mi"
+                  cpu: "250m"
+              envFrom:
+                - secretRef:
+                    name: app-secrets
+                - secretRef:
+                    name: lens-redis
+              env:
+                - name: RUST_LOG
+                  value: "info"
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532


### PR DESCRIPTION
Blobs build on demand and live for the 7-day TTL — right for follows (deltas keep it live), wrong for time-shaped facets: velocity claims "what my network discovered this week" and would serve week-old "this week" until its TTL lapsed. The refresher re-enqueues only facets that already exist per active viewer, so cost tracks actual use. Runs nightly after the projection job rebuilds the tables underneath. Verified live: one manual run re-enqueued the cohort's published facets and the builder rebuilt them all.