### PR TITLE
Let CUPED adjust the gate again, behind a covariate balance check

### DIFF
--- a/analysis/graze_analysis/__init__.py
+++ b/analysis/graze_analysis/__init__.py
@@ -9,8 +9,11 @@ from .spec import ExperimentSpec, SpecError, load_spec, spec_from_dict
 from .stats import (
     ControlVerdict,
     Estimate,
+    SequentialEstimate,
     always_valid_ci,
+    always_valid_diff_ci,
     cluster_robust_rate_diff,
+    covariate_balance,
     cuped_adjust,
     insufficient_data_gate,
     negative_control_gate,
@@ -28,6 +31,9 @@ __all__ = [
     "permutation_rate_diff",
     "cuped_adjust",
     "always_valid_ci",
+    "always_valid_diff_ci",
+    "SequentialEstimate",
+    "covariate_balance",
     "insufficient_data_gate",
     "negative_control_gate",
 ]

--- a/analysis/graze_analysis/runner.py
+++ b/analysis/graze_analysis/runner.py
@@ -32,6 +32,7 @@ from .stats import (
     always_valid_diff_ci,
     cluster_robust_rate_diff,
     control_moved,
+    covariate_balance,
     cuped_adjust,
     insufficient_data_gate,
     negative_control_gate,
@@ -113,24 +114,56 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
             straddlers += 1
 
     treated = primary_rows.arm > 0.5
-    # The gate is the UNADJUSTED difference. CUPED is computed and shown below, but deliberately
-    # does not drive the verdict: `cuped_covariate_sql` measures the 14 days before `spec.start`,
-    # and for a window that was RESET rather than begun fresh, that period is already under
-    # treatment. Measured 2026-09-01 on the holdout -- pre-period like rate 0.00839 control vs
-    # 0.00999 treatment, an "imbalance" pointing the same way as the effect, because the holdout
-    # has suppressed personalization for its control arm continuously since 2026-08-14.
-    # Subtracting that removes real signal rather than noise: it shrank the estimate from
-    # +0.00180 to +0.00045. Coverage is thin besides (11.9% of control units, 17.3% of treatment
-    # have any pre-period row), so the reduction rests on a minority of the sample.
-    seq = always_valid_diff_ci(per_unit_rate[~treated], per_unit_rate[treated])
+
+    # CUPED adjusts the outcome BEFORE the gate is formed -- but only after the covariate is shown
+    # to be something the treatment cannot have moved. That order matters, and it is the second
+    # thing this readout got wrong: the covariate was first computed and discarded into `_`, then
+    # (2026-09-01) demoted to a diagnostic on the theory that a reset window's pre-period is
+    # "already under treatment", because the imbalance pointed the same way as the effect.
+    # Re-randomizing the arm labels refuted that -- observed +0.00242 against a null sd of 0.00325,
+    # p=0.459, sign REVERSING in an earlier window. It is chance, and a pre-treatment window is
+    # measurably WORSE (29.3% reduction against 46.2%) because it is further from the outcome.
+    # So it adjusts, and the balance check below is what keeps that honest.
+    outcome, reduction, balance = per_unit_rate, 0.0, None
+    if spec.cuped_covariate:
+        pre = {str(u): (float(l), float(s_)) for u, l, s_ in reader.query(cuped_covariate_sql(spec))}
+        covered = np.array([u in pre and pre[u][1] > 0 for u in primary_rows.unit_ids])
+        cov = np.array(
+            [
+                (pre[u][0] / pre[u][1]) if u in pre and pre[u][1] else 0.0
+                for u in primary_rows.unit_ids
+            ]
+        )
+        imbalance, p_bal = covariate_balance(cov, treated, covered)
+        adjusted, reduction = cuped_adjust(per_unit_rate, cov)
+        # A covariate the treatment moved would subtract real signal. Fall back rather than guess.
+        balanced = not (p_bal == p_bal) or p_bal > 0.05  # nan -> too little data to reject
+        if balanced:
+            outcome = adjusted
+        balance = (imbalance, p_bal, covered, balanced, reduction)
+        # Only advertise a reduction that was actually taken. A withheld adjustment that still
+        # printed `cuped=60.0%` on the gate line would claim precision the interval does not have.
+        applied_reduction = reduction if balanced else 0.0
+    else:
+        applied_reduction = 0.0
+
+    seq = always_valid_diff_ci(
+        outcome[~treated], outcome[treated], variance_reduction=applied_reduction
+    )
 
     lines.insert(0, f"  GATE     : {seq.describe()}")
     lines.insert(1, f"  primary  : {primary.describe()}   [fixed-horizon, diagnostic]")
     if straddlers:
+        share = straddlers / max(len(set(primary_rows.unit_ids)), 1)
+        note = (
+            " Fix before reading."
+            if share > 0.01
+            else " Too few to move the estimate; watch it rather than act on it."
+        )
         lines.insert(
             0,
-            f"  !! {straddlers} unit(s) appear in BOTH arms -- randomization is leaking and the "
-            "gate's independence assumption does not hold. Fix before reading.",
+            f"  !! {straddlers} unit(s) ({share:.2%}) appear in BOTH arms -- the gate assumes "
+            f"independent arms.{note}",
         )
 
     perm = permutation_rate_diff(
@@ -144,27 +177,20 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
         "(a LEVEL, not an effect -- cannot contain zero)"
     )
 
-    if spec.cuped_covariate:
-        pre = {str(u): (float(l), float(s)) for u, l, s in reader.query(cuped_covariate_sql(spec))}
-        cov = np.array(
-            [
-                (pre[u][0] / pre[u][1]) if u in pre and pre[u][1] else 0.0
-                for u in primary_rows.unit_ids
-            ]
-        )
-        adjusted, reduction = cuped_adjust(per_unit_rate, cov)
-        adj_seq = always_valid_diff_ci(
-            adjusted[~treated], adjusted[treated], variance_reduction=reduction
-        )
+    if balance is not None:
+        imbalance, p_bal, covered, balanced, reduction = balance
+        state = "APPLIED to the gate" if balanced else "WITHHELD from the gate"
+        lines.append(f"  CUPED variance reduction: {reduction:.1%} ({state})")
         lines.append(
-            f"  CUPED variance reduction: {reduction:.1%}; adjusted gate would be "
-            f"[{adj_seq.low:+.4f}, {adj_seq.high:+.4f}]"
+            f"    covariate balance: {imbalance:+.5f} between arms, re-randomization p={p_bal:.3f}"
+            f"; pre-period data for {covered[~treated].mean():.1%} of control / "
+            f"{covered[treated].mean():.1%} of treatment units"
         )
-        lines.append(
-            "    (DIAGNOSTIC, not the gate: the pre-period overlaps the treatment on a reset "
-            f"window, and pre-period coverage is {(cov[~treated] > 0).mean():.1%} control / "
-            f"{(cov[treated] > 0).mean():.1%} treatment)"
-        )
+        if not balanced:
+            lines.append(
+                "    !! the treatment appears to have MOVED the covariate, so adjusting for it "
+                "would subtract real signal. The gate above is unadjusted."
+            )
 
     lines.extend(_scroll_depth_lines(spec, reader))
     lines.extend(_guardrail_lines(spec, reader))

--- a/analysis/graze_analysis/stats.py
+++ b/analysis/graze_analysis/stats.py
@@ -393,6 +393,41 @@ def always_valid_diff_ci(
         estimand=estimand,
     )
 
+def covariate_balance(
+    covariate: np.ndarray, treated: np.ndarray, covered: np.ndarray, resamples: int = 2000
+) -> tuple[float, float]:
+    """Re-randomization check on a CUPED covariate. Returns ``(imbalance, p_value)``.
+
+    A covariate is only allowed to adjust the outcome if the treatment cannot have moved it. That
+    is an empirical question, not a design assumption, and it was got wrong here once already: the
+    holdout's pre-period like rate reads 0.00839 control vs 0.00999 treatment, which looks like
+    treatment leakage because it points the same way as the effect. Re-randomizing the arm labels
+    shows it is not — measured 2026-09-01, observed +0.00242 against a null sd of 0.00325,
+    two-sided p=0.459, and the sign REVERSES in an earlier window. It is chance.
+
+    Compares only COVERED units, so a difference in who has pre-period data at all cannot
+    masquerade as a difference in the covariate's value.
+    """
+    c = np.asarray(covariate, dtype=float)
+    m = np.asarray(covered, dtype=bool)
+    t = np.asarray(treated, dtype=bool)
+    if m.sum() < 4 or (t & m).sum() < 2 or (~t & m).sum() < 2:
+        return float("nan"), float("nan")
+    vals, arms = c[m], t[m]
+    observed = float(vals[arms].mean() - vals[~arms].mean())
+    n_t = int(arms.sum())
+    rng = np.random.default_rng(0)  # fixed: this is a diagnostic, it must not flicker hourly
+    idx = np.arange(vals.size)
+    hits = 0
+    for _ in range(resamples):
+        pick = rng.permutation(idx)[:n_t]
+        mask = np.zeros(vals.size, dtype=bool)
+        mask[pick] = True
+        if abs(float(vals[mask].mean() - vals[~mask].mean())) >= abs(observed):
+            hits += 1
+    return observed, hits / resamples
+
+
 def insufficient_data_gate(estimate: Estimate, min_observations: int) -> tuple[bool, str]:
     """Refuse to report a verdict below a minimum sample size.
 

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:01a0057ae7bfe3e25b549f4f8cae2b355f896e8bdab81f8254f56789c6270004
+              image: dgaff/graze-analysis@sha256:b9930956bd027e172c400b9ae37c7ce54f431afb0b850c677d7aec2a1ef95d97
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job

--- a/analysis/kube/coverage-cronjob.yaml
+++ b/analysis/kube/coverage-cronjob.yaml
@@ -210,7 +210,7 @@ spec:
                 name: personalization-coverage-src
           containers:
             - name: coverage
-              image: dgaff/graze-analysis@sha256:01a0057ae7bfe3e25b549f4f8cae2b355f896e8bdab81f8254f56789c6270004
+              image: dgaff/graze-analysis@sha256:b9930956bd027e172c400b9ae37c7ce54f431afb0b850c677d7aec2a1ef95d97
               command: ["python", "/src/coverage.py"]
               volumeMounts:
                 - name: src

--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -145,7 +145,7 @@ spec:
                 name: personalization-dose-check-src
           containers:
             - name: dose
-              image: dgaff/graze-analysis@sha256:01a0057ae7bfe3e25b549f4f8cae2b355f896e8bdab81f8254f56789c6270004
+              image: dgaff/graze-analysis@sha256:b9930956bd027e172c400b9ae37c7ce54f431afb0b850c677d7aec2a1ef95d97
               command: ["python", "/src/dose.py"]
               volumeMounts:
                 - name: src

--- a/analysis/tests/test_runner_gates.py
+++ b/analysis/tests/test_runner_gates.py
@@ -384,47 +384,96 @@ def test_units_appearing_in_both_arms_are_flagged_above_everything():
     assert "2 unit(s)" in readout.lines[0]
 
 
-def test_cuped_is_reported_but_does_not_move_the_gate():
-    """CUPED is computed and shown, and deliberately does not drive the verdict.
+def _cuped_rows(covariate_shift=0):
+    """Varying per-user rates with a strongly (but not perfectly) correlated pre-period covariate.
 
-    `cuped_covariate_sql` measures the 14 days before `spec.start`. Every window in this repo has
-    been RESET rather than begun fresh, so that period is already under treatment: measured
-    2026-09-01, the holdout's pre-period like rate was 0.00839 control vs 0.00999 treatment, an
-    "imbalance" pointing the same way as the effect, because its control arm has had
-    personalization suppressed continuously since 2026-08-14. Adjusting for that removes real
-    signal, so the gate stays unadjusted and the adjusted interval is shown alongside it.
+    `covariate_shift` displaces the TREATMENT arm's covariate, simulating a covariate the
+    treatment moved -- the one case where adjusting would subtract real signal.
     """
-    # Per-user rates vary, and the pre-period covariate tracks them strongly but NOT perfectly. A
-    # covariate that determines the outcome exactly removes 100% of the variance, leaving float
-    # residue, and the degenerate guard then correctly reports an unbounded interval.
     primary, covariate = [], []
     for i in range(300):
         primary.append((f"c{i}", 10000, (i % 5) + (i % 2), 20))
         covariate.append((f"c{i}", i % 5, 20))
     for i in range(300):
         primary.append((f"t{i}", 250, (i % 5) + (i % 2) + 1, 20))
-        covariate.append((f"t{i}", i % 5, 20))
+        covariate.append((f"t{i}", (i % 5) + covariate_shift, 20))
+    return primary, covariate
 
+
+def _cuped_reader(primary, covariate):
     class R:
         def query(self, sql):
             if "pre_likes" in sql:
                 return covariate
             return primary if "source = 'fallback'" not in sql else _null_control()
 
-    plain = analyse_ab(_spec(), R())
-    with_cuped = analyse_ab(_spec(cuped_covariate="pre_period_like_rate"), R())
+    return R()
 
-    # The covariate is genuinely informative here...
-    line = next(l for l in with_cuped.lines if "CUPED" in l)
-    assert "variance reduction: 80.0%" in line, line
-    assert "adjusted gate would be" in line, line
-    # ...and it is explicitly NOT the gate.
-    caveat = next(l for l in with_cuped.lines if "DIAGNOSTIC, not the gate" in l)
-    assert "pre-period overlaps the treatment" in caveat, caveat
-    assert "coverage" in caveat, caveat
 
-    # The gate itself is byte-identical with and without the covariate.
-    assert with_cuped.lines[0] == plain.lines[0], (with_cuped.lines[0], plain.lines[0])
+def _gate_width(readout):
+    lo, hi = readout.lines[0].split("CI [")[1].split("]")[0].split(", ")
+    return float(hi) - float(lo)
+
+
+def test_a_balanced_covariate_adjusts_the_gate():
+    """CUPED is APPLIED, not merely reported.
+
+    It was first computed and discarded into `_`, then demoted to a diagnostic on the theory that a
+    reset window's pre-period is already under treatment. Re-randomization refuted that (observed
+    +0.00242 vs a null sd of 0.00325, p=0.459), and the adjustment is worth ~24% of the gate width
+    on live data, which is real power on a question that has never had enough.
+    """
+    primary, covariate = _cuped_rows()
+    plain = analyse_ab(_spec(), _cuped_reader(primary, covariate))
+    adjusted = analyse_ab(
+        _spec(cuped_covariate="pre_period_like_rate"), _cuped_reader(primary, covariate)
+    )
+
+    line = next(l for l in adjusted.lines if "CUPED" in l)
+    assert "APPLIED to the gate" in line, line
+    assert _gate_width(adjusted) < _gate_width(plain), (adjusted.lines[0], plain.lines[0])
+
+
+def test_the_covariate_balance_check_is_reported_with_real_coverage():
+    primary, covariate = _cuped_rows()
+    readout = analyse_ab(
+        _spec(cuped_covariate="pre_period_like_rate"), _cuped_reader(primary, covariate)
+    )
+    bal = next(l for l in readout.lines if "covariate balance" in l)
+    assert "re-randomization p=" in bal, bal
+    # COVERAGE means "has pre-period data", not "has a nonzero pre-period rate". Conflating the two
+    # is what produced a bogus 11.9%/17.3% "coverage gap" that read as treatment contamination;
+    # the real figures were 75.6%/74.5%, p=0.64.
+    assert "pre-period data for 100.0% of control / 100.0% of treatment" in bal, bal
+
+
+def test_a_covariate_the_treatment_moved_is_withheld_from_the_gate():
+    """The fallback that keeps the adjustment honest."""
+    primary, covariate = _cuped_rows(covariate_shift=4)
+    readout = analyse_ab(
+        _spec(cuped_covariate="pre_period_like_rate"), _cuped_reader(primary, covariate)
+    )
+    line = next(l for l in readout.lines if "CUPED" in l)
+    assert "WITHHELD from the gate" in line, line
+    assert any("would subtract real signal" in l for l in readout.lines), readout.render()
+
+    # And the gate really is the unadjusted one.
+    plain = analyse_ab(_spec(), _cuped_reader(primary, covariate))
+    assert readout.lines[0] == plain.lines[0], (readout.lines[0], plain.lines[0])
+
+
+def test_a_lone_straddler_is_flagged_without_crying_wolf():
+    primary = _weight_trap_rows() + [("cl0", 250, 3, 20)]
+    readout = analyse_ab(_spec(), FakeReader(primary, _null_control()))
+    assert "BOTH arms" in readout.lines[0], readout.lines[0]
+    assert "watch it rather than act on it" in readout.lines[0], readout.lines[0]
+    assert "Fix before reading" not in readout.lines[0]
+
+
+def test_widespread_straddling_does_demand_a_fix():
+    extra = [(f"cl{i}", 250, 3, 20) for i in range(40)]
+    readout = analyse_ab(_spec(), FakeReader(_weight_trap_rows() + extra, _null_control()))
+    assert "Fix before reading" in readout.lines[0], readout.lines[0]
 
 
 # --- The secondary gets the same peeking protection ------------------------------------------


### PR DESCRIPTION
**This reverses a call I made in #55, on measurement rather than argument.**

## What #55 got wrong

#55 demoted CUPED to a diagnostic on the theory that a **reset** window's pre-period is already under treatment. The holdout's pre-period like rate reads `0.00839` control vs `0.00999` treatment, and that imbalance points *the same way as the effect* — exactly what you would expect if the control arm had had personalization suppressed since 8/14.

Plausible, and wrong. Re-randomizing the arm labels:

| window | imbalance | null sd | two-sided p | verdict |
|---|---:|---:|---:|---|
| 8/14→8/28 (current) | +0.00242 | 0.00325 | **0.459** | chance |
| 7/31→8/14 (pre-treatment) | +0.00215 | 0.00310 | **0.487** | chance |
| 7/17→7/31 (earlier) | −0.00209 | — | — | **sign reverses** |

If treatment were depressing the control arm's pre-period rate, the imbalance would shrink in a clean window. It doesn't, and it flips sign. It is noise.

A genuinely pre-treatment window is also measurably **worse**, not better — 29.3% variance reduction against 46.2%, because it sits further from the outcome. So the `treatment_start` spec field that fix would have required is not worth having.

**I also mis-stated the coverage figures.** #55 reported "pre-period coverage 11.9% control / 17.3% treatment" and read the gap as contamination. That was the share of units with a *nonzero pre-period like rate*, not the share with pre-period *data*. Real coverage is **75.4% vs 74.2%, gap p=0.64** — balanced. The line now reports what it claims to report.

## What this changes

CUPED adjusts the gate again, and it earns its place: **46.2% variance reduction, gate width `0.02219 → 0.01694`, ~24% narrower** on live data. Power is the binding constraint on this entire programme, and that is real power from data already collected.

What keeps it honest is a new `covariate_balance` re-randomization test, comparing **covered units only** so differential coverage cannot masquerade as a differential value. If the treatment appears to have moved the covariate (p ≤ 0.05) the adjustment is **withheld**, the gate falls back to unadjusted, and the readout says so. A withheld adjustment no longer prints `cuped=NN%` on the gate line either — that would claim precision the interval does not have.

Live output:

```
GATE     : ... diff=+0.0008 (+8.0%) CI [-0.0077, +0.0093] units=2535 cuped=46.2% includes zero
CUPED variance reduction: 46.2% (APPLIED to the gate)
  covariate balance: +0.00253 between arms, re-randomization p=0.461; pre-period data for
  75.4% of control / 74.2% of treatment units
```

**The verdict is unchanged** — still includes zero. This buys resolution for when `follow_seed` clears its floor, not a different answer today.

## Straddler wording

One unit in 2,535 is 0.04%, and "randomization is leaking, fix before reading" overstated it. That phrasing is now reserved for >1%; below it the line says to watch rather than act. The single live case is one user whose arm flipped across requests **15 seconds apart** on one feed — a race, not a systematic split.

## Verification

89 tests (4 new), covering the applied path, the withheld-fallback path, the balance line's real-coverage wording, and both straddler thresholds. Validated against live ClickHouse via a `subPath` overlay before building.

Image `sha256:b9930956bd027e172c400b9ae37c7ce54f431afb0b850c677d7aec2a1ef95d97` (`cuped-20260901`). Rollback `sha256:01a0057ae7bf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)