### PR TITLE
Exempt pools with enough absolute like signal from the density gate

### DIFF
--- a/analysis/graze_analysis/drift.py
+++ b/analysis/graze_analysis/drift.py
@@ -17,10 +17,28 @@ This guard reports two distinct things, and the distinction matters:
 
 - **AT RISK** — a feed that is currently productive whose density sits within `warn_factor` of the gate.
   This is a *prediction*, and predictions in this project have a poor record.
-- **NEWLY GATED** — a feed that produced personalized impressions in an earlier window, produces none
-  now, and whose density is below the gate. This is a *detection*: the failure has already happened.
+- **NEWLY GATED** — a feed that produced personalized impressions in the same window *yesterday*,
+  produces none now while still receiving traffic, and whose density is below the gate. This is a
+  *detection*: the failure has already happened.
 
 Both are printed, but the second is the one to act on.
+
+**Why the baseline is 24 hours back and not the preceding window.** It originally compared the last
+`span` hours against the `span` hours before that, and that comparison cannot tell a regression apart
+from a daily cycle. Both terms it reads move together on a diurnal rhythm: a feed's traffic peaks and
+troughs on a clock, and so does its density, because pool age depends on posting volume and posting
+volume is diurnal too. Measured on algo 6445 on 2026-09-01: the 19:17Z run compared 07:17–13:17Z —
+the feed's morning peak, 361 personalized impressions — against 13:17–19:17Z, in which the feed took
+34 impressions in total. It reported a feed that had "stopped being personalized" while that feed was
+crossing back and forth over the gate every day, and had served 161 personalized impressions at 08:00Z
+the same morning. Comparing the same clock window a day earlier removes the confound; comparing the
+preceding window guarantees it.
+
+`min_traffic` closes the other half of the same hole. The old rule read `now == 0` with no volume
+condition at all, so "nobody asked for this feed in the last six hours" was indistinguishable from
+"the engine refused to rank it". A genuine regression keeps its traffic — fallback simply takes the
+slots personalization used to fill — so requiring the now-window to carry impressions costs no real
+detections and removes the quiet-feed false positives.
 """
 
 from __future__ import annotations
@@ -54,30 +72,46 @@ class Finding:
 def classify(
     densities: dict[int, FeedDensity],
     impressions_now: dict[int, int],
-    impressions_before: dict[int, int],
+    impressions_baseline: dict[int, int],
+    traffic_now: dict[int, int],
     gate: float,
     warn_factor: float = 1.5,
     min_impressions: int = 50,
+    min_traffic: int | None = None,
 ) -> list[Finding]:
     """Compare published densities against the live gate and recent personalized output.
 
+    `impressions_baseline` is the SAME clock window one day earlier, not the preceding window, and
+    `traffic_now` counts impressions from every source rather than only personalized ones. Both exist
+    to keep a feed's daily rhythm from reading as a regression — see the module docstring.
+
     A feed with no history is not evidence of anything, so `min_impressions` guards against calling a
     quiet feed a regression — the same small-sample trap that produced two wrong readings earlier in
