### PR TITLE
The domain facet: who a feed's authors collectively follow

### DIFF
--- a/crates/graze-lens-builder/src/bin/refresh.rs
+++ b/crates/graze-lens-builder/src/bin/refresh.rs
@@ -78,6 +78,47 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    info!(enqueued, "refresh complete");
+    // Feed-scoped domain blobs, keyed by algorithm id rather than viewer.
+    // SCAN is fine at this scale: one key per lens-enabled feed.
+    let mut domains = 0usize;
+    let mut cursor: u64 = 0;
+    loop {
+        let (next, keys): (u64, Vec<String>) = deadpool_redis::redis::cmd("SCAN")
+            .arg(cursor)
+            .arg("MATCH")
+            .arg("lens:v2:domain:*")
+            .arg("COUNT")
+            .arg(500)
+            .query_async(&mut conn)
+            .await
+            .context("scan domain blobs")?;
+        for key in keys {
+            let Some(algo_id) = key.rsplit(':').next().and_then(|v| v.parse::<u32>().ok()) else {
+                continue;
+            };
+            let payload =
+                serde_json::json!({ "facet": "domain", "feed_algo_id": algo_id }).to_string();
+            let result: Result<(), _> = deadpool_redis::redis::cmd("XADD")
+                .arg(QUEUE)
+                .arg("MAXLEN")
+                .arg("~")
+                .arg(100_000)
+                .arg("*")
+                .arg("data")
+                .arg(&payload)
+                .query_async(&mut conn)
+                .await;
+            match result {
+                Ok(()) => domains += 1,
+                Err(e) => warn!(algo_id, error = %e, "domain enqueue failed"),
+            }
+        }
+        cursor = next;
+        if cursor == 0 {
+            break;
+        }
+    }
+
+    info!(enqueued, domains, "refresh complete");
     Ok(())
 }

--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -18,6 +18,7 @@ use serde::Deserialize;
 use tracing::{debug, info, warn};
 
 use crate::config::Config;
+use crate::domain;
 use crate::interner::Interner;
 use crate::priors;
 use crate::second_degree;
@@ -38,6 +39,9 @@ pub const FACET_NICHE: &str = "niche";
 pub const FACET_POPULAR: &str = "popular";
 pub const FACET_VELOCITY: &str = "velocity";
 pub const FACET_COMMUNITY: &str = "community";
+/// Feed-scoped: who this feed's recent authors collectively follow. Built per
+/// algorithm id, not per viewer; the reader sums it with viewer facets.
+pub const FACET_DOMAIN: &str = "domain";
 
 /// Facets this builder can actually produce.
 ///
@@ -53,6 +57,7 @@ pub fn is_buildable_facet(facet: &str) -> bool {
             | FACET_POPULAR
             | FACET_VELOCITY
             | FACET_COMMUNITY
+            | FACET_DOMAIN
     )
 }
 
@@ -66,6 +71,7 @@ fn facet_header_id(name: &str) -> Option<u8> {
         FACET_POPULAR => Some(crate::scored::FACET_POPULAR),
         FACET_VELOCITY => Some(crate::scored::FACET_VELOCITY),
         FACET_COMMUNITY => Some(crate::scored::FACET_COMMUNITY),
+        FACET_DOMAIN => Some(crate::scored::FACET_DOMAIN),
         _ => None,
     }
 }
