### PR TITLE
Reset the follow-seed window for the eligibility-gated population

### DIFF
--- a/analysis/experiments/follow_seed.yaml
+++ b/analysis/experiments/follow_seed.yaml
@@ -16,17 +16,23 @@ design: ab
 # ⚠️ MUST be set to the moment FOLLOW_SEED_EXPERIMENT_ENABLED goes live, and re-set on any change to
 # traffic_pct or salt — both move the hash boundary and reassign users, which starts a different
 # experiment. The holdout spec has already been reset twice for exactly this reason.
-# START. This is the FOURTH start for this experiment and the first that measures anything.
-# Three earlier windows contained no valid contrast because the treatment was inert:
-#   - the arm was threaded through `apply_thompson_params`, which is never called
-#   - the arm was nested under `params`, written only on the personalization-success path
-#   - the read path hung off the author-affinity branch, and AUTHOR_AFFINITY_ENABLED=false
-#   - the seed gate turned these users away BEFORE personalization was attempted, so no hook
-#     inside compute_personalization could reach them
+# START, 2026-08-31T16:49:48Z. Fifth start, and the first with a population the treatment can
+# actually reach.
 #
-# Set to the moment the gate fix finished rolling out. First confirmed engagement was 13:46:23Z:
-# follow_seed_fallback_engaged, algo 2323, 300 sources, seed_kind=follows.
-start: "2026-08-28T13:41:26Z"
+# Enrolment was traffic_pct=100 over all non-holdout users until now, and measured on 2026-08-31 only
+# 276 of 1,031 treated users had a `uf:` seed -- 73% of the treatment arm was untreatable and diluted
+# the ITT ~3.7x. Enrolment is now eligibility-gated (no like seed AND has a uf: seed), which trades N
+# (~2,062 units -> ~749) for effect size and nets roughly 2.2x on z.
+#
+# The estimand changes with it, deliberately: this now measures the effect on users follow-seeding
+# CAN reach, not a diluted average over people it never touches. The earlier window is not merely
+# under-powered, it was measuring a different and less meaningful quantity, so nothing interpretable
+# is discarded by resetting.
+#
+# The four windows before this measured nothing at all -- see the git history of this file: the arm
+# never reached the seed step, then was absent from no_user_data rows, then hung off a disabled
+# branch, then was blocked by the pre-personalization seed gate.
+start: "2026-08-31T16:49:48Z"
 
 unit: user
 primary_metric: like_rate

--- a/analysis/experiments/personalization_holdout.yaml
+++ b/analysis/experiments/personalization_holdout.yaml
@@ -33,6 +33,13 @@ design: ab
 # and NOT converging -- p had risen from 0.0952 as the sample grew -- so nothing that was going to
 # resolve was lost. The reason it could not resolve is the reason for the flip: ~39% of the treated
 # arm received no personalized content at all.
+# NOT reset for the 2026-08-31T16:49:48Z eligibility-gating change, deliberately.
+#
+# That change did alter which users receive follow-seeding, so a strict reading argues for a reset.
+# But it only affects the ~749 eligible users, a small fraction of this experiment's treated arm,
+# and this window is finally accruing real signal -- p has been falling as units grow rather than
+# rising as it did across 13 days of the previous window. Resetting a fourth time would cost more
+# than the contamination it removes. Judgment call, recorded rather than silent.
 start: "2026-08-28T13:41:26Z"
 unit: user
 primary_metric: like_rate

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:c7557ee198451aa4f613df4a6ac294bf889a0af07c7d7ecb5dc1c52197000964
+              image: dgaff/graze-analysis@sha256:573861b44a0456467695ff0842c1bf2606d2889e6380410d4aaa400e39c58264
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job

--- a/analysis/kube/coverage-cronjob.yaml
+++ b/analysis/kube/coverage-cronjob.yaml
@@ -210,7 +210,7 @@ spec:
                 name: personalization-coverage-src
           containers:
             - name: coverage
-              image: dgaff/graze-analysis@sha256:c7557ee198451aa4f613df4a6ac294bf889a0af07c7d7ecb5dc1c52197000964
+              image: dgaff/graze-analysis@sha256:573861b44a0456467695ff0842c1bf2606d2889e6380410d4aaa400e39c58264
               command: ["python", "/src/coverage.py"]
               volumeMounts:
                 - name: src

--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -145,7 +145,7 @@ spec:
                 name: personalization-dose-check-src
           containers:
             - name: dose
-              image: dgaff/graze-analysis@sha256:c7557ee198451aa4f613df4a6ac294bf889a0af07c7d7ecb5dc1c52197000964
+              image: dgaff/graze-analysis@sha256:573861b44a0456467695ff0842c1bf2606d2889e6380410d4aaa400e39c58264
               command: ["python", "/src/dose.py"]
               volumeMounts:
                 - name: src
@@ -154,7 +154,7 @@ spec:
                 # Must match the moment FOLLOW_SEED_EXPERIMENT_ENABLED went to 1. Re-set it if the
                 # experiment is ever restarted, or pre-flip rows silently join the control arm.
                 - name: FOLLOW_SEED_FLIP_AT
-                  value: "2026-08-28 13:41:26"
+                  value: "2026-08-31 16:49:48"
               envFrom:
                 - configMapRef:
                     name: personalization-env


### PR DESCRIPTION
**Fifth start**, and the first with a population the treatment can actually reach.

Enrolment was `traffic_pct=100` over all non-holdout users, and only **276 of 1,031** treated users had a `uf:` seed — 73% untreatable, ITT diluted ~3.7×.

The **estimand changes with the reset, deliberately**: this now measures the effect on users follow-seeding *can* reach, rather than a diluted average over people it never touches. The previous window was not merely under-powered — it was measuring a different and less meaningful quantity, so nothing interpretable is discarded.

## The holdout is deliberately NOT reset

Recorded in that spec rather than left implicit. Eligibility gating did change *which* users receive follow-seeding, so a strict reading argues for a reset — but it affects only the ~749 eligible users, a small fraction of the holdout's treated arm, and **that window is finally accruing real signal**: p has been falling as units grow, rather than rising as it did across 13 days of the previous window.

A fourth reset would cost more than the contamination it removes. Judgment call, stated rather than silent.

Dose-check `FOLLOW_SEED_FLIP_AT` updated to match, or pre-change rows would join the control arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)