-    this project.
+    this project. `min_traffic` defaults to the same value and guards the other direction: a feed
+    nobody requested cannot have been observed losing personalization.
     """
+    if min_traffic is None:
+        min_traffic = min_impressions
     findings: list[Finding] = []
     for algo, d in sorted(densities.items()):
         now = impressions_now.get(algo, 0)
-        before = impressions_before.get(algo, 0)
+        baseline = impressions_baseline.get(algo, 0)
+        traffic = traffic_now.get(algo, 0)
 
-        # Detection first: it produced personalized items, now produces none, and is under the gate.
-        if before >= min_impressions and now == 0 and d.share < gate:
+        # Detection first: it produced personalized items in this window yesterday, is still being
+        # served today, produces none now, and is under the gate.
+        if (
+            baseline >= min_impressions
+            and now == 0
+            and traffic >= min_traffic
+            and d.share < gate
+        ):
             findings.append(Finding(
                 algo=algo, kind="newly_gated", share=d.share, gate=gate,
-                impressions_now=now, impressions_before=before,
-                detail=(f"produced {before} personalized impressions in the previous window and 0 now, "
-                        f"with density {d.share:.2%} below the {gate:.2%} gate — this feed has stopped "
-                        f"being personalized"),
+                impressions_now=now, impressions_before=baseline,
+                detail=(f"produced {baseline} personalized impressions in this window yesterday and 0 "
+                        f"now across {traffic} impressions, with density {d.share:.2%} below the "
+                        f"{gate:.2%} gate — this feed has stopped being personalized"),
             ))
             continue
 
@@ -85,7 +119,7 @@ def classify(
         if now >= min_impressions and gate <= d.share < gate * warn_factor:
             findings.append(Finding(
                 algo=algo, kind="at_risk", share=d.share, gate=gate,
-                impressions_now=now, impressions_before=before,
+                impressions_now=now, impressions_before=baseline,
                 detail=(f"productive ({now} personalized impressions) but density {d.share:.2%} is within "
                         f"{warn_factor:g}x of the {gate:.2%} gate — a {100*(1 - gate/d.share):.0f}% fall "
                         f"would silence it"),
@@ -132,17 +166,19 @@ def _densities_from_redis(threshold: int) -> dict[int, FeedDensity]:  # pragma: 
             return out
 
 
-def _impressions(hours_back: int, hours_span: int) -> dict[int, int]:  # pragma: no cover - needs a server
+def _impressions(  # pragma: no cover - needs a server
+    hours_back: int, hours_span: int, personalized_only: bool = True
+) -> dict[int, int]:
     from .data import ClickHouseReader
 
     d = "tryBase64Decode(interaction_feed_context)"
+    source = f"\n      AND JSONExtractString({d}, 'source') = 'personalized'" if personalized_only else ""
     sql = f"""
     SELECT JSONExtractInt({d}, 'algo_id') AS algo, count() AS n
     FROM default.feed_interactions
     WHERE occurred >= now() - INTERVAL {hours_back + hours_span} HOUR
       AND occurred <  now() - INTERVAL {hours_back} HOUR
