### PR TITLE
Give the analysis package CI, and pin what it runs on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,42 @@ jobs:
       # - name: Run integration tests
       #   run: cargo test --workspace --test '*' -- --test-threads=1
 
+  analysis-tests:
+    name: Analysis Tests
+    runs-on: ubuntu-latest
+    # The statistics package had NO CI until 2026-09-01, which is how a confidence sequence
+    # computed over the arms POOLED rather than over their difference shipped and survived: it
+    # bounded a level, could never contain zero, and so could never withhold a result. Everything
+    # here runs offline against fake readers -- no ClickHouse or Redis credentials are needed.
+    defaults:
+      run:
+        working-directory: analysis
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          # Matches the analysis image (python:3.12-slim). A different minor version here would
+          # test something other than what runs.
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: analysis/requirements.lock.txt
+
+      - name: Install pinned dependencies
+        run: pip install --no-cache-dir -r requirements.lock.txt
+
+      - name: Verify the lock matches what is installed
+        # Catches a hand-edited or stale lock: if resolution drifted, the readout would be
+        # validated against a different numerical stack than production runs.
+        run: |
+          pip freeze | sort > /tmp/actual.txt
+          grep -v '^#' requirements.lock.txt | grep -v '^$' | sort > /tmp/expected.txt
+          diff /tmp/expected.txt /tmp/actual.txt
+
+      - name: Run tests
+        run: pytest -q
+
   release-build:
     name: Release Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,10 @@ jobs:
           cache-dependency-path: analysis/requirements.lock.txt
 
       - name: Install pinned dependencies
-        run: pip install --no-cache-dir -r requirements.lock.txt
+        # NOT --no-cache-dir here, though the Dockerfile uses it. That flag keeps the image small,
+        # but on a runner it leaves ~/.cache/pip absent and setup-python's cache:pip post-step then
+        # fails the whole job trying to save a directory that was never created.
+        run: pip install -r requirements.lock.txt
 
       - name: Verify the lock matches what is installed
         # Catches a hand-edited or stale lock: if resolution drifted, the readout would be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,11 @@ jobs:
           diff /tmp/expected.txt /tmp/actual.txt
 
       - name: Run tests
-        run: pytest -q
+        # `python -m pytest`, NOT the bare `pytest` console script. The module form puts the
+        # working directory on sys.path; the console script does not, and there is no conftest.py
+        # or installed package to make up the difference -- so bare `pytest` collects nothing but
+        # ModuleNotFoundError. This job caught exactly that on its first run.
+        run: python -m pytest -q
 
   release-build:
     name: Release Build

--- a/analysis/Dockerfile
+++ b/analysis/Dockerfile
@@ -12,8 +12,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+# Install from the LOCK, not requirements.txt: the lock carries transitive pins too, so a rebuild
+# resolves to the same set the statistics were validated against rather than whatever is current.
+COPY requirements.txt requirements.lock.txt ./
+RUN pip install --no-cache-dir -r requirements.lock.txt
 
 COPY graze_analysis ./graze_analysis
 COPY experiments ./experiments

--- a/analysis/requirements.lock.txt
+++ b/analysis/requirements.lock.txt
@@ -1,0 +1,34 @@
+# Fully resolved dependency set, transitive dependencies included. Captured 2026-09-01 with
+# `pip freeze` from the then-deployed analysis image, and re-verified byte-identical against the
+# image deployed after it -- these are the versions production is running, not an aspiration.
+#
+# The image and CI install from THIS file, so both run the exact set the statistics were
+# validated against. Pinning only the direct dependencies in requirements.txt would still
+# leave statsmodels' formula machinery (formulaic, patsy, narwhals) free to move, which is
+# precisely the layer a silent numerical change would hide in.
+#
+# Regenerate with the pip freeze command documented in requirements.txt. Do not hand-edit.
+PyYAML==6.0.3
+Pygments==2.21.0
+backports.zstd==1.7.0
+certifi==2026.7.22
+clickhouse-connect==1.7.2
+formulaic==1.2.2
+iniconfig==2.3.0
+interface_meta==2.0.1
+lz4==4.4.5
+narwhals==2.25.0
+numpy==2.5.2
+packaging==26.3
+pandas==3.0.5
+patsy==1.0.3
+pluggy==1.6.0
+pytest==9.1.1
+python-dateutil==2.9.0.post0
+redis==8.1.0
+scipy==1.18.1
+six==1.17.0
+statsmodels==0.15.0
+typing_extensions==4.16.0
+urllib3==2.7.0
+wrapt==2.4.0

