### PR TITLE
Build the lens interner on the Redis the blobs live on

### DIFF
--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -173,17 +173,22 @@ impl Builder {
     /// The production builder: refuses to publish a lens for a viewer whose
     /// follow history has not been backfilled, and backfills them instead.
     ///
-    /// `interner_redis` is the Redis holding the **lens-owned** id space,
-    /// which now lives alongside the blobs rather than in the shared space on
-    /// the cache Redis. See `interner.rs` for why that split was made and what
-    /// it costs.
-    pub fn with_backfill(
-        redis: Pool,
-        interner_redis: Option<Pool>,
-        config: Config,
-    ) -> anyhow::Result<Self> {
-        let mut builder = Self::new(redis, config)?;
-        builder.interner = interner_redis.map(Interner::lens);
+    /// The lens-owned id space lives on the **same Redis as the blobs**, so the
+    /// interner is derived from `redis` here rather than passed in.
+    ///
+    /// It used to be a separate `Option<Pool>` argument, and that is exactly how
+    /// it broke: `Interner::lens` names the lens keys, but the caller built the
+    /// pool from `REDIS_URL` (the *cache* Redis). So `lensdid:{lensdid}:map`
+    /// existed on two instances at once — 42,049,737 entries on the lens Valkey,
+    /// where `project_rebuild` builds it and feeder-rs reads it, and a private
+    /// 9,499-entry map on the cache Redis that only the builder ever touched.
+    /// Every v2 blob was filled with ids from the small map and stamped with the
+    /// lens idspace byte, so it looked structurally perfect while no author
+    /// lookup on the serve path could ever match. Deriving the interner from the
+    /// blob pool makes the ids and the blobs impossible to separate again.
+    pub fn with_backfill(redis: Pool, config: Config) -> anyhow::Result<Self> {
+        let mut builder = Self::new(redis.clone(), config)?;
+        builder.interner = Some(Interner::lens(redis));
         let cfg = &builder.config;
 
         let http = reqwest::Client::builder()
@@ -978,5 +983,38 @@ mod tests {
     #[test]
     fn query_excludes_empty_followees() {
         assert!(FOLLOWS_QUERY.contains("followee != ''"));
+    }
+
+    fn test_pool() -> Pool {
+        // deadpool builds lazily; nothing connects until a call is made.
+        deadpool_redis::Config::from_url("redis://127.0.0.1:6379")
+            .builder()
+            .expect("pool builder")
+            .max_size(1)
+            .runtime(deadpool_redis::Runtime::Tokio1)
+            .build()
+            .expect("pool")
+    }
+
+    /// The interner must come from the SAME pool the blobs are published to.
+    ///
+    /// This is the invariant whose violation filled every v2 blob with ids from
+    /// a private 9,499-entry map on the cache Redis while the serve path looked
+    /// authors up in the 42M-entry lens space — a lens that could never match,
+    /// behind a blob that decoded perfectly. `with_backfill` no longer accepts a
+    /// separate pool, so the only thing left to pin is that it always builds one
+    /// and builds it in the lens space.
+    #[test]
+    fn interner_is_always_present_and_lens_spaced() {
+        let builder = Builder::with_backfill(test_pool(), Config::for_test()).expect("builder");
+        let interner = builder
+            .interner
+            .as_ref()
+            .expect("v2 must never be silently disabled: no interner means no v2 or follows2");
+        assert_eq!(
+            interner.idspace(),
+            crate::scored::IDSPACE_LENS,
+            "blobs are stamped with this byte; it must match the space the ids came from"
+        );
     }
 }

--- a/crates/graze-lens-builder/src/config.rs
+++ b/crates/graze-lens-builder/src/config.rs
@@ -131,6 +131,45 @@ impl Config {
             plc_directory: optional("LENS_BOOTSTRAP_PLC_DIRECTORY"),
         })
     }
+
+    /// Defaults with no environment read, for tests that need a `Config` but do
+    /// not care about its values. Deliberately not behind `cfg(test)`: the
+    /// integration tests in `tests/` are separate crates and cannot see it.
+    #[doc(hidden)]
+    pub fn for_test() -> Self {
+        Self {
+            redis_url: "redis://127.0.0.1:6379".to_string(),
+            redis_pool_size: 1,
+            clickhouse: ClickHouseConfig {
+                host: "localhost".to_string(),
+                port: 8123,
+                database: "default".to_string(),
+                user: "default".to_string(),
+                password: String::new(),
+                secure: false,
+            },
+            max_execution_seconds: 20,
+            query_timeout: Duration::from_secs(25),
+            consumer_group: "builders".to_string(),
+            consumer_name: "lens-builder-test".to_string(),
+            batch_size: 16,
+            block: Duration::from_millis(5_000),
+            set_ttl: Duration::from_secs(604_800),
+            max_set_size: 200_000,
+            metrics_port: 9090,
+            second_degree_top_k: 20_000,
+            second_degree_cap: 500_000,
+            velocity_days: 7,
+            community_top: 3,
+            concurrency: 8,
+            drain_timeout: Duration::from_secs(30),
+            backfill_request_timeout: Duration::from_secs(20),
+            backfill_page_delay: Duration::from_millis(150),
+            backfill_max_pages: 600,
+            backfill_max_retries: 4,
+            plc_directory: None,
+        }
+    }
 }
 
 fn optional(name: &str) -> Option<String> {

--- a/crates/graze-lens-builder/src/main.rs
+++ b/crates/graze-lens-builder/src/main.rs
@@ -36,36 +36,12 @@ async fn main() -> anyhow::Result<()> {
     );
     queue.ensure_group().await.context("consumer group")?;
 
-    // The shared DID interner lives on the *cache* Redis, a different instance
-    // from the one lens blobs are published to. Optional: without it the
-    // builder still serves v1 sets, it just cannot build v2 or follows².
-    let interner_pool = match std::env::var("REDIS_URL").ok().filter(|u| !u.is_empty()) {
-        Some(url) => {
-            let built = RedisConfig::from_url(url)
-                .builder()
-                .map_err(anyhow::Error::from)
-                .and_then(|b| {
-                    b.max_size(4)
-                        .runtime(Runtime::Tokio1)
-                        .build()
-                        .map_err(anyhow::Error::from)
-                });
-            match built {
-                Ok(p) => Some(p),
-                Err(e) => {
-                    warn!(error = %e, "interner redis unavailable; v2 and follows2 disabled");
-                    None
-                }
-            }
-        }
-        None => {
-            warn!("REDIS_URL unset; v2 and follows2 disabled");
-            None
-        }
-    };
-
-    let builder =
-        Arc::new(Builder::with_backfill(pool, interner_pool, config.clone()).context("builder")?);
+    // The lens id space is NOT the shared `didint` space on the cache Redis; it
+    // is `lensdid:{lensdid}:map` on the same instance the blobs are published
+    // to, built by `project_rebuild` and read by feeder-rs. So the builder
+    // derives its interner from the blob pool — passing a separate pool here is
+    // what put cache-Redis ids inside lens-space blobs for days.
+    let builder = Arc::new(Builder::with_backfill(pool, config.clone()).context("builder")?);
     let queue = Arc::new(queue);
     let semaphore = Arc::new(tokio::sync::Semaphore::new(config.concurrency.max(1)));
 

--- a/crates/graze-lens-builder/tests/community_repro.rs
+++ b/crates/graze-lens-builder/tests/community_repro.rs
@@ -1,0 +1,129 @@
+//! The `community` facet must rank the reader's STRONGEST community first.
+//!
+//! Written while chasing an identical-for-every-reader `community` blob in prod.
+//! The affinity math turned out to be correct — this test is what proved it, by
+//! running the real parsers over the exact TSVs prod's builder had received and
+//! showing the top-20,000 come from the reader's strongest community. The actual
+//! fault was upstream: the builder interned its *seeds* against a private
+//! 9,499-entry `lensdid` map on the cache Redis instead of the 42M-entry lens
+//! space the ClickHouse tables are keyed by, so every seed id named an unrelated
+//! account. Keeping this test guards the half that was never broken, so a future
+//! change to the weighting cannot quietly invert it.
+//!
+//! Env-gated like the other live-data tests in this crate: point it at TSVs
+//! captured from prod with the builder's own two queries and it reports what
+//! `parse_affinity_tsv` + `parse_members_tsv` actually do with them.
+//!
+//!   COMMUNITY_AFFINITY_TSV=affinity.tsv \
+//!   COMMUNITY_MEMBERS_TSV=members.tsv \
+//!   COMMUNITY_SEEDS=1187 \
+//!   cargo test -p graze-lens-builder --test community_repro -- --nocapture
+
+use std::collections::HashMap;
+
+use graze_lens_builder::priors;
+
+#[test]
+fn community_entries_reflect_the_viewers_affinity() {
+    let (Ok(aff_path), Ok(mem_path)) = (
+        std::env::var("COMMUNITY_AFFINITY_TSV"),
+        std::env::var("COMMUNITY_MEMBERS_TSV"),
+    ) else {
+        eprintln!("skipping: COMMUNITY_AFFINITY_TSV / COMMUNITY_MEMBERS_TSV unset");
+        return;
+    };
+    let seeds: usize = std::env::var("COMMUNITY_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .expect("COMMUNITY_SEEDS required");
+
+    let aff_text = std::fs::read_to_string(&aff_path).expect("read affinity tsv");
+    let mem_text = std::fs::read_to_string(&mem_path).expect("read members tsv");
+
+    let affinity = priors::parse_affinity_tsv(&aff_text, seeds);
+    println!("\n=== affinity as the code parses it (seeds={seeds}) ===");
+    for (c, s) in &affinity {
+        println!("  community {c:>10}  share {s:.6}");
+    }
+
+    // account -> community, straight from the same TSV the builder consumed.
+    let mut community_of: HashMap<u32, u32> = HashMap::new();
+    let mut followers_of: HashMap<u32, u64> = HashMap::new();
+    for line in mem_text.lines() {
+        let mut cols = line.split('\t');
+        if let (Some(a), Some(c), Some(f)) = (cols.next(), cols.next(), cols.next()) {
+            if let (Ok(a), Ok(c), Ok(f)) = (a.trim().parse(), c.trim().parse(), f.trim().parse()) {
+                community_of.insert(a, c);
+                followers_of.insert(a, f);
+            }
+        }
+    }
+    println!("members rows parsed: {}", community_of.len());
+
+    let top_k = 20_000;
+    let map = priors::parse_members_tsv(&mem_text, &affinity, top_k);
+    println!(
+        "\n=== parse_members_tsv -> entries={} all_ids={} ===",
+        map.entries.len(),
+        map.all_ids.len()
+    );
+
+    let mut by_community: HashMap<u32, usize> = HashMap::new();
+    for (id, _) in &map.entries {
+        *by_community
+            .entry(community_of.get(id).copied().unwrap_or(u32::MAX))
+            .or_default() += 1;
+    }
+    let mut rows: Vec<_> = by_community.into_iter().collect();
+    rows.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+    println!("community breakdown of the top-{top_k} entries:");
+    for (c, n) in &rows {
+        let share = affinity
+            .iter()
+            .find(|(k, _)| k == c)
+            .map(|(_, s)| *s)
+            .unwrap_or(f32::NAN);
+        println!("  community {c:>10}  entries {n:>6}  share {share:.6}");
+    }
+
+    // Which account set the normalisation max, and what it looks like.
+    if let Some((top_id, top_w)) = map.entries.iter().max_by_key(|(_, w)| *w) {
+        println!(
+            "\nhighest-weight entry: account {top_id} weight {top_w} community {:?} followers {:?}",
+            community_of.get(top_id),
+            followers_of.get(top_id)
+        );
+    }
+    let scores: Vec<u16> = map.entries.iter().map(|(_, w)| *w).collect();
+    println!(
+        "weight range: {:?} .. {:?}",
+        scores.iter().min(),
+        scores.iter().max()
+    );
+
+    // Dump entries so the prod blob can be diffed against them.
+    if let Ok(out) = std::env::var("COMMUNITY_DUMP_ENTRIES") {
+        let body: String = map
+            .entries
+            .iter()
+            .map(|(id, w)| format!("{id}\t{w}\n"))
+            .collect();
+        std::fs::write(&out, body).expect("write dump");
+        println!("dumped {} entries to {out}", map.entries.len());
+    }
+
+    // The claim under test: a reader's strongest community should dominate.
+    let strongest = affinity
+        .iter()
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+        .map(|(c, _)| *c)
+        .expect("affinity non-empty");
+    let winner = rows.first().map(|(c, _)| *c).expect("entries non-empty");
+    println!(
+        "\nstrongest-affinity community = {strongest}; community dominating entries = {winner}"
+    );
+    assert_eq!(
+        strongest, winner,
+        "the facet ranked a community the reader cares about LESS above their strongest one"
+    );
+}

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
           command: ["/app/graze-lens-builder"]
           resources:
             requests:
@@ -89,7 +89,7 @@ spec:
             - name: LENS_SET_TTL_SECONDS
               value: "604800"
             - name: LENS_QUERY_MAX_EXECUTION_SECONDS
-              value: "20"
+              value: "60"
             - name: LENS_MAX_SET_SIZE
               value: "200000"
             - name: RUST_LOG

--- a/kube/lens-fold-deployment.yaml
+++ b/kube/lens-fold-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: fold
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
           command: ["/app/graze-lens-fold"]
           resources:
             requests:

--- a/kube/lens-lpa-cronjob.yaml
+++ b/kube/lens-lpa-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
           containers:
             - name: lpa
               # Digest-pinned; updated together with the other lens workloads.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
               command: ["/app/graze-lens-lpa"]
               resources:
                 requests:

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               # Built from commit 1a835eb (feat/lens-completeness-guard).
               # Digest-pinned: both `latest` and the short-SHA tag are mutable
               # on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
               command: ["/app/graze-lens-project"]
               resources:
                 requests:

--- a/kube/lens-refresh-cronjob.yaml
+++ b/kube/lens-refresh-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
             - name: docr-graze-social-labs
           containers:
             - name: refresh
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
               command: ["/app/graze-lens-refresh"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: rev-rebuild
               # Built from commit 1a835eb (feat/lens-completeness-guard). Digest-pinned:
               # both `latest` and the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:9bc76cffb666cd69d83f2153902d06475081fef2c63d1d4b2af356934e554c09
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:


### PR DESCRIPTION
Every v2 lens blob in prod held ids from the wrong id space, so no lens could match an author. The feature was inert behind its own fail-open path, which is why it looked fine.

## What was wrong

`lensdid:{lensdid}:map` existed on two instances at once:

| | HLEN | Devin's id |
|---|---|---|
| lens Valkey (`LENS_REDIS_URL`) — `project_rebuild` writes it, feeder-rs reads it, every ClickHouse table is keyed by it | 42,049,737 | 40,671,232 |
| cache Redis (`REDIS_URL`) — the builder's private copy | 9,499 | 613 |

`with_backfill` took a separate `interner_redis` pool and `main.rs` built it from `REDIS_URL`, so `Interner::lens` named the lens keys on the wrong host and get-or-create grew a map nothing else shared. A half-migration: `Interner::shared` → `Interner::lens` happened without moving the pool, and the stale comment above the call site still described the old design.

The blobs decoded perfectly — right magic, right facet byte, right idspace byte (it records the space the builder *intended*, not where the ids came from), plausible counts, fresh TTLs. Devin's `follows` blob held exactly his 1,187 follows with every id between 1 and 9,485 and none in the 42M range the serve path looks up. Matches happened only where a real lens id fell under 9,499.

`community` was the symptom that surfaced, because its entries come from ClickHouse in the real space while only its seeds were wrong: 20,000 entries, byte-identical for all 8 cohort readers, from a community that was not the reader's strongest. Every reader's seeds landed in the same 9,499-wide range, so every affinity resolved the same way. It also explains `exclude_first_degree` removing 3 ids out of 500,000 — it was subtracting cache-space seeds from lens-space entries.

## The fix

`with_backfill` no longer accepts a pool for this; it derives the interner from the pool it publishes blobs to, so ids and blobs cannot be separated again. The interner is also no longer optional — `REDIS_URL` being unset used to disable v2 silently.

## Verified in prod

Deployed `sha256:08d0376a…`, cleared the stale 9,499-entry map, re-ran the refresh:

- Devin's `follows` blob is now an **exact set match** to the 1,187 lens ids of his real followees; **0** ids in the old range.
- All 8 `community` blobs are **distinct** at every sampled offset (were byte-identical); sizes 640,212–644,052 (were all 644,316).
- Reach is realistic everywhere: `niche` 580 → 49,238, `popular` 11,005 → 173,109, `velocity` a few hundred bytes → 9.6k–72k, bball `domain` 2,707 → 19,495 authors reached.
- The cache-Redis map has stayed absent since the roll.
- bball now keeps 22 of 28 authors for Devin, 16 of them with verifiable second-degree reach (the 6 dropped have no lens id at all).

## Tests

`interner_is_always_present_and_lens_spaced` pins presence and idspace. The env-gated `community_repro` test pins the affinity weighting this hunt cleared — the math was never the fault.

fmt, `clippy --all-targets --all-features -D warnings`, and the suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)