### PR TITLE
Gate scroll_depth on its own confidence sequence too

### DIFF
--- a/analysis/graze_analysis/runner.py
+++ b/analysis/graze_analysis/runner.py
@@ -193,6 +193,12 @@ def _scroll_depth_lines(spec: ExperimentSpec, reader: ClickHouseReader) -> list[
     This is a SECONDARY outcome. More scrolling is not unambiguously better: this codebase already
     measured zero-seed users paginating at a ~1s cadence, which is scanning rather than reading. A
     move here is a prompt to investigate, not a result on its own.
+
+    It gets the same anytime-valid treatment as the primary, and for the same reason: it is read
+    hourly. It needed it MORE, not less. On 2026-09-01 this was the only significant-looking number
+    left in the readout once the primary was gated (+14.0%, p=0.0155) -- which is exactly the
+    position a fixed-horizon test should not be trusted from. Being a secondary means it does not
+    move the top-line verdict; it does not mean it may be read loosely.
     """
     if spec.scroll_depth is None:
         return []
@@ -201,11 +207,25 @@ def _scroll_depth_lines(spec: ExperimentSpec, reader: ClickHouseReader) -> list[
     if len(rows) == 0:
         return [f"  scroll_depth (winsorized p{int(q * 100)}): no rows"]
     est = cluster_robust_rate_diff(rows.unit_ids, rows.arm, rows.numerator, rows.denominator)
-    return [
-        f"  scroll_depth (winsorized p{int(q * 100)}, impressions/user): {est.describe()}",
+    # Denominator is 1 per unit here, so this is the winsorized impression COUNT per user, not a
+    # rate. The estimand is labelled accordingly rather than inheriting the default.
+    treated = rows.arm > 0.5
+    per_unit = rows.numerator / np.maximum(rows.denominator, 1.0)
+    seq = always_valid_diff_ci(
+        per_unit[~treated], per_unit[treated], estimand="winsorized impressions/user"
+    )
+    out = [
+        f"  scroll_depth (winsorized p{int(q * 100)}) GATE: {seq.describe()}",
+        f"    {est.describe()}   [fixed-horizon, diagnostic]",
         f"    (secondary outcome; cap declared in the spec, pooled across arms, "
         f"units={len(rows):,})",
     ]
+    if est.significant and not seq.conclusive:
+        out.append(
+            "    !! the fixed-horizon test reads significant and the sequence does not. This line "
+            "is read hourly, so the sequence is the one that holds."
+        )
+    return out
 
 
 def _guardrail_lines(spec: ExperimentSpec, reader: ClickHouseReader) -> list[str]:

--- a/analysis/graze_analysis/stats.py
+++ b/analysis/graze_analysis/stats.py
@@ -303,6 +303,9 @@ class SequentialEstimate:
     n_control: int
     n_treatment: int
     variance_reduction: float = 0.0
+    #: What the difference is *of*. Named because this class is used for a like RATE and for a
+    #: winsorized impression COUNT, and printing "per-unit rate" over a count would misdescribe it.
+    estimand: str = "unweighted per-unit rate"
 
     @property
     def conclusive(self) -> bool:
@@ -317,7 +320,7 @@ class SequentialEstimate:
             f" cuped={self.variance_reduction:.1%}" if self.variance_reduction > 0 else ""
         )
         return (
-            f"anytime-valid on the arm DIFFERENCE (unweighted per-unit rate): "
+            f"anytime-valid on the arm DIFFERENCE ({self.estimand}): "
             f"diff={self.diff:+.4f} ({rel}) CI [{self.low:+.4f}, {self.high:+.4f}] "
             f"units={self.n_control + self.n_treatment}{cuped} "
             f"{'SEPARATED FROM ZERO' if self.conclusive else 'includes zero'}"
@@ -330,6 +333,7 @@ def always_valid_diff_ci(
     alpha: float = 0.05,
     rho: float = 1.0,
     variance_reduction: float = 0.0,
+    estimand: str = "unweighted per-unit rate",
 ) -> SequentialEstimate:
     """Confidence sequence for the DIFFERENCE of two arm means (treatment minus control).
 
@@ -358,6 +362,7 @@ def always_valid_diff_ci(
         return SequentialEstimate(
             diff=float("nan"), rel=float("nan"), low=float("-inf"), high=float("inf"),
             n_control=nc, n_treatment=nt, variance_reduction=variance_reduction,
+            estimand=estimand,
         )
     mc, mt = float(c.mean()), float(t_.mean())
     diff = mt - mc
@@ -379,11 +384,13 @@ def always_valid_diff_ci(
         return SequentialEstimate(
             diff=diff, rel=rel, low=float("-inf"), high=float("inf"),
             n_control=nc, n_treatment=nt, variance_reduction=variance_reduction,
+            estimand=estimand,
         )
     radius = _normal_mixture_radius(var, nc + nt, alpha, rho)
     return SequentialEstimate(
         diff=diff, rel=rel, low=diff - radius, high=diff + radius,
         n_control=nc, n_treatment=nt, variance_reduction=variance_reduction,
+        estimand=estimand,
     )
 
 def insufficient_data_gate(estimate: Estimate, min_observations: int) -> tuple[bool, str]:

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:3281127e0496941d5fda42a5a5077c3a5298dbd411d370293a58d9a3842a8e94
+              image: dgaff/graze-analysis@sha256:01a0057ae7bfe3e25b549f4f8cae2b355f896e8bdab81f8254f56789c6270004
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job

--- a/analysis/kube/coverage-cronjob.yaml
+++ b/analysis/kube/coverage-cronjob.yaml
@@ -210,7 +210,7 @@ spec:
                 name: personalization-coverage-src
           containers:
             - name: coverage
-              image: dgaff/graze-analysis@sha256:3281127e0496941d5fda42a5a5077c3a5298dbd411d370293a58d9a3842a8e94
+              image: dgaff/graze-analysis@sha256:01a0057ae7bfe3e25b549f4f8cae2b355f896e8bdab81f8254f56789c6270004
               command: ["python", "/src/coverage.py"]
               volumeMounts:
                 - name: src

--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -145,7 +145,7 @@ spec:
                 name: personalization-dose-check-src
           containers:
             - name: dose
-              image: dgaff/graze-analysis@sha256:3281127e0496941d5fda42a5a5077c3a5298dbd411d370293a58d9a3842a8e94
+              image: dgaff/graze-analysis@sha256:01a0057ae7bfe3e25b549f4f8cae2b355f896e8bdab81f8254f56789c6270004
               command: ["python", "/src/dose.py"]
               volumeMounts:
                 - name: src

--- a/analysis/tests/test_runner_gates.py
+++ b/analysis/tests/test_runner_gates.py
@@ -425,3 +425,91 @@ def test_cuped_is_reported_but_does_not_move_the_gate():
 
     # The gate itself is byte-identical with and without the covariate.
     assert with_cuped.lines[0] == plain.lines[0], (with_cuped.lines[0], plain.lines[0])
+
+
+# --- The secondary gets the same peeking protection ------------------------------------------
+#
+# scroll_depth is read hourly like everything else. Being a SECONDARY means it does not move the
+# top-line verdict, not that it may be read loosely -- and on 2026-09-01 it was the only
+# significant-looking number left once the primary was gated (+14.0%, p=0.0155).
+
+
+def _scroll_reader(primary, scroll, control=None):
+    class R:
+        def query(self, sql):
+            if "cap AS (" in sql:
+                return scroll
+            return primary if "source = 'fallback'" not in sql else (control or _null_control())
+
+    return R()
+
+
+def test_scroll_depth_carries_its_own_anytime_valid_gate():
+    # Counts vary within arm, so the variance estimate is real rather than float residue.
+    scroll = []
+    for k in range(3):
+        scroll += _uneven(f"sc{k}_", 100, 8 + k, 1, 10000)
+        scroll += _uneven(f"st{k}_", 100, 14 + k, 1, 250)
+    readout = analyse_ab(_scroll_spec(), _scroll_reader(_weight_trap_rows(), scroll))
+
+    gate = next(l for l in readout.lines if "scroll_depth" in l and "GATE" in l)
+    # Labelled as a COUNT, not a rate -- the denominator is 1 per unit here.
+    assert "winsorized impressions/user" in gate, gate
+    assert "unweighted per-unit rate" not in gate, gate
+    assert "arm DIFFERENCE" in gate, gate
+    # A real, large gap in impressions/user must clear it.
+    assert "SEPARATED FROM ZERO" in gate, gate
+
+
+def test_scroll_depths_fixed_horizon_line_is_marked_diagnostic():
+    scroll = _uneven("sc", 150, 8, 1, 10000) + _uneven("st", 150, 9, 1, 250)
+    readout = analyse_ab(_scroll_spec(), _scroll_reader(_weight_trap_rows(), scroll))
+    idx = next(i for i, l in enumerate(readout.lines) if "scroll_depth" in l and "GATE" in l)
+    assert "[fixed-horizon, diagnostic]" in readout.lines[idx + 1], readout.lines[idx + 1]
+    assert "secondary outcome" in readout.lines[idx + 2], readout.lines[idx + 2]
+
+
+def test_a_significant_secondary_whose_sequence_is_quiet_is_flagged_not_believed():
+    """The 2026-09-01 shape: fixed-horizon significant, sequence includes zero.
+
+    NOTE the mechanism differs from the primary's. scroll_depth carries a denominator of 1 per
+    unit, so impression weighting is uniform and both estimands agree exactly (+11.6129 here).
+    The divergence is purely the peeking correction: a boundary of ~3.7 SE against 1.96 SE. A
+    heavy tail is what makes the SE large enough for that to bite -- 10 users of 310 hold most of
+    the mass, which is the real shape of this data.
+    """
+    scroll = (
+        _uneven("scl", 300, 1, 1, 10000)
+        + _uneven("sch", 10, 40, 1, 10000)
+        + _uneven("stl", 300, 1, 1, 250)
+        + _uneven("sth", 10, 400, 1, 250)
+    )
+    readout = analyse_ab(_scroll_spec(), _scroll_reader(_weight_trap_rows(), scroll))
+    idx = next(i for i, l in enumerate(readout.lines) if "scroll_depth" in l and "GATE" in l)
+    gate, fixed = readout.lines[idx], readout.lines[idx + 1]
+
+    # Precondition, asserted rather than assumed: the two genuinely disagree here.
+    assert "SIGNIFICANT" in fixed and "not significant" not in fixed, fixed
+    assert "includes zero" in gate, gate
+    # ...so the reader must be told which one holds.
+    assert "the sequence is the one that holds" in readout.lines[idx + 3], readout.lines[idx + 3]
+
+
+def test_the_secondary_gate_never_moves_the_top_line_verdict():
+    """A secondary may not promote itself into the verdict, gated or not."""
+    # Primary gate is quiet; scroll depth is enormous and clears its own gate.
+    scroll = []
+    for k in range(3):
+        scroll += _uneven(f"sc{k}_", 100, 1 + k, 1, 10000)
+        scroll += _uneven(f"st{k}_", 100, 90 + k, 1, 250)
+    readout = analyse_ab(_scroll_spec(), _scroll_reader(_weight_trap_rows(), scroll))
+
+    scroll_gate = next(l for l in readout.lines if "scroll_depth" in l and "GATE" in l)
+    assert "SEPARATED FROM ZERO" in scroll_gate, scroll_gate
+    # ...and the verdict still reflects the PRIMARY only.
+    assert "NO EFFECT ESTABLISHED" in readout.verdict, readout.render()
+    # The primary's gate leads; the secondary sits below it.
+    assert readout.lines[0].strip().startswith("GATE")
+    primary_at = next(i for i, l in enumerate(readout.lines) if "primary" in l)
+    scroll_at = next(i for i, l in enumerate(readout.lines) if "scroll_depth" in l)
+    assert scroll_at > primary_at


### PR DESCRIPTION
Follow-up to #55, which gated the primary and left this gap open by design.

## Why

Being a **secondary** means scroll_depth does not move the top-line verdict. It does not mean it may be read loosely. It is read hourly like everything else, and once #55 gated the primary it became the **only significant-looking number left in the readout** — which is exactly the position from which a fixed-horizon test should not be trusted.

Measured on live ClickHouse:

```
scroll_depth (winsorized p90) GATE: diff=+2.3798 (+15.0%) CI [-0.9781, +5.7376]  includes zero
  cluster-robust (WLS, clustered SE): diff=+2.3798 (+15.0%) p=0.0084 SIGNIFICANT  [fixed-horizon, diagnostic]
  !! the fixed-horizon test reads significant and the sequence does not. This line is read hourly,
     so the sequence is the one that holds.
```

## The mechanism differs from the primary's, and the code now says so

scroll_depth carries a **denominator of 1 per unit**, so impression weighting is uniform and both estimands agree *exactly* (`+2.3798` either way). The divergence is purely the peeking boundary — ~3.7 SE against 1.96 SE — with the heavy tail supplying enough SE for that to bite.

That is worth stating explicitly because it is *not* what happened on the primary, where weighting was most of the gap (`+317.8%` weighted vs `+19.1%` unweighted). Two different reasons a fixed-horizon reading overstated the case; conflating them would invite the wrong fix later.

## Also

`SequentialEstimate` now carries an `estimand` label. The default reads "unweighted per-unit rate", which would misdescribe scroll_depth — its outcome is a winsorized impression **count**, not a rate.

## Net position

**Nothing in the personalization experiments has an established effect.** Not the holdout primary, not its secondary. `follow_seed` remains `WITHHELD` below its 2,000-observation floor (~2 days out). That is a real change in what we believe, and it is the honest reading rather than a pessimistic one — the point estimates are unchanged; only the claim that they clear a significance bar has gone.

## Verification

- 85 tests pass (4 new), including an asserted-precondition test that pins the exact 2026-09-01 shape: fixed-horizon significant *and* sequence including zero, deterministically, with no RNG.
- Validated against live ClickHouse via a `subPath` overlay on the pinned image before building, then end-to-end from the real CronJob after.
- `pip freeze` byte-identical to the previous build — code-only change.

## Deploy

`dgaff/graze-analysis@sha256:01a0057ae7bfe3e25b549f4f8cae2b355f896e8bdab81f8254f56789c6270004` (tag `gate2-20260901`), all three CronJobs. Rollback `sha256:3281127e0496`.

Committed from a separate git worktree: another session is working `crates/` in the primary checkout, and switching branches there would have swapped its files mid-task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)