### PR TITLE
Keep the traversal projection current between nightly rebuilds

### DIFF
--- a/crates/graze-common/src/lens_interner.rs
+++ b/crates/graze-common/src/lens_interner.rs
@@ -33,6 +33,16 @@
 //! that, a blob built in one space and read in another resolves every lookup to
 //! the wrong account and looks like a lens with strange taste, not a broken one.
 
+/// Blob header byte for the space rust-smasher and membership-service share.
+pub const IDSPACE_SHARED: u8 = 0;
+/// Blob header byte for the lens-owned space.
+///
+/// ⚠️ This records the space the builder *intended*, not where the ids came
+/// from. It is not a provenance guard — a blob filled from the wrong Redis still
+/// carries whichever byte the code stamped. See
+/// `memory/community-facet-not-personalized.md`.
+pub const IDSPACE_LENS: u8 = 1;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -87,7 +97,7 @@ impl Interner {
             redis,
             map_key: DIDINT_MAP,
             seq_key: DIDINT_SEQ,
-            idspace: crate::scored::IDSPACE_SHARED,
+            idspace: IDSPACE_SHARED,
             cache: Arc::new(DashMap::new()),
         }
     }
@@ -98,7 +108,7 @@ impl Interner {
             redis,
             map_key: LENSDID_MAP,
             seq_key: LENSDID_SEQ,
-            idspace: crate::scored::IDSPACE_LENS,
+            idspace: IDSPACE_LENS,
             cache: Arc::new(DashMap::new()),
         }
     }
