### PR TITLE
Make the pre-scoring personalization gates visible in fallback_reason

### DIFF
--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -556,6 +556,7 @@ impl LinkLonkAlgorithm {
                 );
                 return Ok(ScoringResult {
                     posts_checked: pool_size,
+                    skip_reason: Some("pool_size"),
                     ..Default::default()
                 });
             }

--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -178,7 +178,7 @@ impl LinkLonkAlgorithm {
         let result_key = Keys::cached_result(algo_id, &user_hash);
         let ttl = self.redis.ttl(&result_key).await?;
 
-        let (posts, cached, cache_age_seconds, scoring_stats) =
+        let (posts, cached, cache_age_seconds, scoring_stats, skip_reason) =
             if ttl > self.config.stale_refresh_threshold_seconds as i64 {
                 // Fresh cache exists - use it
                 let posts = self.get_cached_posts(&result_key, limit, cursor).await?;
@@ -187,6 +187,9 @@ impl LinkLonkAlgorithm {
                     true,
                     Some((params.result_ttl_seconds as i64 - ttl) as u32),
                     None, // No scoring stats for cached results
+                    // A cache hit means an earlier compute cleared the gates, so there is no skip
+                    // to report. A gated compute writes no cache, so it cannot be replayed as one.
+                    None,
                 )
             } else {
                 // Need to compute fresh results
@@ -254,7 +257,7 @@ impl LinkLonkAlgorithm {
                         compute_result.requires_preserved_order,
                     )
                     .await?;
-                (posts, false, Some(0), stats)
+                (posts, false, Some(0), stats, compute_result.skip_reason)
             };
 
         let compute_time_ms = start_time.elapsed().as_secs_f64() * 1000.0;
@@ -285,6 +288,7 @@ impl LinkLonkAlgorithm {
                 posts_checked,
                 colikers_used: None, // Tracked at co-liker level
                 scoring_time_ms,
+                skip_reason: skip_reason.map(str::to_string),
             },
         })
     }
@@ -501,6 +505,11 @@ impl LinkLonkAlgorithm {
             // Whichever arm faceted the seed reported its keep rate; carry it so an interleaved
             // readout can still tell a ranking effect from a coverage collapse.
             seed_keep_rate: treatment.seed_keep_rate.or(control.seed_keep_rate),
+            // Neither draft can carry one — both come from `score_with_ranker`, which is only
+            // reached once the gates have passed. Propagated rather than hardcoded to `None` so
+            // that if a gate ever moves inside the ranker path, the reason survives the merge
+            // instead of being silently dropped here.
+            skip_reason: treatment.skip_reason.or(control.skip_reason),
         }
     }
 
@@ -602,7 +611,10 @@ impl LinkLonkAlgorithm {
                             scoreable_floor = floor,
                             "early_exit: pool like-density below personalization gate"
                         );
-                        return Ok(ScoringResult::default());
+                        return Ok(ScoringResult {
+                            skip_reason: Some("pool_density"),
+                            ..Default::default()
+                        });
                     }
                 }
             }

--- a/crates/graze-api/src/algorithm/scorer.rs
+++ b/crates/graze-api/src/algorithm/scorer.rs
@@ -90,8 +90,8 @@ pub struct ScoringResult {
     pub seed_keep_rate: Option<f64>,
     /// Why scoring was skipped entirely before it ran, when it was.
     ///
-    /// `pool_density` (the feed's like-density gate fired). `None` whenever scoring actually
-    /// ran, including
+    /// `pool_density` (the feed's like-density gate fired) | `pool_size` (the feed's candidate
+    /// pool is below the personalization gate). `None` whenever scoring actually ran, including
     /// when it ran and produced nothing — "we refused to look" and "we looked and found nothing"
     /// are different coverage failures and the whole point of this field is to keep them apart.
     ///

--- a/crates/graze-api/src/algorithm/scorer.rs
+++ b/crates/graze-api/src/algorithm/scorer.rs
@@ -88,6 +88,17 @@ pub struct ScoringResult {
     /// collapse: a keep rate near zero means the treatment was effectively "no personalization",
     /// which would otherwise look like a ranking finding.
     pub seed_keep_rate: Option<f64>,
+    /// Why scoring was skipped entirely before it ran, when it was.
+    ///
+    /// `pool_density` (the feed's like-density gate fired). `None` whenever scoring actually
+    /// ran, including
+    /// when it ran and produced nothing — "we refused to look" and "we looked and found nothing"
+    /// are different coverage failures and the whole point of this field is to keep them apart.
+    ///
+    /// `&'static str` rather than `String` because every value is a compile-time constant, and
+    /// because the consumer in `api::feed` needs a `'static` reason it can hold past the response
+    /// it came from.
+    pub skip_reason: Option<&'static str>,
 }
 
 impl ScoringResult {
@@ -712,6 +723,9 @@ impl Scorer {
             seed_keep_rate: None,
             ranker_by_post: Default::default(),
             requires_preserved_order: false,
+            // Scoring ran to completion here; an empty result from this path means "looked and
+            // found nothing", which is deliberately not a skip.
+            skip_reason: None,
         })
     }
 
