### PR TITLE
Propagate a reader's own follows into their lens within seconds

### DIFF
--- a/crates/graze-lens-fold/src/config.rs
+++ b/crates/graze-lens-fold/src/config.rs
@@ -29,6 +29,13 @@ pub struct Config {
     pub deltas_enabled: bool,
     /// How often to reload the set of viewers worth tracking.
     pub active_refresh_interval: Duration,
+    /// How often the sweeper turns dirty viewers into rebuild requests.
+    ///
+    /// This IS the propagation latency for a reader's own follows: a change is
+    /// visible once the sweep fires and the builder drains the queue. Lower is
+    /// fresher and costs more ClickHouse work per changed viewer; the coalescing
+    /// means it costs nothing extra per *event*.
+    pub dirty_sweep_interval: Duration,
     /// Life extension applied to a set each time a delta lands. Long on
     /// purpose: with deltas keeping it correct, an actively-read set should
     /// never expire, and expiry becomes a garbage-collector for readers who
@@ -66,6 +73,7 @@ impl Config {
             read_timeout_seconds: parse("LENS_FOLD_READ_TIMEOUT_SECONDS", 45)?,
 
             deltas_enabled: parse("LENS_FOLD_DELTAS_ENABLED", true)?,
+            dirty_sweep_interval: Duration::from_secs(parse("LENS_FOLD_DIRTY_SWEEP_SECONDS", 30)?),
             active_refresh_interval: Duration::from_secs(parse(
                 "LENS_FOLD_ACTIVE_REFRESH_SECONDS",
                 60,

--- a/crates/graze-lens-fold/src/delta.rs
+++ b/crates/graze-lens-fold/src/delta.rs
@@ -6,6 +6,37 @@
 //! rebuild runs. Applying the follow stream to sets that already exist lets the
 //! TTL move out to days, and an actively-read set then never expires at all.
 //!
+//! # The v2 blobs are what readers actually get
+//!
+//! Everything above is about the v1 *sets*, and the serve path stopped reading
+//! those: it loads `lens:v2:{facet}:{did}` blobs and only falls back to a v1 set
+//! when a single-facet plan has no blob at all. So applying a follow to the v1
+//! set kept the set correct and changed nothing a reader saw — a follow made
+//! today did not reach their lens until the nightly rebuild, up to ~24h later.
+//!
+//! A blob cannot be updated the way a set can. It is a sorted `(didint, score)`
+//! array with a bloom trailer, so inserting one author means rewriting the whole
+//! value — 640 KB for `community` — per event, racing every other writer.
+//!
+//! So the blobs are not mutated; they are **rebuilt**, and this module's job is
+//! to notice that a rebuild is owed and to ask for exactly one. A graph change
+//! marks the viewer dirty (`SADD lens:dirty`, O(1) and idempotent) and a sweeper
+//! drains that set on a timer, enqueuing a rebuild per facet the viewer already
+//! has.
+//!
+//! **Trailing edge, deliberately.** A per-viewer cooldown would lose updates: a
+//! follow at t=0 enqueues, a follow at t=5s is suppressed as "recently done", and
+//! the t=0 rebuild has already run without it. Marking and sweeping coalesces by
+//! construction and cannot drop an update — any change inside the window is
+//! picked up by the next sweep. It also bounds the cost: at most one rebuild per
+//! viewer per sweep however many times they follow, which matters because a
+//! `community` rebuild is a 500k-row ClickHouse query.
+//!
+//! What this does NOT fix: *other people's* follows changing this viewer's second
+//! degree. The seeds are live, but the traversal graph `follow_graph_int` is
+//! rebuilt nightly, so an edge someone else made today enters the second degree
+//! tomorrow.
+//!
 //! # Creates apply; deletes rebuild
 //!
 //! A follow *create* carries its subject, so it applies directly: one `SADD`.
@@ -31,13 +62,35 @@ use deadpool_redis::Pool;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::event::FollowEdge;
 use crate::metrics::Metrics;
 
 /// Viewers with a published lens set. The builder adds to this on publish.
 pub const ACTIVE_KEY: &str = "lens:active";
+/// Viewers whose own graph changed since the last sweep.
+pub const DIRTY_KEY: &str = "lens:dirty";
+
+/// Per-viewer facets a rebuild may cover.
+///
+/// Must stay in step with `FACETS` in `graze-lens-builder/src/bin/refresh.rs` —
+/// the sweeper is the event-driven twin of that nightly job, and a facet missing
+/// here would simply never be refreshed on change. `domain` is absent because it
+/// is keyed by feed, not viewer, so a reader's follows cannot affect it.
+pub const VIEWER_FACETS: &[&str] = &[
+    "follows",
+    "follows2",
+    "niche",
+    "popular",
+    "velocity",
+    "community",
+];
+
+/// Dirty viewers drained in one sweep. A ceiling rather than a target: it bounds
+/// how much ClickHouse work a single tick can schedule if something upstream
+/// marks far more viewers than usual.
+const SWEEP_BATCH: usize = 256;
 /// The build queue feeder-rs and this module both write to.
 const BUILD_QUEUE_KEY: &str = "queue:lens";
 const BUILD_QUEUE_MAXLEN: usize = 100_000;
@@ -111,8 +164,125 @@ impl DeltaApplier {
         match edge.op {
             "create" => self.apply_follow(edge).await,
             "delete" => self.request_rebuild(&edge.follower).await,
-            _ => {}
+            _ => return,
         }
+        // Both directions change what this reader's lens should say, and neither
+        // is expressible as an edit to a blob. Mark, and let the sweeper coalesce.
+        self.mark_dirty(&edge.follower).await;
+    }
+
+    /// Note that this viewer's own graph moved, so their blobs are stale.
+    async fn mark_dirty(&self, viewer: &str) {
+        let result = async {
+            let mut conn = self.redis.get().await?;
+            let _: i64 = conn.sadd(DIRTY_KEY, viewer).await?;
+            Ok::<_, anyhow::Error>(())
+        }
+        .await;
+        match result {
+            Ok(()) => {
+                self.metrics.dirty_marked.inc();
+            }
+            Err(e) => {
+                warn!(error = %e, viewer, "could not mark viewer dirty");
+                self.metrics.delta_failures.inc();
+            }
+        }
+    }
+
+    /// Drain the dirty set and enqueue a rebuild per facet each viewer has.
+    ///
+    /// `SPOP` with a count is atomic: whatever it returns is removed, so a viewer
+    /// cannot be swept twice, and a viewer who changes again mid-sweep is simply
+    /// re-marked and picked up next tick. On failure the viewers are already
+    /// popped, so they are re-marked rather than silently dropped — a lost mark
+    /// means a lens stale until the nightly job, which is the outcome this whole
+    /// module exists to avoid.
+    pub async fn sweep(&self) {
+        self.metrics.sweeps.inc();
+        let mut conn = match self.redis.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, "sweep could not reach redis");
+                self.metrics.sweep_failures.inc();
+                return;
+            }
+        };
+
+        let drained = deadpool_redis::redis::cmd("SPOP")
+            .arg(DIRTY_KEY)
+            .arg(SWEEP_BATCH)
+            .query_async::<Vec<String>>(&mut conn)
+            .await;
+        let viewers: Vec<String> = match drained {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "sweep could not drain the dirty set");
+                self.metrics.sweep_failures.inc();
+                return;
+            }
+        };
+        self.metrics.dirty_viewers.set(viewers.len() as i64);
+        if viewers.is_empty() {
+            return;
+        }
+
+        let mut requested = 0usize;
+        let mut failed: Vec<String> = Vec::new();
+        for viewer in &viewers {
+            match self.enqueue_existing_facets(&mut conn, viewer).await {
+                Ok(n) => requested += n,
+                Err(e) => {
+                    warn!(error = %e, viewer, "sweep failed for viewer; re-marking");
+                    failed.push(viewer.clone());
+                }
+            }
+        }
+
+        if !failed.is_empty() {
+            self.metrics.sweep_failures.inc();
+            let _: Result<i64, _> = conn.sadd(DIRTY_KEY, failed).await;
+        }
+        self.metrics
+            .sweep_rebuilds_requested
+            .inc_by(requested as u64);
+        info!(
+            viewers = viewers.len(),
+            rebuilds = requested,
+            "swept dirty viewers"
+        );
+    }
+
+    /// Enqueue a rebuild for every facet this viewer ALREADY has.
+    ///
+    /// Only existing facets, mirroring the nightly refresh: enqueuing a facet
+    /// nobody has asked for would build a blob no feed reads and pay a
+    /// ClickHouse query for it.
+    async fn enqueue_existing_facets(
+        &self,
+        conn: &mut deadpool_redis::Connection,
+        viewer: &str,
+    ) -> anyhow::Result<usize> {
+        let mut requested = 0;
+        for facet in VIEWER_FACETS {
+            let exists: bool = conn.exists(format!("lens:v2:{facet}:{viewer}")).await?;
+            if !exists {
+                continue;
+            }
+            let payload = serde_json::json!({ "viewer_did": viewer, "facet": facet }).to_string();
+            deadpool_redis::redis::cmd("XADD")
+                .arg(BUILD_QUEUE_KEY)
+                .arg("MAXLEN")
+                .arg("~")
+                .arg(BUILD_QUEUE_MAXLEN)
+                .arg("*")
+                .arg("data")
+                .arg(&payload)
+                .query_async::<()>(conn)
+                .await?;
+            requested += 1;
+        }
+        Ok(requested)
     }
 
     async fn apply_follow(&self, edge: &FollowEdge) {
@@ -194,6 +364,60 @@ impl DeltaApplier {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The sweeper is the event-driven twin of the nightly refresh job, so it has
+    /// to cover the same facets. There is no shared constant to import across
+    /// crates, so the list is pinned here and this test is the thing that fails
+    /// when the two drift — a facet missing from one side is simply never
+    /// refreshed on that path, with nothing to say so.
+    #[test]
+    fn viewer_facets_match_the_nightly_refresh_job() {
+        assert_eq!(
+            VIEWER_FACETS,
+            &[
+                "follows",
+                "follows2",
+                "niche",
+                "popular",
+                "velocity",
+                "community"
+            ],
+            "keep in step with FACETS in graze-lens-builder/src/bin/refresh.rs"
+        );
+    }
+
+    /// `domain` is keyed by feed, not by viewer, so no amount of following
+    /// changes it. Enqueuing it per reader would pay a ClickHouse query to
+    /// rebuild a blob that cannot have moved.
+    #[test]
+    fn domain_is_not_a_viewer_facet() {
+        assert!(!VIEWER_FACETS.contains(&"domain"));
+    }
+
+    /// Both directions have to mark. An unfollow already requested a rebuild of
+    /// `follows` alone; without marking, every other facet the reader has stayed
+    /// stale until the nightly job.
+    #[test]
+    fn both_ops_are_handled_not_just_creates() {
+        let src = include_str!("delta.rs");
+        let apply = src
+            .split("pub async fn apply(")
+            .nth(1)
+            .expect("apply must exist");
+        let body = &apply[..apply.find("\n    }").expect("apply must close")];
+        assert!(body.contains("\"create\""), "creates must be handled");
+        assert!(body.contains("\"delete\""), "deletes must be handled");
+        assert!(
+            body.contains("mark_dirty"),
+            "both ops must mark the viewer dirty, or the blobs never get rebuilt"
+        );
+    }
+
+    #[test]
+    fn dirty_key_is_stable() {
+        // Named in operational checks and in the sweeper's own logs.
+        assert_eq!(DIRTY_KEY, "lens:dirty");
+    }
 
     /// `SADD` on a missing key creates it. A lens set with one member would
     /// silently hide almost everything from that reader — strictly worse than

--- a/crates/graze-lens-fold/src/main.rs
+++ b/crates/graze-lens-fold/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
     let cursor = Cursor::new(pool.clone());
 
     let deltas = if config.deltas_enabled {
-        let applier = DeltaApplier::new(pool, metrics.clone(), config.set_ttl_seconds);
+        let applier = DeltaApplier::new(pool.clone(), metrics.clone(), config.set_ttl_seconds);
         // Warm the active list before the first event, so a restart does not
         // spend an interval ignoring deltas for viewers who are already live.
         match applier.refresh_active().await {
@@ -39,6 +39,30 @@ async fn main() -> anyhow::Result<()> {
         info!("live lens maintenance disabled; sets will expire on their TTL");
         None
     };
+
+    // The sweeper turns "this viewer's graph moved" into rebuild requests. It
+    // runs on its own timer rather than inline with the stream: the stream is far
+    // too hot to do per-event Redis work on, and coalescing is the point.
+    if deltas.is_some() {
+        // A second applier rather than a shared one: the sweeper works entirely
+        // from the dirty set in Redis and never consults the active-viewer cache,
+        // so it needs no state from the streamer's copy and sharing one would
+        // only add a lock on the hot path.
+        let sweeper = DeltaApplier::new(pool, metrics.clone(), config.set_ttl_seconds);
+        let interval = config.dirty_sweep_interval;
+        info!(
+            sweep_seconds = interval.as_secs(),
+            "dirty-viewer sweeper enabled; this is the propagation latency for a reader's own follows"
+        );
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                sweeper.sweep().await;
+            }
+        });
+    }
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     serve_metrics(config.metrics_port, metrics.clone());

--- a/crates/graze-lens-fold/src/metrics.rs
+++ b/crates/graze-lens-fold/src/metrics.rs
@@ -28,6 +28,18 @@ pub struct Metrics {
     pub deltas_rebuild_requested: Counter,
     pub delta_failures: Counter,
     pub active_viewers: Gauge,
+
+    /// Propagation of a viewer's OWN graph changes into their v2 blobs.
+    ///
+    /// `dirty_marked` counts graph changes seen for active viewers;
+    /// `sweep_rebuilds_requested` counts the rebuilds that resulted. The ratio is
+    /// the coalescing factor — a viewer on a follow spree is marked many times
+    /// and rebuilt once, which is the whole point.
+    pub dirty_marked: Counter,
+    pub sweeps: Counter,
+    pub sweep_rebuilds_requested: Counter,
+    pub sweep_failures: Counter,
+    pub dirty_viewers: Gauge,
 }
 
 impl Metrics {
@@ -85,6 +97,37 @@ impl Metrics {
             deltas_applied.clone(),
         );
 
+        let dirty_marked = Counter::default();
+        registry.register(
+            "dirty_marked",
+            "Graph changes seen for an active viewer, before coalescing",
+            dirty_marked.clone(),
+        );
+
+        let sweeps = Counter::default();
+        registry.register("sweeps", "Dirty-viewer sweeps run", sweeps.clone());
+
+        let sweep_rebuilds_requested = Counter::default();
+        registry.register(
+            "sweep_rebuilds_requested",
+            "Facet rebuilds enqueued by the sweeper, after coalescing",
+            sweep_rebuilds_requested.clone(),
+        );
+
+        let sweep_failures = Counter::default();
+        registry.register(
+            "sweep_failures",
+            "Sweeps that could not complete; their viewers stay dirty for the next one",
+            sweep_failures.clone(),
+        );
+
+        let dirty_viewers = Gauge::default();
+        registry.register(
+            "dirty_viewers",
+            "Viewers drained by the most recent sweep",
+            dirty_viewers.clone(),
+        );
+
         let deltas_rebuild_requested = Counter::default();
         registry.register(
             "deltas_rebuild_requested",
@@ -116,6 +159,11 @@ impl Metrics {
             reconnects,
             cursor_age_seconds,
             deltas_applied,
+            dirty_marked,
+            sweeps,
+            sweep_rebuilds_requested,
+            sweep_failures,
+            dirty_viewers,
             deltas_rebuild_requested,
             delta_failures,
             active_viewers,

--- a/crates/graze-lens-fold/tests/dirty_sweep.rs
+++ b/crates/graze-lens-fold/tests/dirty_sweep.rs
@@ -1,0 +1,146 @@
+//! The propagation chain: a viewer's own graph change reaching a rebuild request.
+//!
+//! Env-gated on `TEST_REDIS_URL` like the other live tests in this workspace. The
+//! whole point of the mark-and-sweep is behaviour Redis mediates — coalescing,
+//! atomic draining, only-existing-facets — so a unit test over pure functions
+//! would prove none of it.
+//!
+//! Deliberately ONE test with phases rather than four tests: `lens:dirty` and
+//! `queue:lens` are fixed global keys, and `SPOP` drains the dirty set wholesale,
+//! so a parallel sweep in another test would swallow this one's marked viewer.
+//! Phases keep it honest without requiring `--test-threads=1` to pass.
+//!
+//!   TEST_REDIS_URL=redis://127.0.0.1:16379 \
+//!   cargo test -p graze-lens-fold --test dirty_sweep -- --nocapture
+
+use deadpool_redis::redis::AsyncCommands;
+use deadpool_redis::{Config as RedisConfig, Runtime};
+use graze_lens_fold::{DeltaApplier, Metrics};
+
+const VIEWER: &str = "did:plc:sweep-test-viewer";
+
+fn url() -> Option<String> {
+    std::env::var("TEST_REDIS_URL")
+        .ok()
+        .filter(|u| !u.is_empty())
+}
+
+async fn pool(url: &str) -> deadpool_redis::Pool {
+    RedisConfig::from_url(url)
+        .builder()
+        .expect("pool builder")
+        .max_size(4)
+        .runtime(Runtime::Tokio1)
+        .build()
+        .expect("pool")
+}
+
+async fn cleanup(pool: &deadpool_redis::Pool) {
+    let mut conn = pool.get().await.expect("conn");
+    let _: i64 = conn.del("lens:dirty").await.unwrap_or(0);
+    let _: i64 = conn.del("queue:lens").await.unwrap_or(0);
+    for facet in [
+        "follows",
+        "follows2",
+        "niche",
+        "popular",
+        "velocity",
+        "community",
+    ] {
+        let _: i64 = conn
+            .del(format!("lens:v2:{facet}:{VIEWER}"))
+            .await
+            .unwrap_or(0);
+    }
+}
+
+/// Queue length, so a test can count what the sweeper asked for.
+async fn queue_len(pool: &deadpool_redis::Pool) -> usize {
+    let mut conn = pool.get().await.expect("conn");
+    let n: usize = deadpool_redis::redis::cmd("XLEN")
+        .arg("queue:lens")
+        .query_async(&mut conn)
+        .await
+        .unwrap_or(0);
+    n
+}
+
+#[tokio::test]
+async fn a_viewers_own_change_becomes_exactly_the_rebuilds_it_should() {
+    let Some(url) = url() else {
+        eprintln!("skipping: TEST_REDIS_URL unset");
+        return;
+    };
+    let pool = pool(&url).await;
+    let applier = DeltaApplier::new(pool.clone(), Metrics::new(), 604_800);
+
+    // --- an idle sweep is silent and free -------------------------------------
+    // It runs every 30s forever, so doing nothing has to cost nothing.
+    cleanup(&pool).await;
+    applier.sweep().await;
+    assert_eq!(queue_len(&pool).await, 0, "no work, no queue entries");
+
+    // --- only the facets the viewer HAS --------------------------------------
+    // Enqueuing a facet nobody asked for pays a ClickHouse query — a 500k-row one
+    // for `community` — to build a blob no feed will read.
+    cleanup(&pool).await;
+    let mut conn = pool.get().await.expect("conn");
+    let _: () = conn
+        .set(format!("lens:v2:follows:{VIEWER}"), "x")
+        .await
+        .expect("seed");
+    let _: () = conn
+        .set(format!("lens:v2:niche:{VIEWER}"), "x")
+        .await
+        .expect("seed");
+    let _: i64 = conn.sadd("lens:dirty", VIEWER).await.expect("mark");
+
+    applier.sweep().await;
+    assert_eq!(
+        queue_len(&pool).await,
+        2,
+        "one rebuild per EXISTING facet, not one per facet that could exist"
+    );
+    assert_eq!(
+        conn.scard::<_, usize>("lens:dirty").await.expect("scard"),
+        0,
+        "a swept viewer must not stay dirty"
+    );
+
+    // --- many marks coalesce into one rebuild --------------------------------
+    // The property that makes it safe to mark on every event.
+    cleanup(&pool).await;
+    let _: () = conn
+        .set(format!("lens:v2:follows:{VIEWER}"), "x")
+        .await
+        .expect("seed");
+    for _ in 0..50 {
+        let _: i64 = conn.sadd("lens:dirty", VIEWER).await.expect("mark");
+    }
+    assert_eq!(
+        conn.scard::<_, usize>("lens:dirty").await.expect("scard"),
+        1,
+        "a set dedupes by construction"
+    );
+    applier.sweep().await;
+    assert_eq!(
+        queue_len(&pool).await,
+        1,
+        "50 follows must cost one rebuild, not 50"
+    );
+
+    // --- a viewer with no blobs costs nothing, and is still drained ----------
+    // Someone outside the cohort can be marked (active once, or the active list
+    // is mid-refresh). They must not cause builds, and must not be retried forever.
+    cleanup(&pool).await;
+    let _: i64 = conn.sadd("lens:dirty", VIEWER).await.expect("mark");
+    applier.sweep().await;
+    assert_eq!(queue_len(&pool).await, 0, "no blobs, no rebuilds");
+    assert_eq!(
+        conn.scard::<_, usize>("lens:dirty").await.expect("scard"),
+        0,
+        "still drained, so we do not retry them forever"
+    );
+
+    cleanup(&pool).await;
+}

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-fold-deployment.yaml
+++ b/kube/lens-fold-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: fold
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
           command: ["/app/graze-lens-fold"]
           resources:
             requests:

--- a/kube/lens-lpa-cronjob.yaml
+++ b/kube/lens-lpa-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
           containers:
             - name: lpa
               # Digest-pinned; updated together with the other lens workloads.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
               command: ["/app/graze-lens-lpa"]
               resources:
                 requests:

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               # Built from commit 1a835eb (feat/lens-completeness-guard).
               # Digest-pinned: both `latest` and the short-SHA tag are mutable
               # on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
               command: ["/app/graze-lens-project"]
               resources:
                 requests:

--- a/kube/lens-refresh-cronjob.yaml
+++ b/kube/lens-refresh-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
             - name: docr-graze-social-labs
           containers:
             - name: refresh
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
               command: ["/app/graze-lens-refresh"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: rev-rebuild
               # Built from commit 1a835eb (feat/lens-completeness-guard). Digest-pinned:
               # both `latest` and the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:08d0376a79c3e20e040abecc98e6e7eb5bcf0d971cacd360b2073954d6ec51e0
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:


### PR DESCRIPTION
A cohort member could follow someone and their lens would not change until the next nightly rebuild — up to **~24 hours**.

The graph itself was never the problem. `lens-fold` sits at the tip of the firehose (`cursor_age_seconds 0`, ~974k follows and ~157k unfollows in one session, 97k creates + 13.5k deletes in the last hour), and `follow_graph_int` holds **2,776,633,634 of the 2,796,270,792 edges**. The freshness simply stopped before it reached anything a reader is served.

## Why, precisely

1. **Creates were applied to the v1 *sets***, with a single `SADD`. But the serve path moved to v2 blobs and only falls back to a v1 set when a single-facet plan has no blob at all — which never happens now. So the apply kept the set correct and changed nothing anyone saw. `deltas_applied_total` was doing real work into a dead end.
2. **An unfollow requested a rebuild of `follows` alone**, leaving `follows2`/`niche`/`popular`/`velocity`/`community` stale regardless.

## Why not just edit the blob

A blob is a sorted `(didint, score)` array with a bloom trailer. Inserting one author means rewriting the whole value — **640 KB for `community`** — on every event, racing every other writer. So blobs are not mutated; they are rebuilt. This module's job is to notice a rebuild is owed and ask for exactly one.

## Mark and sweep

A graph change in either direction marks the viewer dirty (`SADD lens:dirty`, O(1), idempotent). A sweeper drains that set every 30s (`LENS_FOLD_DIRTY_SWEEP_SECONDS`) and enqueues one rebuild per facet the viewer **already has** — existing facets only, mirroring the nightly refresh, because enqueuing one nobody asked for pays a ClickHouse query (a 500k-row one for `community`) to build a blob no feed reads.

**Trailing edge on purpose.** A per-viewer cooldown loses updates: a follow at t=0 enqueues, a follow at t=5s is suppressed as "recently done", and the t=0 rebuild already ran without it. Mark-and-sweep coalesces by construction and cannot drop an update, and it bounds cost at one rebuild per viewer per sweep however many times they follow. `SPOP` with a count is atomic so a viewer cannot be swept twice; a failed sweep **re-marks** its viewers rather than dropping them, because a lost mark means a lens stale until the nightly job — the exact outcome this exists to prevent.

Marking stays behind the existing `is_active` hash lookup, so the millions of follows by accounts nobody has a lens for still cost nothing and `lens:dirty` stays the size of the cohort.

## Verified in prod

Deployed `sha256:b5766264…` and marked a cohort viewer exactly as a real follow does:

```
01:43:5x  marked
01:44:28  swept dirty viewers viewers=1 rebuilds=6
01:44:31  built scored facet facet="community" seeds=1187 reached=499220
```

All six of his facets came back fresh: rebuilt 9–40s ago, `FRESH_COUNT=6/6`. Metrics: `sweeps_total 3`, `sweep_rebuilds_requested_total 6`, `sweep_failures_total 0`. **~24h → under a minute.**

## Scoped, deliberately not built

Other people's follows changing this viewer's **second degree**. The seeds are live (`follow_edges FINAL`) but the traversal graph `follow_graph_int` is rebuilt nightly (31 min for 2.78B rows), so an edge someone else made today enters the second degree tomorrow. `velocity` feels it most, since recency is its whole point. Closing it needs incremental projection maintenance — a separate piece, sized in the commit message.

## Tests

Four phases against a live Redis: an idle sweep is free, only existing facets are enqueued, 50 marks coalesce to one rebuild, and a viewer with no blobs costs nothing yet is still drained. Deliberately **one** test rather than four — `lens:dirty` and `queue:lens` are fixed global keys and `SPOP` drains wholesale, so parallel tests swallow each other's viewers and would need `--test-threads=1` to pass. Verified it genuinely runs by pointing `TEST_REDIS_URL` at a closed port and watching it fail.

38 tests pass in parallel with no flags; `fmt` and `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)