@@ -115,6 +125,53 @@ impl Interner {
     ///
     /// Order is not preserved; the caller gets a map, because every caller here
     /// wants lookup rather than position.
+    /// Ids for the DIDs that ALREADY have one. Allocates nothing.
+    ///
+    /// The counterpart to `intern_many`, and the right primitive for anything
+    /// reading the firehose. Interning every account that flies past would grow
+    /// this hash by roughly 19M entries a day — it already holds ~42M, on a Redis
+    /// where depth is an outage budget.
+    ///
+    /// Dropping unknown accounts is also the *correct* semantics rather than a
+    /// concession: `follow_graph_int` is built with INNER joins against the id
+    /// map, so an account without an id is already absent from the projection.
+    /// A delta that invented ids would describe edges the base table cannot, and
+    /// the two would disagree about who exists. Unknown accounts are picked up by
+    /// the nightly job's bounded interning, exactly as today.
+    pub async fn lookup_many(&self, dids: &[String]) -> anyhow::Result<HashMap<String, u32>> {
+        let mut out = HashMap::with_capacity(dids.len());
+        let mut unknown: Vec<&String> = Vec::new();
+
+        for did in dids {
+            match self.cache.get(did) {
+                Some(id) => {
+                    out.insert(did.clone(), *id);
+                }
+                None => unknown.push(did),
+            }
+        }
+        if unknown.is_empty() {
+            return Ok(out);
+        }
+
+        let mut conn = self.redis.get().await?;
+        for chunk in unknown.chunks(INTERN_CHUNK) {
+            let mut cmd = deadpool_redis::redis::cmd("HMGET");
+            cmd.arg(self.map_key);
+            for did in chunk {
+                cmd.arg(did.as_str());
+            }
+            let ids: Vec<Option<u32>> = cmd.query_async(&mut conn).await?;
+            for (did, id) in chunk.iter().zip(ids) {
+                if let Some(id) = id {
+                    self.cache.insert((*did).clone(), id);
+                    out.insert((*did).clone(), id);
+                }
+            }
+        }
+        Ok(out)
+    }
+
     pub async fn intern_many(&self, dids: &[String]) -> anyhow::Result<HashMap<String, u32>> {
         let mut out = HashMap::with_capacity(dids.len());
         let mut missing: Vec<String> = Vec::new();

--- a/crates/graze-common/src/lib.rs
+++ b/crates/graze-common/src/lib.rs
@@ -10,6 +10,7 @@ pub mod clickhouse;
 pub mod coliker_profile;
 pub mod error;
 pub mod exclusion;
+pub mod lens_interner;
 pub mod metrics_server;
 pub mod models;
 pub mod post_id;

--- a/crates/graze-lens-builder/src/lib.rs
+++ b/crates/graze-lens-builder/src/lib.rs
@@ -8,7 +8,10 @@
 pub mod builder;
 pub mod config;
 pub mod domain;
-pub mod interner;
+// The interner moved to graze-common so graze-lens-fold can use it too: the
+// builder depends on the fold, so the fold cannot depend back on the builder.
+// Re-exported under the old path so every `crate::interner::…` still resolves.
+pub use graze_common::lens_interner as interner;
 pub mod priors;
 pub mod queue;
 pub mod scored;

--- a/crates/graze-lens-builder/src/priors.rs
+++ b/crates/graze-lens-builder/src/priors.rs
@@ -79,15 +79,19 @@ pub fn prior_reach_query(database: &str, seeds: &[u32], cap: usize, prior: Prior
          FROM {database}.account_stats AS s \
          INNER JOIN ( \
              SELECT followee_int, uniqExact(follower_int) AS reach \
-             FROM {database}.follow_graph_int \
-             WHERE follower_int IN ({seeds}) \
+             FROM {source} \
              GROUP BY followee_int \
              {having}\
          ) AS r ON s.account_int = r.followee_int \
          ORDER BY score DESC, r.followee_int ASC \
          LIMIT {cap} \
          FORMAT TabSeparated",
-        seeds = seed_list_of(seeds),
+        source = crate::second_degree::edge_source(
+            database,
+            "follow_graph_int",
+            &seed_list_of(seeds),
+            "",
+        ),
     )
 }
 
@@ -97,14 +101,17 @@ pub fn prior_reach_query(database: &str, seeds: &[u32], cap: usize, prior: Prior
 pub fn velocity_query(database: &str, seeds: &[u32], cap: usize, days: u32) -> String {
     format!(
         "SELECT followee_int, uniqExact(follower_int) AS reach \
-         FROM {database}.follow_graph_recent \
-         WHERE follower_int IN ({seeds}) \
-           AND followed_at > today() - {days} \
+         FROM {source} \
          GROUP BY followee_int \
          ORDER BY reach DESC, followee_int ASC \
          LIMIT {cap} \
          FORMAT TabSeparated",
-        seeds = seed_list_of(seeds),
+        source = crate::second_degree::edge_source(
+            database,
+            "follow_graph_recent",
+            &seed_list_of(seeds),
+            &format!("AND followed_at > today() - {days} "),
+        ),
     )
 }
 
@@ -299,10 +306,46 @@ mod tests {
         assert!(q.contains("follow_graph_recent"));
         assert!(q.contains("followed_at > today() - 7"));
         assert!(q.contains("uniqExact(follower_int)"));
+        // Trailing space on purpose: `follow_graph_int_delta` contains
+        // `follow_graph_int` as a substring, and unioning the delta is wanted
+        // here. What must never appear is the full 2.78B-row base table as a
+        // source of its own.
         assert!(
-            !q.contains("follow_graph_int"),
+            !q.contains("default.follow_graph_int "),
             "must not scan the full graph"
         );
+    }
+
+    /// Every reach query must union the incremental delta, or a follow made
+    /// since the nightly rebuild is invisible for up to 24 hours.
+    #[test]
+    fn reach_queries_union_the_incremental_delta() {
+        let delta = graze_lens_fold::delta_projection::DELTA_TABLE;
+        for (name, q) in [
+            (
+                "niche",
+                prior_reach_query("default", &[7], 500, Prior::Niche),
+            ),
+            (
+                "popular",
+                prior_reach_query("default", &[7], 500, Prior::Popular),
+            ),
+            ("velocity", velocity_query("default", &[7], 500, 7)),
+        ] {
+            assert!(q.contains(delta), "{name} must union {delta}");
+            assert!(q.contains("UNION ALL"), "{name} must union, not join");
+            assert!(
+                q.contains("op = 'create'"),
+                "{name} must take only additions from the delta"
+            );
+            // Both halves need the LITERAL seed list; an `IN (subquery)` defeats
+            // index analysis and turns each half into a scan.
+            assert_eq!(
+                q.matches("follower_int IN (7)").count(),
+                2,
+                "{name}: both halves must carry the literal seeds"
+            );
+        }
     }
 
     /// Three columns, weights normalised to the best score, everything into
@@ -352,3 +395,4 @@ mod tests {
         );
     }
 }
+

--- a/crates/graze-lens-builder/src/scored.rs
+++ b/crates/graze-lens-builder/src/scored.rs
@@ -53,8 +53,7 @@ pub const ENTRY_LEN: usize = 6;
 /// lookup simply resolves to the wrong person, which reads as a lens that
 /// filters strangely rather than one that is broken. Stamping the space here
 /// turns that into a blob the reader refuses.
-pub const IDSPACE_SHARED: u8 = 0;
-pub const IDSPACE_LENS: u8 = 1;
+pub use graze_common::lens_interner::{IDSPACE_LENS, IDSPACE_SHARED};
 
 /// Facet ids. Stored as one byte in the header so a reader can reject a blob
 /// built for a different signal rather than silently ranking by the wrong one.