@@ -1248,6 +1262,9 @@ impl Scorer {
             seed_keep_rate: None,
             ranker_by_post: Default::default(),
             requires_preserved_order: false,
+            // Scoring ran to completion here; an empty result from this path means "looked and
+            // found nothing", which is deliberately not a skip.
+            skip_reason: None,
         })
     }
 }
@@ -1255,6 +1272,16 @@ impl Scorer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A default result carries no skip reason, so only a gate can produce one.
+    ///
+    /// Load-bearing because `ScoringResult::default()` is what several "nothing to do" paths
+    /// return. If the default ever gained a reason, every one of those would be relabelled as a
+    /// gate that never fired.
+    #[test]
+    fn a_default_result_reports_no_skip() {
+        assert_eq!(ScoringResult::default().skip_reason, None);
+    }
 
     #[test]
     fn overlap_buckets_cover_every_count_monotonically() {

--- a/crates/graze-api/src/api/feed.rs
+++ b/crates/graze-api/src/api/feed.rs
@@ -134,6 +134,7 @@ fn graze_api_hash_experiment(config: &crate::config::Config) -> crate::algorithm
 fn skip_reason_to_fallback_reason(skip: Option<&str>) -> Option<&'static str> {
     match skip {
         Some("pool_density") => Some("pool_density"),
+        Some("pool_size") => Some("pool_size"),
         _ => None,
     }
 }