--- a/analysis/requirements.txt
+++ b/analysis/requirements.txt
@@ -1,8 +1,24 @@
-numpy>=1.26
-scipy>=1.11
-pandas>=2.1
-statsmodels>=0.14
-pyyaml>=6.0
-clickhouse-connect>=0.7
-pytest>=8.0
-redis>=5.0
+# Direct dependencies, pinned exactly.
+#
+# Pinned rather than floored because this package decides experiment verdicts and the image is
+# rebuilt by hand: an unpinned rebuild silently moves the statistics libraries underneath the
+# inference, and nothing would fail loudly if statsmodels changed how a clustered SE is computed.
+# This org has already been bitten by the general form of it (an unpinned redis-py 8.1.0 broke
+# Redis on rebuild in another service).
+#
+# Versions are the ones the live analysis image resolved to, captured 2026-09-01 -- so pinning
+# changes nothing today, it freezes what is already running. The full resolved set, transitive
+# dependencies included, is in
+# requirements.lock.txt, which is what the image and CI actually install.
+#
+# To upgrade: change a pin here, regenerate the lock with
+#   docker run --rm --platform=linux/amd64 --entrypoint pip <built image> freeze
+# and check the readout still renders before deploying.
+numpy==2.5.2
+scipy==1.18.1
+pandas==3.0.5
+statsmodels==0.15.0
+pyyaml==6.0.3
+clickhouse-connect==1.7.2
+pytest==9.1.1
+redis==8.1.0


### PR DESCRIPTION
## The gap

The statistics package had **no CI**. Actions ran `Rust Checks`, `Rust Tests` and `Release Build`, and nothing else — so every routine that decides an experiment verdict was untested on every PR. **93 tests existed and none of them ran.**

That is how the bug fixed in #55 shipped and survived: a confidence sequence computed over the arms *pooled* rather than over their *difference*, which bounds a level, can never contain zero, and so could never withhold a result.

## The CI job

`Analysis Tests` sits alongside the Rust jobs in the same workflow rather than in a parallel file, so a PR gets one run with four jobs. Python 3.12 to match the image — a different minor version would be testing something other than what runs. Everything is offline against fake readers, so no ClickHouse or Redis credentials are needed, and none are configured.

## Pinning

`requirements.txt` floored every dependency (`numpy>=1.26`, `statsmodels>=0.14`, …) while the image is rebuilt **by hand**. A rebuild could silently move the statistics libraries underneath the inference, and nothing would fail loudly if statsmodels changed how a clustered SE is computed. This org has been bitten by the general form before (an unpinned redis-py 8.1.0 broke Redis on rebuild in another service).

I got lucky three times today — `pip freeze` came back byte-identical across every rebuild — which is why this is a no-op rather than a bug report.

Two files, deliberately:

| file | contents | who installs it |
|---|---|---|
| `requirements.txt` | direct dependencies, now pinned exactly | nobody — it documents intent |
| `requirements.lock.txt` | full resolved set, transitive included | the image **and** CI |

Pinning only the direct dependencies would leave statsmodels' formula machinery (`formulaic`, `patsy`, `narwhals`) free to move, and that is precisely the layer a silent numerical change would hide in.

The CI job also **diffs `pip freeze` against the lock**, so a hand-edited or stale lock fails loudly rather than quietly validating against a different numerical stack than production runs.

## Verification

- Built the image from the lock: clean.
- Ran the suite **inside that image**: `93 passed`.
- Ran the lock-consistency diff inside it: clean — so the check is not brittle.

## No redeploy

The pinned versions are exactly what is deployed — captured from the then-live image and re-verified byte-identical against the image deployed after it. Nothing needs rebuilding for this, and nothing is rebuilt here.

## Unrelated drift, flagged not fixed

The cluster currently runs `dgaff/graze-analysis@sha256:457de73c066e…` while `analysis/kube/*.yaml` on main still pins `sha256:b9930956bd02…`. That is #59's deploy, whose manifest digests were not bumped — so applying the repo manifests today would revert that drift-gate fix. Left alone here because that work may still be in flight; it wants a one-line digest bump from whoever owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)