-      AND interaction_feed_context != ''
-      AND JSONExtractString({d}, 'source') = 'personalized'
+      AND interaction_feed_context != ''{source}
       AND interaction_event = 'app.bsky.feed.defs#interactionSeen'
     GROUP BY algo
     """
@@ -160,8 +196,12 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover - thin CLI
 
     densities = _densities_from_redis(threshold)
     now = _impressions(0, span)
-    before = _impressions(span, span)
-    findings = classify(densities, now, before, gate, warn_factor)
+    # Same clock window a day earlier, so a feed's daily rhythm cancels instead of registering as a
+    # regression. `DRIFT_BASELINE_LAG_HOURS` is the lag, not a second window length.
+    lag = int(os.environ.get("DRIFT_BASELINE_LAG_HOURS", "24"))
+    baseline = _impressions(lag, span)
+    traffic = _impressions(0, span, personalized_only=False)
+    findings = classify(densities, now, baseline, traffic, gate, warn_factor)
     print(render(findings, gate, len(densities)))
     # Exit non-zero only for detections, so the CronJob surfaces a real regression as a failed job while
     # a mere warning does not page anyone.

--- a/analysis/tests/test_drift.py
+++ b/analysis/tests/test_drift.py
@@ -26,9 +26,16 @@ class TestDetection:
 
     def test_feed_that_went_silent_under_the_gate_is_detected(self):
         # 2304 was productive, then its density fell below the gate and its output went to zero.
+        # Traffic is unchanged — fallback took the slots personalization used to fill.
         dens = dict(MEASURED)
         dens[2304] = FeedDensity(2304, post_count=5215, scoreable=150)  # 2.88%, drifted under
-        findings = classify(dens, impressions_now={2304: 0}, impressions_before={2304: 800}, gate=GATE)
+        findings = classify(
+            dens,
+            impressions_now={2304: 0},
+            impressions_baseline={2304: 800},
+            traffic_now={2304: 950},
+            gate=GATE,
+        )
         kinds = {f.algo: f.kind for f in findings}
         assert kinds.get(2304) == "newly_gated", findings
         assert "stopped being personalized" in next(f for f in findings if f.algo == 2304).detail
@@ -36,7 +43,11 @@ class TestDetection:
     def test_feed_below_gate_that_was_never_productive_is_not_flagged(self):
         # 5395 and 4051 are supposed to be gated. Flagging them would make the guard cry wolf forever.
         findings = classify(
-            MEASURED, impressions_now={5395: 0, 4051: 0}, impressions_before={5395: 0, 4051: 0}, gate=GATE
+            MEASURED,
+            impressions_now={5395: 0, 4051: 0},
+            impressions_baseline={5395: 0, 4051: 0},
+            traffic_now={5395: 900, 4051: 900},
+            gate=GATE,
         )
         assert findings == [], findings
 
@@ -44,8 +55,67 @@ class TestDetection:
         # Below min_impressions of history: absence of output proves nothing. This is the small-sample
         # trap that produced two wrong readings earlier in this project.
         dens = {2304: FeedDensity(2304, post_count=5215, scoreable=150)}
-        findings = classify(dens, {2304: 0}, {2304: 3}, gate=GATE, min_impressions=50)
+        findings = classify(dens, {2304: 0}, {2304: 3}, {2304: 900}, gate=GATE, min_impressions=50)
         assert findings == []
+
+    def test_feed_nobody_requested_is_not_called_a_regression(self):
+        # The other half of the same trap. Output of zero is only evidence if the feed was actually
+        # being served: with no traffic there is nothing for the engine to have failed to rank.
+        dens = {2304: FeedDensity(2304, post_count=5215, scoreable=150)}
+        findings = classify(dens, {2304: 0}, {2304: 800}, {2304: 4}, gate=GATE, min_impressions=50)
+        assert findings == []
+
+
+class TestDiurnalFalsePositive:
+    """Algo 6445, 2026-09-01 — the reading that made this comparison change.
+
+    The feed crosses the gate downward every afternoon and back up overnight, because its pool is
+    truncated by ALGO_POSTS_LIMIT to ~23h and therefore tracks posting volume, which is itself
+    diurnal. Comparing consecutive windows reads that cycle as a feed that has died.
+    """
+
+    #: 38,546 posts, 1,452 clearing 10 likers — 3.77% against a 4.00% gate, measured 19:17Z.
+    DIURNAL = {6445: FeedDensity(6445, post_count=38546, scoreable=1452)}
+
+    def test_the_afternoon_trough_is_not_a_regression(self):
+        # Real numbers from the run that fired: 361 personalized in the 07:17-13:17Z peak, then 0
+        # personalized across 34 total impressions in the 13:17-19:17Z trough. The same hours the
+        # day before held 35 personalized impressions, below the floor, so there is nothing to
+        # compare against and no verdict should be formed.
+        findings = classify(
+            self.DIURNAL,
+            impressions_now={6445: 0},
+            impressions_baseline={6445: 35},
+            traffic_now={6445: 34},
+            gate=GATE,
+        )
+        assert findings == [], findings
+
+    def test_the_old_consecutive_window_comparison_is_what_misfired(self):
+        # Pinning the bug itself: hand the guard the previous window as the baseline, the way it used
+        # to, and the same inputs produce the false detection. This asserts the fix is the comparison
+        # basis and not the thresholds.
+        findings = classify(
+            self.DIURNAL,
+            impressions_now={6445: 0},
+            impressions_baseline={6445: 361},  # the morning peak, i.e. the OLD baseline
+            traffic_now={6445: 900},           # and enough traffic to clear the volume floor
+            gate=GATE,
+        )
+        assert [f.kind for f in findings] == ["newly_gated"], findings
+
+    def test_a_feed_that_really_stopped_is_still_caught_across_the_cycle(self):
+        # The guard must not be deadened. Same feed, same diurnal traffic, but yesterday's matching
+        # window was productive and today's is not — that is a real regression and must still fire.
+        findings = classify(
+            self.DIURNAL,
+            impressions_now={6445: 0},
+            impressions_baseline={6445: 340},
+            traffic_now={6445: 420},
+            gate=GATE,
+        )
+        assert [f.kind for f in findings] == ["newly_gated"], findings
+        assert "in this window yesterday" in findings[0].detail
 
 
 class TestPrediction:
@@ -54,20 +124,36 @@ class TestPrediction:
         # so it should NOT warn at 1.5x but SHOULD at 1.75x. Pinning both directions.
         assert not any(
             f.algo == 2304
-            for f in classify(MEASURED, {2304: 500}, {2304: 500}, gate=GATE, warn_factor=1.5)
+            for f in classify(
+                MEASURED, {2304: 500}, {2304: 500}, {2304: 700}, gate=GATE, warn_factor=1.5
+            )
         )
-        warned = classify(MEASURED, {2304: 500}, {2304: 500}, gate=GATE, warn_factor=1.75)
+        warned = classify(
+            MEASURED, {2304: 500}, {2304: 500}, {2304: 700}, gate=GATE, warn_factor=1.75
+        )
         assert any(f.algo == 2304 and f.kind == "at_risk" for f in warned), warned
 
     def test_high_density_feeds_are_never_warned_about(self):
-        findings = classify(MEASURED, {396: 5000, 2323: 5000}, {396: 5000, 2323: 5000}, gate=GATE)
+        findings = classify(
+            MEASURED,
+            {396: 5000, 2323: 5000},
+            {396: 5000, 2323: 5000},
+            {396: 6000, 2323: 6000},
+            gate=GATE,
+        )
         assert not any(f.algo in (396, 2323) for f in findings)
 
     def test_detection_outranks_prediction_in_the_report(self):
         dens = dict(MEASURED)
         dens[2304] = FeedDensity(2304, post_count=5215, scoreable=150)   # under gate, went silent
         dens[8386] = FeedDensity(8386, post_count=5653, scoreable=250)   # 4.42%, productive, near gate
-        findings = classify(dens, {2304: 0, 8386: 900}, {2304: 800, 8386: 900}, gate=GATE)
+        findings = classify(
+            dens,
+            {2304: 0, 8386: 900},
+            {2304: 800, 8386: 900},
+            {2304: 950, 8386: 1100},
+            gate=GATE,
+        )
         out = render(findings, GATE, len(dens))
         assert out.index("NEWLY_GATED") < out.index("AT_RISK"), out
 

--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -584,7 +584,14 @@ impl LinkLonkAlgorithm {
             if let (Some(scoreable), Some(post_count)) = (scoreable, post_count) {
                 if post_count > 0.0 {
                     let share = scoreable / post_count;
-                    if share < density_gate {
+                    // Absolute exemption. `share`'s denominator is `ALGO_POSTS_LIMIT` on any pool
+                    // that hits the cap, so on those feeds a low share means "the pool covers few
+                    // hours", not "there is no like signal here". A pool holding this many scoreable
+                    // candidates can produce a ranking regardless of what sits beside them.
+                    // Off by default; see Config::min_pool_scoreable_posts.
+                    let floor = self.config.min_pool_scoreable_posts;
+                    let has_absolute_signal = floor > 0 && scoreable >= floor as f64;
+                    if share < density_gate && !has_absolute_signal {
                         info!(
                             user_hash = %&user_hash[..8.min(user_hash.len())],
                             algo_id,
@@ -592,6 +599,7 @@ impl LinkLonkAlgorithm {
                             post_count,
                             share = format!("{:.4}", share),
                             density_gate,
+                            scoreable_floor = floor,
                             "early_exit: pool like-density below personalization gate"
                         );
                         return Ok(ScoringResult::default());

--- a/crates/graze-api/src/config.rs
+++ b/crates/graze-api/src/config.rs
@@ -133,7 +133,34 @@ pub struct Config {
     ///
     /// This matters because algo 5395 is ~83% of all scoring traffic at 2% scoreable, so most of the
     /// engine's compute currently goes to a feed that structurally cannot produce a ranking.
+    ///
+    /// **The share alone is not sufficient — see [`Config::min_pool_scoreable_posts`].** Every pool
+    /// in the measurement above was small enough that `ALGO_POSTS_LIMIT` never bound, so
+    /// `post_count` described the feed. On a pool that hits the cap it describes the cap instead.
     pub min_pool_scoreable_share: f64,
+
+    /// Absolute number of scoreable candidates that exempts a feed from
+    /// [`Config::min_pool_scoreable_share`]. `0` disables the exemption, leaving the share gate
+    /// exactly as it was.
+    ///
+    /// The share gate is a ratio whose denominator is decided by `ALGO_POSTS_LIMIT` (40,000), not by
+    /// the feed. Candidate sync takes the newest N posts within its window, so a feed matching more
+    /// than N posts gets a pool covering *less* time — and likes accrue over time. Measured on algo
+    /// 6445 on 2026-09-01: 118,589 eligible posts in the 72h window against a 40,000 cap, so the
+    /// pool spanned ~23h, and the share of posts clearing 10 likers rose monotonically with age
+    /// across it — 2.00% at 0-3.6h to 5.28% at 14.4-21h, still climbing where the cap cuts. The feed
+    /// crossed the 4% gate downward every afternoon and back up overnight.
+    ///
+    /// What actually determines whether a co-liker walk can rank is how many scoreable candidates
+    /// there are, not what fraction of the pool they are. Sorted by that count, the feeds the share
+    /// gate blocked were 1,452 · 1,352 · 30 · 24 · 22 · 22 · 20 — a 45x gap with nothing in it, and
+    /// the two largest were the 5th busiest feed in the fleet (2,140 personalized impressions/7d,
+    /// 75% of its output) and one other. Any threshold in 100..=1,200 separates that bimodal set
+    /// identically, so this is not a tuning knob; 500 sits in the empty middle.
+    ///
+    /// Deliberately an exemption rather than a replacement: a feed can still be gated on density
+    /// alone, which is what keeps algo 30374 (20 scoreable posts) correctly skipped.
+    pub min_pool_scoreable_posts: usize,
 
     pub walk_count: usize,
 
@@ -553,6 +580,7 @@ impl Config {
             inverted_coliker_like_days: parse_u32_env("INVERTED_COLIKER_LIKE_DAYS", 4),
             inverted_coliker_like_limit: parse_usize_env("INVERTED_COLIKER_LIKE_LIMIT", 500),
             min_pool_scoreable_share: parse_f64_env("MIN_POOL_SCOREABLE_SHARE", 0.0),
+            min_pool_scoreable_posts: parse_usize_env("MIN_POOL_SCOREABLE_POSTS", 0),
             personalization_holdout_salt: std::env::var("PERSONALIZATION_HOLDOUT_SALT")
                 .unwrap_or_else(|_| "pholdout-v1".to_string()),
             walk_count: parse_usize_env("WALK_COUNT", 2000),
@@ -1097,5 +1125,85 @@ mod density_gate_guards {
                 "algo {algo} at share {share} classified wrongly by gate {gate}"
             );
         }
+    }
+
+    #[test]
+    fn scoreable_floor_defaults_to_disabled() {
+        // Ships inert for the same reason the share gate did: the deploy must not move any feed.
+        // Turning it on is then a single env var, and rolling it back is unsetting one.
+        let c = Config::from_env();
+        assert_eq!(
+            c.min_pool_scoreable_posts, 0,
+            "MIN_POOL_SCOREABLE_POSTS must default to 0 (exemption disabled)"
+        );
+    }
+
+    /// The gate decision, extracted so the floor's effect can be asserted without a Redis round
+    /// trip. Mirrors `LinkLonkAlgorithm::compute_personalization` step 0b exactly.
+    fn is_gated(scoreable: f64, post_count: f64, gate: f64, floor: usize) -> bool {
+        if post_count <= 0.0 {
+            return false;
+        }
+        let share = scoreable / post_count;
+        let has_absolute_signal = floor > 0 && scoreable >= floor as f64;
+        share < gate && !has_absolute_signal
+    }
+
+    #[test]
+    fn a_zero_floor_leaves_the_share_gate_untouched() {
+        // The whole safety case for deploying this rests on it. Floor 0 must reproduce the old
+        // behaviour for every feed, including the ones the gate is supposed to stop.
+        let live: [(i32, f64, f64, bool); 5] = [
+            // algo, scoreable@10, post_count, gated under the 4% share gate alone (measured 9/01)
+            (6445, 1452.0, 38546.0, true),
+            (33516, 1352.0, 39989.0, true),
+            (30374, 20.0, 3797.0, true),
+            (2304, 918.0, 7958.0, false),
+            (2243, 1723.0, 20246.0, false),
+        ];
+        for (algo, sc, pc, gated) in live {
+            assert_eq!(
+                is_gated(sc, pc, 0.04, 0),
+                gated,
+                "algo {algo} moved with the floor disabled"
+            );
+        }
+    }
+
+    #[test]
+    fn the_floor_rescues_pools_with_signal_and_not_pools_without() {
+        // Measured 2026-09-01. The blocked set is bimodal — 1,452 / 1,352 / 30 / 24 / 22 / 22 / 20 —
+        // so every threshold in this range must produce the same partition. If this test ever
+        // becomes sensitive to the exact number, the population has changed and the floor needs
+        // re-measuring rather than re-tuning.
+        for floor in [100usize, 200, 500, 750, 1_200] {
+            assert!(
+                !is_gated(1452.0, 38546.0, 0.04, floor),
+                "algo 6445 (1,452 scoreable, ~23h pool) should be exempt at floor {floor}"
+            );
+            assert!(
+                !is_gated(1352.0, 39989.0, 0.04, floor),
+                "algo 33516 (1,352 scoreable) should be exempt at floor {floor}"
+            );
+            assert!(
+                is_gated(20.0, 3797.0, 0.04, floor),
+                "algo 30374 has 20 scoreable posts and must stay gated at floor {floor}"
+            );
+            assert!(
+                is_gated(30.0, 1260.0, 0.04, floor),
+                "algo 4051 has 30 scoreable posts and must stay gated at floor {floor}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_floor_cannot_gate_a_feed_the_share_gate_would_have_passed() {
+        // It is an exemption, never an additional gate. A dense feed with few scoreable posts —
+        // small pools that clear the share gate easily — must not start being skipped.
+        assert!(!is_gated(8.0, 166.0, 0.04, 500), "algo 3653 at 4.82% share");
+        assert!(
+            !is_gated(192.0, 727.0, 0.04, 500),
+            "algo 8352 at 26.4% share"
+        );
     }
 }


### PR DESCRIPTION
Diagnosis and evidence: https://claude.ai/code/artifact/6b4e7906-2dc2-42d5-bfc1-a43e57706436

## What broke

The hourly `personalization-analysis` CronJob started failing with:

> `[NEWLY_GATED] algo 6445: produced 341 personalized impressions in the previous window and 0 now, with density 3.77% below the 4.00% gate — this feed has stopped being personalized`

The number is right. The conclusion is not — 6445 served **161 personalized impressions at 08:00Z the same morning**. It goes dark for about seven hours each afternoon and comes back, and it did the same yesterday.

## Root cause

`MIN_POOL_SCOREABLE_SHARE` is a ratio whose denominator is decided by `ALGO_POSTS_LIMIT` (40,000, unset on the deployment so it takes the default), not by the feed. Candidate sync fetches `ORDER BY bluesky_created_at DESC LIMIT {cap}`, so a feed matching more posts than the cap gets a pool covering *less time*.

6445 matches **118,589** eligible posts in the intended 72h window — a 3.1× overrun — so its pool spans **~23 hours**. Verified directly: all 38,546 post ids in `apc:6445` carry only two intern dates.

Likes accrue over time, so that pool is structurally under-liked. Measured on the live pool by post age:

| age | ≥10 likers |
|---|---|
| 0–3.6 h | 2.00% |
| 3.6–6.3 h | 2.93% |
| 6.3–8.9 h | 3.92% |
| 11.4–14.4 h | 4.64% |
| 14.4–21.0 h | **5.28%** — still climbing where the cap cuts |

Four of 69 live pools are cap-truncated: 33516 (38.6×, 1.9h window), 33048 (4.4×, 16.4h), 6445 (3.1×, 23.4h), 31990 (2.7×, 27h). Everything else reaches the full 72h, and feeds under `SYNC_MINIMUM_POSTS` fall back to 336h. The effective observation window across the fleet spans **1.9h → 336h**, all compared against one constant.

## Why not just lower the gate

Because 4% is fine for a pool that spans three days, and lowering it moves the line for all 69 feeds to rescue one. The ratio is the wrong statistic, not the threshold. Sorted by *absolute* rankable candidates, the blocked set is:

| algo | scoreable @10 | density | personalized / 7d |
|---|---|---|---|
| **6445** | **1,452** | 3.77% | **2,140** |
| 33516 | 1,352 | 3.38% | 5 |
| 4051 | 30 | 2.38% | 0 |
| 31291 | 24 | 1.85% | 2 |
| 32765 | 22 | 1.47% | 0 |
| 5395 | 22 | 2.83% | 0 |
| 30374 | 20 | 0.53% | 0 |

A 45× gap with nothing in it. The gate is stopping the two largest rankable inventories in the fleet with the rule built for feeds holding twenty posts.

## The change

`MIN_POOL_SCOREABLE_POSTS` exempts a pool from the share gate when it holds that many scoreable candidates. **Defaults to 0 (inert)** — this deploy moves no feed, and enabling it is one env var (rollback is unsetting it).

It is an exemption, never an additional gate: density alone can still stop a feed, which is what keeps 30374 (20 scoreable posts) correctly skipped.

Because the blocked set is bimodal, **every value in 100..=1,200 un-gates exactly {6445, 33516} and nothing else** — this is not a tuning knob. Proposed value is 500, in the empty middle.

## Guard fix

`classify()` compared consecutive windows, and both terms it reads move together on a daily cycle — traffic is diurnal, and so is density, because pool age tracks posting volume. The 19:17Z run compared the 07:17–13:17Z morning peak (361 personalized) against the 13:17–19:17Z trough (34 impressions total, all fallback).

- Baseline is now the **same clock window 24h earlier** (`DRIFT_BASELINE_LAG_HOURS`, default 24).
- A detection additionally requires the now-window to **carry traffic**. `now == 0` previously had no volume condition at all, so "nobody asked for this feed" was indistinguishable from "the engine refused to rank it". A genuine regression keeps its impressions — fallback takes the slots — so this costs no real detections.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean; 370 lib tests pass.
- 89 analysis tests pass, including new cases that pin the diurnal false positive, pin the *old* comparison as the thing that misfired, and confirm a real regression is still caught across the cycle.
- New guard run against **live production** (69 pools, real ClickHouse + Redis): `=== density drift guard — OK ===`, exit 0, where the current one fires.

## Rollout

1. Merge, build, deploy by digest — no behaviour change (floor is 0).
2. Rebuild the analysis image, update the CronJob — hourly failures stop.
3. Set `MIN_POOL_SCOREABLE_POSTS=500` in `personalization-env`, restart the API — 6445 un-gates.

## Follow-up, not in this PR

The density gate is invisible in ClickHouse: `fallback_reason` has no value for it, so a density-gated response is written with no reason at all. Deliberately left out — it means threading a field through `ScoringResult` and `ResponseMeta` and it changes experiment provenance, which does not belong in the same rollout as a ranking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)