@@ -1764,7 +1765,7 @@ mod tests {
     /// here shows up as an obviously-unfinished change rather than as a silently unlabelled row.
     #[test]
     fn every_engine_skip_reason_maps_to_a_fallback_reason() {
-        for reason in ["pool_density"] {
+        for reason in ["pool_density", "pool_size"] {
             assert_eq!(
                 skip_reason_to_fallback_reason(Some(reason)),
                 Some(reason),

--- a/crates/graze-api/src/api/feed.rs
+++ b/crates/graze-api/src/api/feed.rs
@@ -123,6 +123,21 @@ fn graze_api_hash_experiment(config: &crate::config::Config) -> crate::algorithm
     }
 }
 
+/// Map a pre-scoring skip reported by the engine onto a provenance `fallback_reason`.
+///
+/// Returns a `'static` reason so the caller can hold it in `fallback_reason` past the response it
+/// was read from — the reason is a compile-time constant on both sides, only the wire type differs.
+///
+/// A value this build does not recognise maps to `None` rather than being passed through:
+/// `fallback_reason` is a closed set that ClickHouse readouts group by, and an unknown category is
+/// better reported as absent than as one nobody has defined.
+fn skip_reason_to_fallback_reason(skip: Option<&str>) -> Option<&'static str> {
+    match skip {
+        Some("pool_density") => Some("pool_density"),
+        _ => None,
+    }
+}
+
 /// Build feedContext provenance for one item and encode to base64 string.
 /// feed_uri must always be provided—the client echoes this back with interactions
 /// and we rely on it for ClickHouse storage.
@@ -1062,6 +1077,8 @@ pub async fn get_feed_skeleton(
                         let posts_checked = result.meta.posts_checked.unwrap_or(0);
                         let posts_scored = result.meta.total_scored.unwrap_or(0);
                         let _scoring_time_ms = result.meta.scoring_time_ms.unwrap_or(0.0);
+                        // Read before `result` is consumed below.
+                        let skip_reason = result.meta.skip_reason.clone();
 
                         // Collect post IDs that need conversion to URIs
                         let posts_to_convert: Vec<String> = result
@@ -1205,6 +1222,16 @@ pub async fn get_feed_skeleton(
                             .take(limit)
                             .collect();
                         was_personalized = !base_posts_tagged.is_empty();
+
+                        // A pre-scoring gate returns Ok with nothing scored, so this response is
+                        // fallback — and until the engine reported *why*, it was fallback with no
+                        // reason recorded at all, which is the one case `fallback_reason` could not
+                        // decompose. Only fills a slot nothing else has claimed, so a reason set
+                        // earlier on this path (holdout, exhausted) still wins.
+                        if fallback_reason.is_none() {
+                            fallback_reason =
+                                skip_reason_to_fallback_reason(skip_reason.as_deref());
+                        }
                         response_thompson_meta = Some(ResponseThompsonMeta {
                             params: thompson_params.clone(),
                             response_time_ms: total_response_time_ms,
@@ -1730,6 +1757,39 @@ pub async fn send_interactions(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The gates the engine can report, and the reason each becomes in the provenance blob.
+    ///
+    /// Kept as one table so adding a gate to `compute_personalization` without giving it a label
+    /// here shows up as an obviously-unfinished change rather than as a silently unlabelled row.
+    #[test]
+    fn every_engine_skip_reason_maps_to_a_fallback_reason() {
+        for reason in ["pool_density"] {
+            assert_eq!(
+                skip_reason_to_fallback_reason(Some(reason)),
+                Some(reason),
+                "{reason} must reach the provenance blob"
+            );
+        }
+    }
+
+    /// Scoring that ran and returned nothing is NOT a skip, and must not be labelled as one.
+    ///
+    /// This is the distinction the field exists to preserve: "we refused to look" is a feed-level
+    /// property that a different feed configuration would fix, whereas "we looked and found
+    /// nothing" is a user-level one. Collapsing them would recreate the ambiguity in a new place.
+    #[test]
+    fn no_skip_yields_no_fallback_reason() {
+        assert_eq!(skip_reason_to_fallback_reason(None), None);
+    }
+
+    /// An unrecognised value is reported as absent rather than passed through, so a blob written
+    /// by a newer build can never introduce a category this build's readouts do not define.
+    #[test]
+    fn an_unknown_skip_reason_is_not_passed_through() {
+        assert_eq!(skip_reason_to_fallback_reason(Some("something_new")), None);
+        assert_eq!(skip_reason_to_fallback_reason(Some("")), None);
+    }
 
     /// The cache previously stored bare URIs, so every item read back was relabelled
     /// `PostLevelPersonalization` — silently mis-attributing fallback and author-affinity

--- a/crates/graze-common/src/models/feed_context.rs
+++ b/crates/graze-common/src/models/feed_context.rs
@@ -89,7 +89,15 @@ pub struct FeedContextProvenance {
     ///
     /// `no_user_data` (no seed in the like window) | `no_auth` (unauthenticated request) |
     /// `no_algo_posts` (the feed's candidate pool is empty) | `personalization_holdout` |
-    /// `personalization_error`. `None` when the response *was* personalized.
+    /// `personalization_error` | `pool_density` (the feed's candidate pool carries too little like
+    /// signal to rank — `MIN_POOL_SCOREABLE_SHARE`). `None` when the response *was* personalized.
+    ///
+    /// `pool_density` is a gate the engine applies *before* scoring, and was added later than the
+    /// rest: it returned an empty result indistinguishable from "scored and found nothing", so a
+    /// gated response was served as fallback carrying no reason at all. Verified on feed 6445 on
+    /// 2026-09-01: 22 of the 24 items served at 18:00Z had `source=fallback` and no
+    /// `fallback_reason`. Rows written before that fix carry no reason for this cause, so a
+    /// readout spanning the deploy must not read absence as "personalized".
     ///
     /// Exists because this reason was previously only ever written to a log line, so coverage
     /// failures could not be decomposed in ClickHouse and every experiment silently mixed users

--- a/crates/graze-common/src/models/feed_context.rs
+++ b/crates/graze-common/src/models/feed_context.rs
@@ -90,13 +90,15 @@ pub struct FeedContextProvenance {
     /// `no_user_data` (no seed in the like window) | `no_auth` (unauthenticated request) |
     /// `no_algo_posts` (the feed's candidate pool is empty) | `personalization_holdout` |
     /// `personalization_error` | `pool_density` (the feed's candidate pool carries too little like
-    /// signal to rank — `MIN_POOL_SCOREABLE_SHARE`). `None` when the response *was* personalized.
+    /// signal to rank — `MIN_POOL_SCOREABLE_SHARE`) | `pool_size` (the feed's candidate pool is
+    /// below `MIN_CANDIDATE_POOL_FOR_PERSONALIZATION`). `None` when the response *was*
+    /// personalized.
     ///
-    /// `pool_density` is a gate the engine applies *before* scoring, and was added later than the
-    /// rest: it returned an empty result indistinguishable from "scored and found nothing", so a
-    /// gated response was served as fallback carrying no reason at all. Verified on feed 6445 on
-    /// 2026-09-01: 22 of the 24 items served at 18:00Z had `source=fallback` and no
-    /// `fallback_reason`. Rows written before that fix carry no reason for this cause, so a
+    /// The last two are the gates the engine applies *before* scoring, and they were added later
+    /// than the rest: both returned an empty result indistinguishable from "scored and found
+    /// nothing", so a gated response was served as fallback carrying no reason at all. Verified on
+    /// feed 6445 on 2026-09-01: 22 of the 24 items served at 18:00Z had `source=fallback` and no
+    /// `fallback_reason`. Rows written before that fix carry no reason for these two causes, so a
     /// readout spanning the deploy must not read absence as "personalized".
     ///
     /// Exists because this reason was previously only ever written to a log line, so coverage

--- a/crates/graze-common/src/models/responses.rs
+++ b/crates/graze-common/src/models/responses.rs
@@ -93,6 +93,21 @@ pub struct ResponseMeta {
     /// Scoring time in milliseconds (excluding cache/URI resolution).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scoring_time_ms: Option<f64>,
+
+    /// Why scoring was skipped entirely before it ran: `pool_density`. Absent when scoring ran,
+    /// including when it ran and returned nothing.
+    ///
+    /// Exists so `api::feed` can turn a pre-scoring gate into a `fallback_reason` on the
+    /// provenance blob. Before this, the gate returned an empty `ScoringResult` that was
+    /// indistinguishable from "scored and found nothing", so the response was served as fallback
+    /// with no reason recorded at all and the coverage failure could not be decomposed in
+    /// ClickHouse. Verified on feed 6445 on 2026-09-01: 22 of 24 items carried `source=fallback`
+    /// with no `fallback_reason`.
+    ///
+    /// `Option<String>` rather than `&'static str` because this crosses the wire on
+    /// `/v1/personalize`; the reasons themselves are constants on `ScoringResult::skip_reason`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<String>,
 }
 
 /// Response from the personalize endpoint.
@@ -181,4 +196,31 @@ pub struct InvalidateResponse {
 
     /// Message.
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `skip_reason` is absent from the wire unless a gate actually fired.
+    ///
+    /// Same additive property the provenance blob's own fields rely on: a consumer that has never
+    /// heard of this field sees exactly the payload it saw before, and a present value therefore
+    /// means something happened rather than being a default that is always there.
+    #[test]
+    fn skip_reason_is_omitted_unless_a_gate_fired() {
+        let mut meta = ResponseMeta::default();
+        let json = serde_json::to_string(&meta).expect("serialize");
+        assert!(
+            !json.contains("skip_reason"),
+            "a response that scored must not carry skip_reason: {json}"
+        );
+
+        meta.skip_reason = Some("pool_density".to_string());
+        let json = serde_json::to_string(&meta).expect("serialize");
+        assert!(
+            json.contains("\"skip_reason\":\"pool_density\""),
+            "a gated response must carry the reason: {json}"
+        );
+    }
 }

--- a/crates/graze-common/src/models/responses.rs
+++ b/crates/graze-common/src/models/responses.rs
@@ -94,11 +94,11 @@ pub struct ResponseMeta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scoring_time_ms: Option<f64>,
 
-    /// Why scoring was skipped entirely before it ran: `pool_density`. Absent when scoring ran,
-    /// including when it ran and returned nothing.
+    /// Why scoring was skipped entirely before it ran: `pool_density` | `pool_size`. Absent when
+    /// scoring ran, including when it ran and returned nothing.
     ///
     /// Exists so `api::feed` can turn a pre-scoring gate into a `fallback_reason` on the
-    /// provenance blob. Before this, the gate returned an empty `ScoringResult` that was
+    /// provenance blob. Before this, both gates returned an empty `ScoringResult` that was
     /// indistinguishable from "scored and found nothing", so the response was served as fallback
     /// with no reason recorded at all and the coverage failure could not be decomposed in
     /// ClickHouse. Verified on feed 6445 on 2026-09-01: 22 of 24 items carried `source=fallback`


### PR DESCRIPTION
Two gates skip personalization *before* scoring runs — `MIN_POOL_SCOREABLE_SHARE`
(pool like-density, step 0b) and `MIN_CANDIDATE_POOL_FOR_PERSONALIZATION` (pool
size, step 0). Both return an empty `ScoringResult`, which the feed handler
cannot tell apart from "scored and found nothing", so the response goes out as
fallback with **no `fallback_reason` at all**. Verified in production 2026-09-01:
22 of the 24 items feed 6445 served at 18:00Z carried `source=fallback` with no
reason of any kind.

This is the defect 5d3286d fixed for `no_user_data`, in the two paths that commit
did not reach. Same consequence: a coverage failure cannot be decomposed in
ClickHouse, and the running holdout and follow-seed experiments mix users the
engine served with users it refused to look at.

## What changed

- `ScoringResult::skip_reason: Option<&'static str>` — `None` whenever scoring
  actually ran, set at each gate's early exit.
- Surfaced on `ResponseMeta` as `Option<String>` with
  `skip_serializing_if = "Option::is_none"`.
- `api::feed` maps it onto `fallback_reason` through a small `'static`-returning
  helper, only when nothing else has already claimed a reason.
- New values documented on `FeedContextProvenance::fallback_reason`:
  `pool_density` | `pool_size`.

No ClickHouse migration, for the same reason `ranker` and `fallback_reason`
needed none: the blob is stored verbatim in `interaction_feed_context String` and
decoded with plain `serde_json`, which ignores unknown keys.

A skip is deliberately **not** recorded when scoring ran and returned nothing.
"We refused to look" is a feed-level property a config change would fix; "we
looked and found nothing" is a user-level one. Collapsing them would recreate the
ambiguity this removes, one level down.

## Why the pool-size gate is in here (second commit)

The brief flagged it as possibly a separate change. I bundled it, and it reverts
on its own if you disagree. Leaving it out would not have made the density fix
safer, only less useful: both gates produce an identical symptom, so labelling
one still leaves "absent reason" a mixture and a coverage query has to guess
which gate it is looking at. The point of the enum is that the unlabelled bucket
means something.

Worth knowing: `MIN_CANDIDATE_POOL_FOR_PERSONALIZATION=500` is set in the
**deployment container env**, not in the `personalization-env` ConfigMap. The
gate is live.

## Two production facts that change what to expect after deploy

1. **Feed 6445 will probably not show `pool_density`.** The 18:00Z observation
   was served by revision 55/56. The running image (revision 57, deployed
   2026-09-01T23:36Z) is the `ba8efa9` build, and `MIN_POOL_SCOREABLE_POSTS=500`
   is set — so 6445, at 1,452 scoreable candidates, is now *exempt* from the
   density gate. Expect `pool_density` on the small-signal feeds (the 20/22/24/30
   scoreable ones), and expect it to be low volume. If 6445 still serves
   unlabelled fallback after this ships, the cause is something neither gate
   explains, and this instrumentation is what will say so.
2. **The interleaving path bypasses both gates.** `apply_interleaving` replaces
   the gated result wholesale when co-liker weights are non-empty. Pre-existing,
   not touched here, but it bounds what these labels can measure while
   interleaving is on.

## Experiment impact — please read before the next readout

This relabels rows that today carry **no** reason. Any readout spanning the
deploy must classify personalization positively (`personalized_count > 0`) rather
than by absence of `fallback_reason`, or it will report the deploy boundary as a
change in coverage.

The coverage CronJob already does exactly that and buckets unknown reasons by
name, so it absorbs `pool_density` / `pool_size` with no change. Both land in its
*addressable* set, which is correct — both are addressable by config.

## Verification

`cargo fmt`, `cargo clippy --all-targets --all-features` clean, 234 lib tests
pass. New tests pin: every engine skip reason maps to a reason that reaches the
blob; a completed-but-empty scoring run is not labelled a skip; an unrecognised
value is reported absent rather than passed through as a new category; and
`ResponseMeta` omits the field from the wire unless a gate fired.

## Deploy

`docker-release.yml` via `workflow_dispatch` → DOCR, then deploy
`personalization-api` **by digest** (tags are mutable). Canary + surge-first per
standing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)