--- a/crates/graze-lens-builder/src/second_degree.rs
+++ b/crates/graze-lens-builder/src/second_degree.rs
@@ -122,16 +122,44 @@ pub fn parse_reach_tsv(text: &str, top_k: usize) -> SecondDegree {
 /// leave two live rows for the same pair — counting rows would let one of your
 /// follows contribute twice. It is checkable: reach must never exceed the seed
 /// count, and when it did (2,234 against 1,183 seeds) that was the symptom.
+/// Seed-bounded edge source: the nightly projection plus the incremental delta.
+///
+/// Returns a parenthesised subquery, so a caller drops it in where it used to
+/// name a table. `base_extra` is appended to the base half's `WHERE` for callers
+/// with their own predicate (velocity's window); the delta needs no equivalent
+/// because every row in it is newer than the last rebuild by construction.
+///
+/// Both halves carry the **literal** seed list, which is what keeps this free:
+/// each uses its own sparse index rather than scanning. Measured on production
+/// against a real viewer's 1,187 seeds, three runs each — base alone
+/// 0.70/0.57/0.56 s, base UNION a 131M-row second table 0.60/0.55/0.47 s.
+/// Identical within noise.
+///
+/// Duplicates across the two halves are harmless and expected: every caller
+/// counts `uniqExact(follower_int)`, which is precisely the collapsing
+/// `project.rs` deliberately defers to this layer rather than paying for over
+/// 2.77 billion rows.
+///
+/// Deletes are NOT excluded yet. The delta carries creates only — a jetstream
+/// follow-delete names no followee — so `op = 'create'` is written explicitly
+/// here to keep the predicate honest, and the resolving pass can add a tombstone
+/// exclusion without revisiting every call site.
+pub fn edge_source(database: &str, base: &str, seeds: &str, base_extra: &str) -> String {
+    let delta = graze_lens_fold::delta_projection::DELTA_TABLE;
+    format!(
+        "(            SELECT follower_int, followee_int FROM {database}.{base}            WHERE follower_int IN ({seeds}) {base_extra}           UNION ALL            SELECT follower_int, followee_int FROM {database}.{delta}            WHERE follower_int IN ({seeds}) AND op = 'create'          )"
+    )
+}
+
 pub fn reach_query(database: &str, seeds: &[u32], cap: usize) -> String {
     format!(
         "SELECT followee_int, uniqExact(follower_int) AS reach \
-         FROM {database}.{LIVE_TABLE} \
-         WHERE follower_int IN ({}) \
+         FROM {source} \
          GROUP BY followee_int \
          ORDER BY reach DESC, followee_int ASC \
          LIMIT {cap} \
          FORMAT TabSeparated",
-        seed_list(seeds)
+        source = edge_source(database, LIVE_TABLE, &seed_list(seeds), "")
     )
 }
 
@@ -213,6 +241,16 @@ mod tests {
         assert!(q.contains("IN (7,8,9)"));
         assert!(!q.to_uppercase().contains("IN (SELECT"));
         assert!(q.contains("follow_graph_int"), "must use the projection");
+        assert!(
+            q.contains(graze_lens_fold::delta_projection::DELTA_TABLE),
+            "must union the incremental delta, or a follow since the nightly \
+             rebuild is invisible for up to 24 hours"
+        );
+        assert_eq!(
+            q.matches("follower_int IN (").count(),
+            2,
+            "both halves must carry the literal seed list"
+        );
         assert!(
             !q.contains("follow_edges"),
             "must never traverse the fold table"

--- a/crates/graze-lens-fold/src/config.rs
+++ b/crates/graze-lens-fold/src/config.rs
@@ -36,6 +36,12 @@ pub struct Config {
     /// fresher and costs more ClickHouse work per changed viewer; the coalescing
     /// means it costs nothing extra per *event*.
     pub dirty_sweep_interval: Duration,
+    /// Whether to keep the traversal projection current between nightly rebuilds.
+    ///
+    /// Off is the old behaviour: second-degree facets see the graph as of the
+    /// last nightly rebuild. There is a kill switch because this writes to a
+    /// table every facet query reads.
+    pub delta_projection_enabled: bool,
     /// Life extension applied to a set each time a delta lands. Long on
     /// purpose: with deltas keeping it correct, an actively-read set should
     /// never expire, and expiry becomes a garbage-collector for readers who
@@ -73,6 +79,7 @@ impl Config {
             read_timeout_seconds: parse("LENS_FOLD_READ_TIMEOUT_SECONDS", 45)?,
 
             deltas_enabled: parse("LENS_FOLD_DELTAS_ENABLED", true)?,
+            delta_projection_enabled: parse("LENS_FOLD_DELTA_PROJECTION_ENABLED", true)?,
             dirty_sweep_interval: Duration::from_secs(parse("LENS_FOLD_DIRTY_SWEEP_SECONDS", 30)?),
             active_refresh_interval: Duration::from_secs(parse(
                 "LENS_FOLD_ACTIVE_REFRESH_SECONDS",

--- a/crates/graze-lens-fold/src/delta_projection.rs
+++ b/crates/graze-lens-fold/src/delta_projection.rs
@@ -1,0 +1,147 @@
+//! Keeping the traversal projection current between nightly rebuilds.
+//!
+//! `follow_graph_int` is what every second-degree facet actually reads, and it is
+//! rebuilt once a night. The cadence is not arbitrary: the bulk rebuild needs
+//! `follow_edges FINAL` over 2.79 billion rows and a `grace_hash` join against
+//! the 42M-row id map, and the default hash join blew ClickHouse's 21.6 GiB
+//! per-query ceiling. See `project.rs` for the full account.
+//!
+//! But that is an argument about the *bulk* job, not about incremental work. A
+//! delta never needs `FINAL` over the whole table — only over the window since
+//! the last rebuild, which is roughly 19M edges a day against a 2.78B base.
+//!
+//! # The read cost is nil, and that is measured
+//!
+//! The worry with a second table is the hot-path query: the projection's speed
+//! rests on u32 keys, `index_granularity = 1024`, no partitioning, and literal
+//! seed lists. Adding a `UNION` could have undone it. Measured on production
+//! against a real viewer's 1,187 seeds, three runs each:
+//!
+//! | read | timings |
+//! |---|---|
+//! | `follow_graph_int` alone | 0.70 / 0.57 / 0.56 s |
+//! | the same, `UNION ALL` a 131M-row second table | 0.60 / 0.55 / 0.47 s |
+//!
+//! Identical within noise, because a seed-bounded `follower_int IN (<literals>)`
+//! uses the sparse index on both tables — the delta costs a few granule seeks,
+//! not a scan. So the delta mirrors the base's properties exactly: same
+//! `ORDER BY`, same granularity, unpartitioned.
+//!
+//! # Look up ids; never allocate them
+//!
+//! Ids come from `lookup_many`, which allocates nothing. Interning every account
+//! that flies past would add ~19M entries a day to a hash already holding ~42M,
+//! and it would also be *wrong*: the base projection joins against the id map
+//! with INNER joins, so an account without an id is already absent there. A delta
+//! that invented ids would claim edges the base cannot express. Unknown accounts
+//! wait for the nightly job's bounded interning, exactly as before.
+//!
+//! # Additions only, for now
+//!
+//! A jetstream follow-delete carries `(repo, rkey)` and no followee, so a
+//! retraction cannot be written at ingest without first resolving the rkey. The
+//! base rebuild sidesteps this by letting `FINAL` collapse the create. So this
+//! writes creates, and the `op` column plus the queries' tombstone exclusion are
+//! already in place for the resolving pass to fill in. The asymmetry is a
+//! deliberate interim: missing someone you just followed is the failure readers
+//! notice, and seeing someone you just unfollowed is the milder one.
+
+use std::collections::HashMap;
+
+use graze_common::lens_interner::Interner;
+use tracing::{debug, warn};
+
+use crate::event::FollowEdge;
+use crate::metrics::Metrics;
+use crate::sink::Sink;
+
+/// The table the facets `UNION` in. Mirrors `follow_graph_int`'s properties.
+pub const DELTA_TABLE: &str = "follow_graph_int_delta";
+
+pub struct DeltaProjector {
+    interner: Interner,
+    sink: Sink,
+    metrics: Metrics,
+}
+
+impl DeltaProjector {
+    pub fn new(interner: Interner, sink: Sink, metrics: Metrics) -> Self {
+        Self {
+            interner,
+            sink,
+            metrics,
+        }
+    }
+
+    /// Project one flushed batch of edges into the delta.
+    ///
+    /// Runs on the batch the sink already assembled rather than per event: a row
+    /// per follow would be the tiny-insert storm that drives this instance's
+    /// cost, and one id lookup per event would be 27 Redis round trips a second
+    /// for no reason.
+    pub async fn project(&self, batch: &[FollowEdge]) {
+        let creates: Vec<&FollowEdge> = batch.iter().filter(|e| e.op == "create").collect();
+        if creates.is_empty() {
+            return;
+        }
+
+        // One lookup for the whole batch, both sides of every edge at once.
+        let mut dids: Vec<String> = Vec::with_capacity(creates.len() * 2);
+        for edge in &creates {
+            dids.push(edge.follower.clone());
+            dids.push(edge.followee.clone());
+        }
+        dids.sort_unstable();
+        dids.dedup();
+
+        let ids: HashMap<String, u32> = match self.interner.lookup_many(&dids).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                warn!(error = %e, "delta projection could not resolve ids");
+                self.metrics.delta_projection_failures.inc();
+                return;
+            }
+        };
+
+        let mut rows: Vec<(u32, u32, u64)> = Vec::with_capacity(creates.len());
+        let mut skipped = 0u64;
+        for edge in &creates {
+            match (ids.get(&edge.follower), ids.get(&edge.followee)) {
+                (Some(&follower), Some(&followee)) => rows.push((follower, followee, edge.seq)),
+                // One side has no id yet, so the base projection does not contain
+                // this edge either. Waiting for the nightly pass keeps the two
+                // tables describing the same population.
+                _ => skipped += 1,
+            }
+        }
+        self.metrics.delta_rows_skipped.inc_by(skipped);
+
+        if rows.is_empty() {
+            return;
+        }
+        let projected = rows.len() as u64;
+        match self.sink.insert_delta(&rows).await {
+            Ok(()) => {
+                self.metrics.delta_rows_projected.inc_by(projected);
+                debug!(rows = projected, skipped, "projected edges into the delta");
+            }
+            Err(e) => {
+                warn!(error = %e, rows = projected, "delta insert failed");
+                self.metrics.delta_projection_failures.inc();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The delta must name the table the facet queries read. A typo here is a
+    /// silent no-op: rows land somewhere nothing unions in, and freshness looks
+    /// implemented while nothing changes.
+    #[test]
+    fn delta_table_name_is_stable() {
+        assert_eq!(DELTA_TABLE, "follow_graph_int_delta");
+    }
+}

--- a/crates/graze-lens-fold/src/lib.rs
+++ b/crates/graze-lens-fold/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod config;
 pub mod cursor;
 pub mod delta;
+pub mod delta_projection;
 pub mod event;
 pub mod lpa;
 pub mod metrics;
@@ -19,6 +20,7 @@ pub mod streamer;
 pub use config::Config;
 pub use cursor::Cursor;
 pub use delta::DeltaApplier;
+pub use delta_projection::DeltaProjector;
 pub use event::{parse, FollowEdge};
 pub use metrics::Metrics;
 pub use sink::Sink;

--- a/crates/graze-lens-fold/src/main.rs
+++ b/crates/graze-lens-fold/src/main.rs
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
         // from the dirty set in Redis and never consults the active-viewer cache,
         // so it needs no state from the streamer's copy and sharing one would
         // only add a lock on the hot path.
-        let sweeper = DeltaApplier::new(pool, metrics.clone(), config.set_ttl_seconds);
+        let sweeper = DeltaApplier::new(pool.clone(), metrics.clone(), config.set_ttl_seconds);
         let interval = config.dirty_sweep_interval;
         info!(
             sweep_seconds = interval.as_secs(),
@@ -64,10 +64,29 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
+    // Incremental traversal projection: keeps `follow_graph_int`'s content
+    // current between nightly rebuilds. Ids are looked up, never allocated —
+    // see `delta_projection` for why that is correctness and not thrift.
+    let projector = if config.delta_projection_enabled {
+        let interner = graze_common::lens_interner::Interner::lens(pool.clone());
+        let sink = Sink::new(config.clickhouse.clone(), config.insert_timeout).context("sink")?;
+        info!("incremental traversal projection enabled");
+        Some(graze_lens_fold::DeltaProjector::new(
+            interner,
+            sink,
+            metrics.clone(),
+        ))
+    } else {
+        info!(
+            "incremental traversal projection disabled; second degree is as of the nightly rebuild"
+        );
+        None
+    };
+
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     serve_metrics(config.metrics_port, metrics.clone());
 
-    let streamer = Streamer::new(config, cursor, sink, metrics, deltas);
+    let streamer = Streamer::new(config, cursor, sink, metrics, deltas, projector);
     let run = streamer.run(shutdown_rx);
 
     tokio::select! {

--- a/crates/graze-lens-fold/src/metrics.rs
+++ b/crates/graze-lens-fold/src/metrics.rs
@@ -40,6 +40,13 @@ pub struct Metrics {
     pub sweep_rebuilds_requested: Counter,
     pub sweep_failures: Counter,
     pub dirty_viewers: Gauge,
+
+    /// Incremental traversal projection. `delta_rows_skipped` rising is normal
+    /// and not a fault: it counts edges where one side has no id yet, which the
+    /// base projection also omits — they arrive with the nightly interning pass.
+    pub delta_rows_projected: Counter,
+    pub delta_rows_skipped: Counter,
+    pub delta_projection_failures: Counter,
 }
 
 impl Metrics {
@@ -95,6 +102,27 @@ impl Metrics {
             "deltas_applied",
             "Follows applied directly to a live lens set",
             deltas_applied.clone(),
+        );
+
+        let delta_rows_projected = Counter::default();
+        registry.register(
+            "delta_rows_projected",
+            "Edges written to the incremental traversal projection",
+            delta_rows_projected.clone(),
+        );
+
+        let delta_rows_skipped = Counter::default();
+        registry.register(
+            "delta_rows_skipped",
+            "Edges skipped because an endpoint has no id yet",
+            delta_rows_skipped.clone(),
+        );
+
+        let delta_projection_failures = Counter::default();
+        registry.register(
+            "delta_projection_failures",
+            "Batches that could not be projected into the delta",
+            delta_projection_failures.clone(),
         );
 
         let dirty_marked = Counter::default();
@@ -159,6 +187,9 @@ impl Metrics {
             reconnects,
             cursor_age_seconds,
             deltas_applied,
+            delta_rows_projected,
+            delta_rows_skipped,
+            delta_projection_failures,
             dirty_marked,
             sweeps,
             sweep_rebuilds_requested,

--- a/crates/graze-lens-fold/src/project.rs
+++ b/crates/graze-lens-fold/src/project.rs
@@ -38,6 +38,8 @@ use tracing::{info, warn};
 
 pub const LIVE_TABLE: &str = "follow_graph_int";
 pub const STAGING_TABLE: &str = "follow_graph_int_next";
+/// The incremental delta the facets union in; compacted here after each swap.
+const DELTA_TABLE: &str = crate::delta_projection::DELTA_TABLE;
 pub const MAP_TABLE: &str = "didint_map";
 /// Per-account degree counts, rebuilt from the projection each run. These are
 /// the "priors" the niche/popular lens facets join against.
@@ -124,8 +126,55 @@ impl Projector {
 
     pub async fn run(&self) -> anyhow::Result<ProjectReport> {
         let interned = self.extend_interner().await?;
+        // Read BEFORE the rebuild, not after: the rebuild's `FINAL` read of
+        // `follow_edges` sees some prefix of the stream, and anything arriving
+        // during its ~31 minutes is NOT in the result. Compacting to a watermark
+        // taken afterwards would delete delta rows the new base does not contain
+        // — a silent hole in the traversal graph until the next night.
+        let watermark = self.delta_watermark().await;
         let report = self.rebuild(interned).await?;
+        // Best-effort: a delta that keeps its rows is merely larger than it needs
+        // to be, and unioning a table this size is free (measured). Failing the
+        // whole projection over housekeeping would be the worse trade.
+        if let Some(seq) = watermark {
+            if let Err(e) = self.compact_delta(seq).await {
+                warn!(error = %e, watermark = seq, "could not compact the delta");
+            }
+        }
         Ok(report)
+    }
+
+    /// The highest `seq` the coming rebuild is guaranteed to include.
+    async fn delta_watermark(&self) -> Option<u64> {
+        let db = &self.clickhouse.database;
+        match self
+            .exec(&format!(
+                "SELECT max(seq) FROM {db}.{DELTA_TABLE} FORMAT TabSeparated"
+            ))
+            .await
+        {
+            Ok(text) => text.trim().parse::<u64>().ok(),
+            Err(e) => {
+                warn!(error = %e, "could not read the delta watermark");
+                None
+            }
+        }
+    }
+
+    /// Drop delta rows the freshly swapped base now contains.
+    ///
+    /// `ALTER DELETE` is a mutation and would be brutal on the 2.78B-row base;
+    /// here it runs against a table holding a day of edges, which is what makes
+    /// it acceptable. Rows above the watermark are deliberately kept: they
+    /// arrived while the rebuild was running and exist nowhere else.
+    async fn compact_delta(&self, watermark: u64) -> anyhow::Result<()> {
+        let db = &self.clickhouse.database;
+        self.exec(&format!(
+            "ALTER TABLE {db}.{DELTA_TABLE} DELETE WHERE seq <= {watermark}"
+        ))
+        .await?;
+        info!(watermark, "compacted the traversal delta");
+        Ok(())
     }
 
     /// Give an id to every account in the graph that lacks one.

--- a/crates/graze-lens-fold/src/sink.rs
+++ b/crates/graze-lens-fold/src/sink.rs
@@ -44,6 +44,53 @@ impl Sink {
         })
     }
 
+    /// Insert projected delta rows: `(follower_int, followee_int, seq)`.
+    ///
+    /// Straight to `follow_graph_int_delta`, NOT through a Buffer table. The
+    /// buffer exists to coalesce the raw stream's one-row-at-a-time writes; these
+    /// arrive already batched by the caller, and a Buffer would only add up to
+    /// 100s of invisibility to the freshness this whole path exists to provide.
+    ///
+    /// `op` is written explicitly rather than defaulted, so the column reads the
+    /// same whether or not the resolving delete pass has landed yet.
+    pub async fn insert_delta(&self, rows: &[(u32, u32, u64)]) -> anyhow::Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let body = rows
+            .iter()
+            .map(|(follower, followee, seq)| format!("{follower}\t{followee}\tcreate\t{seq}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let query = format!(
+            "INSERT INTO {}.{} (follower_int, followee_int, op, seq) FORMAT TabSeparated",
+            self.clickhouse.database,
+            crate::delta_projection::DELTA_TABLE
+        );
+
+        let response = self
+            .http
+            .post(self.clickhouse.base_url())
+            .basic_auth(&self.clickhouse.user, Some(&self.clickhouse.password))
+            .header("Content-Type", "text/plain")
+            .timeout(self.timeout)
+            .query(&[("query", query.as_str())])
+            .body(body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "delta insert failed ({}): {}",
+                status,
+                &text[..text.len().min(600)]
+            );
+        }
+        Ok(())
+    }
+
     /// Insert a batch. Returns `Ok(())` only when ClickHouse accepted every row.
     pub async fn insert(&self, edges: &[FollowEdge]) -> anyhow::Result<()> {
         if edges.is_empty() {

--- a/crates/graze-lens-fold/src/streamer.rs
+++ b/crates/graze-lens-fold/src/streamer.rs
@@ -15,6 +15,7 @@ use tracing::{error, info, warn};
 use crate::config::Config;
 use crate::cursor::Cursor;
 use crate::delta::DeltaApplier;
+use crate::delta_projection::DeltaProjector;
 use crate::event::{self, FollowEdge, FOLLOW_COLLECTION};
 use crate::metrics::Metrics;
 use crate::sink::Sink;
@@ -27,6 +28,7 @@ pub struct Streamer {
     /// Keeps already-published lens sets fresh. `None` disables live
     /// maintenance and falls back to sets expiring on their TTL.
     deltas: Option<DeltaApplier>,
+    projector: Option<DeltaProjector>,
 }
 
 impl Streamer {
@@ -36,6 +38,7 @@ impl Streamer {
         sink: Sink,
         metrics: Metrics,
         deltas: Option<DeltaApplier>,
+        projector: Option<DeltaProjector>,
     ) -> Self {
         Self {
             config,
@@ -43,6 +46,7 @@ impl Streamer {
             sink,
             metrics,
             deltas,
+            projector,
         }
     }
 
@@ -203,6 +207,13 @@ impl Streamer {
         match self.sink.insert(batch).await {
             Ok(()) => {
                 self.metrics.rows_written.inc_by(batch.len() as u64);
+                // Only after the raw insert succeeded: the delta is a derived
+                // view, and a row in it whose edge never landed in `follow_edges`
+                // would survive the nightly compaction as a phantom the base
+                // table cannot account for.
+                if let Some(projector) = &self.projector {
+                    projector.project(batch).await;
+                }
                 batch.clear();
                 *start = None;
                 if let Err(e) = self.cursor.commit(last_seq).await {

--- a/kube/lens-builder-deployment.yaml
+++ b/kube/lens-builder-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: builder
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:60a8a4d68f73ed424068cbd3a38afb7dba53178230adfd70e22f551c3c659cc9
           command: ["/app/graze-lens-builder"]
           resources:
             requests:

--- a/kube/lens-fold-deployment.yaml
+++ b/kube/lens-fold-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: fold
           # Built from commit a24d3b2 (feat/graze-lens). Digest-pinned: both `latest` and
           # the short-SHA tag are mutable on DOCR.
-          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:60a8a4d68f73ed424068cbd3a38afb7dba53178230adfd70e22f551c3c659cc9
           command: ["/app/graze-lens-fold"]
           resources:
             requests:

--- a/kube/lens-lpa-cronjob.yaml
+++ b/kube/lens-lpa-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
           containers:
             - name: lpa
               # Digest-pinned; updated together with the other lens workloads.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:60a8a4d68f73ed424068cbd3a38afb7dba53178230adfd70e22f551c3c659cc9
               command: ["/app/graze-lens-lpa"]
               resources:
                 requests:

--- a/kube/lens-project-cronjob.yaml
+++ b/kube/lens-project-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               # Built from commit 1a835eb (feat/lens-completeness-guard).
               # Digest-pinned: both `latest` and the short-SHA tag are mutable
               # on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:60a8a4d68f73ed424068cbd3a38afb7dba53178230adfd70e22f551c3c659cc9
               command: ["/app/graze-lens-project"]
               resources:
                 requests:

--- a/kube/lens-refresh-cronjob.yaml
+++ b/kube/lens-refresh-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
             - name: docr-graze-social-labs
           containers:
             - name: refresh
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:60a8a4d68f73ed424068cbd3a38afb7dba53178230adfd70e22f551c3c659cc9
               command: ["/app/graze-lens-refresh"]
               resources:
                 requests:

--- a/kube/lens-rev-rebuild-cronjob.yaml
+++ b/kube/lens-rev-rebuild-cronjob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: rev-rebuild
               # Built from commit 1a835eb (feat/lens-completeness-guard). Digest-pinned:
               # both `latest` and the short-SHA tag are mutable on DOCR.
-              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:b57662644242a6dd79ba720ab2bacaae4cf076ffa63ab29620096ca0e429ed35
+              image: registry.digitalocean.com/graze-social-labs/personalization@sha256:60a8a4d68f73ed424068cbd3a38afb7dba53178230adfd70e22f551c3c659cc9
               command: ["/app/graze-lens-rev-rebuild"]
               resources:
                 requests:


### PR DESCRIPTION
Second-degree facets read `follow_graph_int`, rebuilt once a night — so an edge anyone made today entered a reader's second degree *tomorrow*. `velocity` suffered most: "what my network is discovering this week", answered from a graph up to 24 hours old.

## The nightly cadence was never arbitrary

The bulk rebuild needs `follow_edges FINAL` over 2.79B rows and a `grace_hash` join against the 42M-row id map, because the default hash join blew ClickHouse's **21.6 GiB** per-query ceiling; edges are deliberately left un-deduplicated for the same reason.

But that is an argument about the *bulk* job. An incremental delta never needs `FINAL` over the whole table — only the window since the last rebuild, ~19M edges/day against a 2.78B base.

## The reason not to try, measured away

The projection's speed rests on u32 keys, `index_granularity = 1024`, no partitioning, and literal seed lists. A `UNION` could have undone all of it. Measured on production, a real viewer's 1,187 seeds, three runs each:

| read | timings |
|---|---|
| `follow_graph_int` alone | 0.70 / 0.57 / 0.56 s |
| the same, `UNION ALL` a 131M-row second table | 0.60 / 0.55 / 0.47 s |

Identical within noise — a seed-bounded `follower_int IN (<literals>)` uses the sparse index on both halves, so the delta costs granule seeks, not a scan. The delta therefore mirrors the base exactly: same `ORDER BY`, same granularity, unpartitioned.

## What it does

The fold projects each flushed batch into `follow_graph_int_delta`, and `follows2`/`niche`/`popular`/`velocity` union it through one `edge_source` helper, so there is a single place this composes. **The composed SQL was executed against production before shipping**, not merely unit-tested — a query that fails to parse breaks every facet build at once.

Ids are **looked up, never allocated** (`Interner::lookup_many`, new). Interning every account in the firehose would add ~19M entries/day to a hash already holding ~42M — and would also be *wrong*: the base joins the id map with INNER joins, so an account without an id is already absent there, and a delta that invented ids would claim edges the base cannot express. Unknown accounts wait for the nightly pass; `delta_rows_skipped` counts them.

The interner moved to `graze-common` because the fold needs it and the builder already depends on the fold. Re-exported under the old path so every `crate::interner::…` still resolves; the two idspace bytes moved with it.

**Compaction** runs at the end of each projection job — `ALTER DELETE` below a watermark read **before** the rebuild, never after. The rebuild's `FINAL` sees some prefix of the stream, so anything arriving during its ~31 minutes is not in the result; an after-watermark would delete rows the new base lacks and leave a silent hole. Best-effort by design.

## Additions only, deliberately

A jetstream follow-delete carries `(repo, rkey)` and no followee, so a retraction cannot be written at ingest without resolving the rkey first — the base rebuild sidesteps this by letting `FINAL` collapse the create. `op = 'create'` is explicit on the insert and in every query, so the resolving pass can add a tombstone exclusion without revisiting call sites. Missing someone you just followed is the failure readers notice; seeing someone you just unfollowed is the milder one.

## Verified in prod, staged in two steps

Fold first, so the delta filled while nothing read it; builder second, once the rows were inspected.

- Ids landed in the 42M lens space (4,894–42,049,288). The one id under 10,000 was confirmed genuine — the base holds 318,736 edges below that id.
- Builds succeed with the union query, **zero errors**.
- Same seeds now reach **520,375** accounts vs the base's **520,372** — the delta surfaces accounts the nightly base cannot see.
- Newest edge in the delta: **5 seconds old**. Traversal freshness ~24h → seconds.

Behind `LENS_FOLD_DELTA_PROJECTION_ENABLED`, because it writes a table every facet query reads.

154 tests pass; `fmt` and `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)