@@ -236,6 +242,83 @@ impl Builder {
     /// building from ClickHouse alone would publish a handful of incidental
     /// edges as if it were their graph — a wrong feed, not a narrow one, and
     /// indistinguishable from someone who genuinely follows almost nobody.
+    /// Build the feed-scoped `domain` blob for one algorithm id.
+    ///
+    /// Deliberately not routed through `build()`: that path is a viewer
+    /// pipeline — completeness guard, PDS backfill, lensmeta state — and none
+    /// of it means anything for a feed. A feed with no recent authors is
+    /// Empty, not NeedsBackfill.
+    pub async fn build_domain(&self, algo_id: u32) -> anyhow::Result<BuildOutcome> {
+        let Some(interner) = &self.interner else {
+            anyhow::bail!("no interner configured; cannot build domain");
+        };
+
+        let authors_sql = domain::author_weights_query(&self.clickhouse.database, algo_id);
+        let authors = domain::parse_author_weights(&self.query_text(&authors_sql).await?);
+        if authors.is_empty() {
+            info!(algo_id, "feed has no recent authors; nothing to build");
+            return Ok(BuildOutcome::Empty);
+        }
+
+        // Intern the authors, carrying each one's decayed weight through.
+        let dids: Vec<String> = authors.iter().map(|(d, _)| d.clone()).collect();
+        let ids = interner.intern_many(&dids).await?;
+        let seeds: Vec<(u32, f64)> = authors
+            .iter()
+            .filter_map(|(d, w)| ids.get(d).map(|id| (*id, *w)))
+            .collect();
+        if seeds.is_empty() {
+            return Ok(BuildOutcome::Empty);
+        }
+
+        let reach_sql = domain::weighted_reach_query(
+            &self.clickhouse.database,
+            &seeds,
+            self.config.second_degree_cap,
+        );
+        let map = domain::parse_domain_tsv(
+            &self.query_text(&reach_sql).await?,
+            self.config.second_degree_top_k,
+        );
+        if map.is_empty() {
+            return Ok(BuildOutcome::Empty);
+        }
+        // Same arithmetic impossibility as every reach facet: an account
+        // cannot be followed by more of the feed's authors than there are.
+        if (map.max_reach as usize) > seeds.len() {
+            anyhow::bail!(
+                "domain: max_reach {} exceeds {} seed authors — id map or projection corrupt",
+                map.max_reach,
+                seeds.len()
+            );
+        }
+
+        let blob = map.encode_as(crate::scored::FACET_DOMAIN, interner.idspace(), now_secs());
+        info!(
+            algo_id,
+            authors = seeds.len(),
+            reached = map.all_ids.len(),
+            scored = map.entries.len(),
+            max_reach = map.max_reach,
+            bytes = blob.len(),
+            "built domain facet"
+        );
+
+        // Keyed by algorithm id. Numeric, so it cannot collide with the
+        // DID-keyed viewer blobs sharing the prefix.
+        let key = format!("lens:v2:{FACET_DOMAIN}:{algo_id}");
+        let ttl = self.config.set_ttl.as_secs();
+        let mut conn = self.redis.get().await?;
+        deadpool_redis::redis::cmd("SET")
+            .arg(&key)
+            .arg(blob)
+            .arg("EX")
+            .arg(ttl)
+            .query_async::<()>(&mut conn)
+            .await?;
+        Ok(BuildOutcome::Published)
+    }
+
     pub async fn build(&self, viewer: &str, facet: &str) -> anyhow::Result<BuildOutcome> {
         // Reject an unknown facet before anything else, and in particular before
         // marking the viewer "building" — a state nothing would ever clear.
@@ -805,6 +888,7 @@ mod tests {
             FACET_POPULAR,
             FACET_VELOCITY,
             FACET_COMMUNITY,
+            FACET_DOMAIN,
         ] {
             assert!(is_buildable_facet(f), "{f} should build");
         }
@@ -813,6 +897,7 @@ mod tests {
         // degree under a name that promises a blend.
         assert!(!is_buildable_facet("network"));
         assert!(!is_buildable_facet("discover"));
+        assert!(!is_buildable_facet("expertise"));
         assert!(!is_buildable_facet("mutuals"), "not implemented yet");
         assert!(!is_buildable_facet(""));
         assert!(!is_buildable_facet("FOLLOWS"), "matching is exact");
@@ -829,6 +914,7 @@ mod tests {
             crate::scored::FACET_POPULAR,
             crate::scored::FACET_VELOCITY,
             crate::scored::FACET_COMMUNITY,
+            crate::scored::FACET_DOMAIN,
         ];
         let mut sorted = ids.to_vec();
         sorted.sort_unstable();

--- a/crates/graze-lens-builder/src/domain.rs
+++ b/crates/graze-lens-builder/src/domain.rs
@@ -1,0 +1,153 @@
+//! The `domain` facet: who a feed's own authors collectively follow.
+//!
+//! Every other facet answers a question about the *viewer's* graph. This one
+//! answers a question about the *feed's*: take the accounts whose posts the
+//! feed has recently kept — its live voice — and ask who they follow. A
+//! basketball feed's authors collectively follow the basketball world; their
+//! aggregated follow graph is a map of the domain's authorities that no
+//! keyword or classifier could produce.
+//!
+//! # Time decay is the "recent" in "recent authors"
+//!
+//! Each author seeds the traversal with a weight: the sum of `exp(-age/τ)`
+//! over their kept posts. An author the feed featured daily this week counts
+//! for far more than one who appeared twice last month, so the blob tracks the
+//! feed's *current* editorial center of gravity rather than its lifetime
+//! archive. τ = 10 days: a post's influence halves in about a week.
+//!
+//! # Feed-scoped, viewer-independent
+//!
+//! One blob per feed (`lens:v2:domain:{algo_id}`), shared by every reader.
+//! Personalization happens at serve time, where the reader SUMS this facet
+//! with the viewer's own graph facets — sum, not max, because "this feed's
+//! authors follow them" and "my network follows them" are different facts
+//! about an account, and holding both is genuinely stronger than either.
+
+use crate::priors::parse_prior_tsv;
+use crate::second_degree::{seed_list_of, SecondDegree};
+
+/// Half-life-ish decay constant, days.
+const DECAY_TAU_DAYS: f64 = 10.0;
+/// How far back a feed's authorship counts at all.
+const AUTHOR_WINDOW_DAYS: u32 = 30;
+/// Seed ceiling. A firehose feed can have tens of thousands of authors; past
+/// the strongest couple of thousand, the tail's weights are noise that costs
+/// query size.
+pub const MAX_SEED_AUTHORS: usize = 2_000;
+
+/// Time-decayed author weights for one feed.
+pub fn author_weights_query(database: &str, algo_id: u32) -> String {
+    format!(
+        "SELECT author, sum(exp(-dateDiff('day', created_at, now()) / {DECAY_TAU_DAYS})) AS w \
+         FROM {database}.algorithm_posts_v2 \
+         WHERE algo_id = {algo_id} \
+           AND created_at > now() - INTERVAL {AUTHOR_WINDOW_DAYS} DAY \
+         GROUP BY author \
+         ORDER BY w DESC, author ASC \
+         LIMIT {MAX_SEED_AUTHORS} \
+         FORMAT TabSeparated"
+    )
+}
+
+/// Parse `(author_did, weight)` rows.
+pub fn parse_author_weights(text: &str) -> Vec<(String, f64)> {
+    text.lines()
+        .filter_map(|line| {
+            let mut cols = line.split('\t');
+            let (did, w) = (cols.next()?, cols.next()?);
+            let w: f64 = w.trim().parse().ok()?;
+            if !did.starts_with("did:") || w <= 0.0 {
+                return None;
+            }
+            Some((did.trim().to_string(), w))
+        })
+        .collect()
+}
+
+/// Weighted reach: how much of the feed's recent voice follows each account.
+///
+/// Output columns are (id, reach, score) so `parse_prior_tsv` and the
+/// `reach ≤ seeds` invariant both carry over unchanged. The weights ride in a
+/// `values()` table on the RIGHT of the join (a couple of thousand rows), and
+/// the literal IN list keeps the primary-key pruning that makes this an
+/// index seek rather than a scan.
+pub fn weighted_reach_query(database: &str, seeds: &[(u32, f64)], cap: usize) -> String {
+    let ids: Vec<u32> = seeds.iter().map(|(id, _)| *id).collect();
+    let tuples: String = seeds
+        .iter()
+        .map(|(id, w)| format!("({id},{w:.6})"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "SELECT g.followee_int, uniqExact(g.follower_int) AS reach, sum(v.w) AS score \
+         FROM {database}.follow_graph_int AS g \
+         INNER JOIN (SELECT * FROM values('f UInt32, w Float64', {tuples})) AS v \
+             ON g.follower_int = v.f \
+         WHERE g.follower_int IN ({ids}) \
+         GROUP BY g.followee_int \
+         ORDER BY score DESC, g.followee_int ASC \
+         LIMIT {cap} \
+         FORMAT TabSeparated",
+        ids = seed_list_of(&ids),
+    )
+}
+
+/// Parse into a scored map. Same shape as the prior facets.
+pub fn parse_domain_tsv(text: &str, top_k: usize) -> SecondDegree {
+    parse_prior_tsv(text, top_k)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The seed query is where "expertise" gets its meaning: authors weighted
+    /// by decayed presence, not lifetime post count. A feed that pivoted last
+    /// month should have already pivoted its domain blob.
+    #[test]
+    fn author_weights_decay_and_window() {
+        let q = author_weights_query("default", 29094);
+        assert!(q.contains("exp(-dateDiff('day', created_at, now()) / 10)"));
+        assert!(q.contains("INTERVAL 30 DAY"));
+        assert!(q.contains("algo_id = 29094"));
+        assert!(q.contains("LIMIT 2000"));
+        assert!(!q.to_uppercase().contains("OFFSET"));
+    }
+
+    /// Weights ride a values() table on the RIGHT of the join (small side in
+    /// memory), and the literal IN list keeps primary-key pruning. Losing
+    /// either half re-runs the 21.6 GiB lesson.
+    #[test]
+    fn weighted_reach_keeps_pruning_and_small_right() {
+        let q = weighted_reach_query("default", &[(7, 1.5), (9, 0.25)], 100);
+        assert!(q.contains("IN (7,9)"), "literal ids prune the scan");
+        assert!(q.contains("values('f UInt32, w Float64', (7,1.500000),(9,0.250000))"));
+        let join_at = q.find("INNER JOIN (SELECT * FROM values").unwrap();
+        let from_at = q.find("FROM default.follow_graph_int").unwrap();
+        assert!(
+            from_at < join_at,
+            "the big table streams, the weights build"
+        );
+        assert!(q.contains("uniqExact(g.follower_int) AS reach"));
+        assert!(q.contains("sum(v.w) AS score"));
+    }
+
+    #[test]
+    fn author_rows_parse_and_reject_junk() {
+        let tsv = "did:plc:a\t3.5\nnot-a-did\t9\ndid:plc:b\t0\ndid:plc:c\t1.25\n";
+        let w = parse_author_weights(tsv);
+        assert_eq!(w.len(), 2);
+        assert_eq!(w[0].0, "did:plc:a");
+        assert!((w[1].1 - 1.25).abs() < 1e-9);
+    }
+
+    /// Output columns match the prior facets, so the invariant machinery —
+    /// including reach ≤ seeds — carries over without a parallel parser.
+    #[test]
+    fn domain_rows_reuse_the_prior_parser() {
+        let m = parse_domain_tsv("10\t5\t99.5\n20\t3\t42.0\n", 10);
+        assert_eq!(m.all_ids, vec![10, 20]);
+        assert_eq!(m.max_reach, 5);
+        assert_eq!(m.entries[0].1, crate::scored::WEIGHT_MAX);
+    }
+}

--- a/crates/graze-lens-builder/src/lib.rs
+++ b/crates/graze-lens-builder/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod builder;
 pub mod config;
+pub mod domain;
 pub mod interner;
 pub mod priors;
 pub mod queue;

--- a/crates/graze-lens-builder/src/main.rs
+++ b/crates/graze-lens-builder/src/main.rs
@@ -118,7 +118,20 @@ async fn main() -> anyhow::Result<()> {
                 let viewer = delivery.request.viewer_did.clone();
                 let facet = delivery.request.facet.clone();
 
-                match builder.build(&viewer, &facet).await {
+                // Feed-scoped facets carry an algorithm id and no viewer.
+                let result = if facet == "domain" {
+                    match delivery.request.feed_algo_id {
+                        Some(algo_id) => builder.build_domain(algo_id).await,
+                        None => {
+                            warn!(facet, "domain request without feed_algo_id; dropping");
+                            Ok(BuildOutcome::UnknownFacet)
+                        }
+                    }
+                } else {
+                    builder.build(&viewer, &facet).await
+                };
+
+                match result {
                     Ok(BuildOutcome::Published) => info!(viewer, facet, "lens published"),
                     Ok(BuildOutcome::Empty) => info!(viewer, facet, "viewer follows nobody"),
                     Ok(BuildOutcome::TooLarge) => warn!(viewer, facet, "lens over size budget"),

--- a/crates/graze-lens-builder/src/queue.rs
+++ b/crates/graze-lens-builder/src/queue.rs
@@ -16,8 +16,13 @@ pub const STREAM_KEY: &str = "queue:lens";
 /// One build request, as written by the serve path.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct BuildRequest {
+    /// Empty for feed-scoped builds (the `domain` facet), which have no viewer.
+    #[serde(default)]
     pub viewer_did: String,
     pub facet: String,
+    /// Set only for feed-scoped facets: the algorithm id whose blob to build.
+    #[serde(default)]
+    pub feed_algo_id: Option<u32>,
 }
 
 /// A request together with the stream id needed to acknowledge it.

--- a/crates/graze-lens-builder/src/scored.rs
+++ b/crates/graze-lens-builder/src/scored.rs
@@ -64,6 +64,7 @@ pub const FACET_NICHE: u8 = 3;
 pub const FACET_POPULAR: u8 = 4;
 pub const FACET_VELOCITY: u8 = 5;
 pub const FACET_COMMUNITY: u8 = 6;
+pub const FACET_DOMAIN: u8 = 7;
 
 /// The full-confidence weight. A first-degree follow is exactly this.
 pub const WEIGHT_MAX: u16 = u16::MAX;

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-fold-deployment.yaml
+++ b/kube/lens-fold-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: fold
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
           command: ["/app/graze-lens-fold"]
           resources:
             requests:

--- a/kube/lens-lpa-cronjob.yaml
+++ b/kube/lens-lpa-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
           containers:
             - name: lpa
               # Digest-pinned; updated together with the other lens workloads.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
               command: ["/app/graze-lens-lpa"]
               resources:
                 requests:

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               # Built from commit 1a835eb (feat/lens-completeness-guard).
               # Digest-pinned: both `latest` and the short-SHA tag are mutable
               # on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
               command: ["/app/graze-lens-project"]
               resources:
                 requests:

--- a/kube/lens-refresh-cronjob.yaml
+++ b/kube/lens-refresh-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
             - name: docr-graze-social-labs
           containers:
             - name: refresh
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:6dd2e6776768668e187c0667b84a840dd7eec9aa369101fb8ef8510a40a3afcc
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
               command: ["/app/graze-lens-refresh"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: rev-rebuild
               # Built from commit 1a835eb (feat/lens-completeness-guard). Digest-pinned:
               # both `latest` and the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:33c5d924c5f52403ac63b10b8604dbaf53eb5a2c5d6f4e03619ecbc865ec484a
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:


### PR DESCRIPTION
The first feed-scoped facet. Take the accounts whose posts the feed has kept in
the last 30 days — its live voice — weight each by time-decayed presence
(`exp(-age/10d)` per kept post), and aggregate who they follow. A basketball
feed's authors collectively follow the basketball world; the merged graph is a
map of the domain's authorities no keyword or classifier could produce.

One blob per algorithm id (`lens:v2:domain:{algo_id}`), shared by every reader —
personalization happens at serve time, where feeder-rs SUMS it with the viewer's
own facets (`expertise` = domain 1.0 + follows 0.5 + follows² 0.25). Sum, not
max: "this feed's authors follow them" and "my network follows them" are
different facts about an account, and holding both is genuinely stronger.

Deliberately not routed through the viewer build path — completeness guards and
PDS backfills mean nothing for a feed, and a feed with no recent authors is
Empty, not NeedsBackfill. The weighted-reach query keeps every scale lesson: the
weights ride a `values()` table on the small right side of the join, the literal
IN list keeps primary-key pruning, and `reach ≤ seed-author-count` is enforced
before publish.

Verified live on the bball feed: 56 recent authors → 2,666 accounts, max_reach
50, correct facet byte (7) and id space. Known tuning question, flagged rather
than solved solo: ubiquitous accounts (bsky.app) top the raw ranking because
every author follows them — same shape as the niche lesson, likely wants a
fame-dampened variant.