### PR TITLE
Gate verdicts on UNITS as well as observations

### DIFF
--- a/analysis/experiments/follow_seed.yaml
+++ b/analysis/experiments/follow_seed.yaml
@@ -93,6 +93,21 @@ population: >
 
 min_observations: 2000
 
+# Units floor, declared separately because min_observations counts IMPRESSIONS while the estimand
+# is per-USER, and on this population the two diverge badly. Measured 2026-09-02: this spec cleared
+# its 2000-observation floor with obs=2037 drawn from only **239 users** -- ~8.5 impressions per
+# unit, against the holdout's 30 -- and a verdict was formed and read. The obs floor had never been
+# a units guard.
+#
+# ⚠️ 500 is a floor against estimates that are simply WRONG, not a power guarantee, and it does NOT
+# rescue this experiment. The eligible population's per-unit like rate is ~0.015% (the holdout
+# population's is ~1.13%, i.e. ~75x higher) because eligibility IS "no like seed" -- we select for
+# users who do not like things and then measure their like rate. The 2026-09-02 interval was ~13x
+# its own base rate, so separating from zero would need a >1000% effect. That is a choice-of-metric
+# problem. It is recorded here rather than hidden behind the gate, and it is the open question on
+# this spec: see the ledger, and do NOT resolve it with a sixth window reset.
+min_units: 500
+
 notes: >
   Expect this to accrue faster than the holdout: enrolment is 100% of non-holdout users by default
   rather than 20%, and both arms are the same size.

--- a/analysis/graze_analysis/runner.py
+++ b/analysis/graze_analysis/runner.py
@@ -62,7 +62,7 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
     )
 
     # --- Gate 1: enough data to form any verdict at all ---
-    thin, thin_msg = insufficient_data_gate(primary, spec.min_observations)
+    thin, thin_msg = insufficient_data_gate(primary, spec.min_observations, spec.min_units)
     if thin:
         return Readout(spec.id, "WITHHELD (insufficient data)", [thin_msg])
 

--- a/analysis/graze_analysis/spec.py
+++ b/analysis/graze_analysis/spec.py
@@ -128,6 +128,19 @@ class ExperimentSpec:
     population: str | None = None
     #: Minimum competitive pairs / observations before any verdict is reported.
     min_observations: int = 200
+    #: Minimum UNITS of randomization before any verdict is reported.
+    #:
+    #: Separate from `min_observations` because every estimand here is per-UNIT while that floor
+    #: counts impressions, and the two diverge wildly. Measured 2026-09-02: follow_seed formed a
+    #: verdict on obs=2037 (over its 2000 floor) drawn from just **239 users** — roughly 8.5
+    #: impressions per unit against the holdout's 30. An impression floor is not a unit floor.
+    #:
+    #: This is a floor against estimates that are simply WRONG, exactly as `min_observations` is
+    #: (see `insufficient_data_gate`), and explicitly NOT a power guarantee. No units floor could
+    #: have rescued that readout: the eligible population's per-unit like rate is ~0.015%, so the
+    #: interval is ~13x the base rate and separating from zero would need a >1000% effect. That is
+    #: a metric problem, not a sample-size problem, and it is not this gate's job to hide it.
+    min_units: int = 500
     notes: str = ""
 
     def assert_not_post_treatment(self, *fields: str) -> None:
@@ -243,6 +256,7 @@ def spec_from_dict(raw: dict[str, Any], source: str = "<dict>") -> ExperimentSpe
             raw.get("post_treatment_fields", DEFAULT_POST_TREATMENT_FIELDS)
         ),
         min_observations=int(raw.get("min_observations", 200)),
+        min_units=int(raw.get("min_units", 500)),
         notes=str(raw.get("notes", "")),
     )
 

--- a/analysis/graze_analysis/stats.py
+++ b/analysis/graze_analysis/stats.py
@@ -428,13 +428,26 @@ def covariate_balance(
     return observed, hits / resamples
 
 
-def insufficient_data_gate(estimate: Estimate, min_observations: int) -> tuple[bool, str]:
-    """Refuse to report a verdict below a minimum sample size.
+def insufficient_data_gate(
+    estimate: Estimate, min_observations: int, min_units: int = 0
+) -> tuple[bool, str]:
+    """Refuse to report a verdict below a minimum sample size, in BOTH denominations.
 
     Significance testing alone is not enough protection. The motivating incident was a 37-response
     sample reading ``no_user_data`` at 14% when the value at 706 responses was 49.3% — the small
     sample was not *significant*, it was simply **wrong**, and it was believed because it was
     looked at. A hard floor stops a verdict being formed from a sample that cannot support one.
+
+    Units are checked as well as observations because every estimand in this package is per-UNIT
+    while ``min_observations`` counts impressions. Measured 2026-09-02: follow_seed cleared its
+    2000-observation floor with obs=2037 and formed a verdict from **239 users**, ~8.5 impressions
+    per unit against the holdout's 30. The obs floor had never been a units guard, and nothing
+    said so.
+
+    Neither floor is a power guarantee, and this gate must not be mistaken for one. The same
+    readout's interval was ~13x its own base rate (per-unit like rate ~0.015%), which no sample
+    size available here would fix — that is a choice-of-metric problem and it belongs in the open,
+    not behind a gate.
     """
     if estimate.n_obs < min_observations:
         return True, (
@@ -442,7 +455,17 @@ def insufficient_data_gate(estimate: Estimate, min_observations: int) -> tuple[b
             "Small samples do not merely widen intervals, they produce point estimates that are "
             "simply wrong; no verdict is formed at this size."
         )
-    return False, f"{estimate.n_obs} observations meets the {min_observations} minimum"
+    if estimate.n_units < min_units:
+        return True, (
+            f"WITHHELD: {estimate.n_units} units is below the {min_units} minimum "
+            f"(observations were fine at {estimate.n_obs}). The estimand is per-unit, so units "
+            "are what the interval rests on; a few heavy users clearing an impression floor is "
+            "not evidence."
+        )
+    return False, (
+        f"{estimate.n_obs} observations / {estimate.n_units} units meets the "
+        f"{min_observations} / {min_units} minimums"
+    )
 
 
 @dataclass(frozen=True)

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:457de73c066e6cea9141c32c1611750350bc54773657ba71e1fe2014cd47c72a
+              image: dgaff/graze-analysis@sha256:8bbe3d69be10efe6e3e8c253b1b49817a96575ee65ce70c1133ed5f4796fc132
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job

--- a/analysis/kube/coverage-cronjob.yaml
+++ b/analysis/kube/coverage-cronjob.yaml
@@ -210,7 +210,7 @@ spec:
                 name: personalization-coverage-src
           containers:
             - name: coverage
-              image: dgaff/graze-analysis@sha256:457de73c066e6cea9141c32c1611750350bc54773657ba71e1fe2014cd47c72a
+              image: dgaff/graze-analysis@sha256:8bbe3d69be10efe6e3e8c253b1b49817a96575ee65ce70c1133ed5f4796fc132
               command: ["python", "/src/coverage.py"]
               volumeMounts:
                 - name: src

--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -145,7 +145,7 @@ spec:
                 name: personalization-dose-check-src
           containers:
             - name: dose
-              image: dgaff/graze-analysis@sha256:457de73c066e6cea9141c32c1611750350bc54773657ba71e1fe2014cd47c72a
+              image: dgaff/graze-analysis@sha256:8bbe3d69be10efe6e3e8c253b1b49817a96575ee65ce70c1133ed5f4796fc132
               command: ["python", "/src/dose.py"]
               volumeMounts:
                 - name: src

--- a/analysis/tests/test_runner_gates.py
+++ b/analysis/tests/test_runner_gates.py
@@ -26,6 +26,10 @@ def _spec(**over):
             {"name": "fallback", "reason": "no causal path", "where": "source = 'fallback'"}
         ],
         "min_observations": 200,
+        # Lowered for the same reason min_observations is: these fixtures are ~300 units and exist
+        # to exercise negative controls, guardrails and ordering, not the sample floors. The
+        # floors themselves are tested explicitly further down.
+        "min_units": 100,
     }
     body.update(over)
     return spec_from_dict(body)
@@ -562,3 +566,72 @@ def test_the_secondary_gate_never_moves_the_top_line_verdict():
     primary_at = next(i for i, l in enumerate(readout.lines) if "primary" in l)
     scroll_at = next(i for i, l in enumerate(readout.lines) if "scroll_depth" in l)
     assert scroll_at > primary_at
+
+
+# --- The sample floors, in both denominations -------------------------------------------------
+#
+# `min_observations` counts IMPRESSIONS while every estimand here is per-UNIT, and the two diverge
+# wildly. Measured 2026-09-02: follow_seed cleared its 2000-observation floor with obs=2037 drawn
+# from 239 users -- ~8.5 impressions per unit against the holdout's 30 -- and formed a verdict. The
+# obs floor had never been a units guard and nothing said so.
+
+
+def test_a_verdict_is_withheld_when_units_are_thin_even_if_observations_are_not():
+    """The 2026-09-02 shape: impression floor cleared, unit count nowhere near enough."""
+    # 60 users carrying 40 impressions each: obs=2400 clears a 2000 floor, units=60 does not.
+    primary = _uneven("c", 30, 1, 40, 10000) + _uneven("t", 30, 3, 40, 250)
+    readout = analyse_ab(
+        _spec(min_observations=2000, min_units=500), FakeReader(primary, _null_control())
+    )
+    assert "WITHHELD" in readout.verdict, readout.render()
+    joined = "\n".join(readout.lines)
+    assert "60 units is below the 500 minimum" in joined, joined
+    # It must say the obs floor was NOT the problem, or the reader will chase the wrong number.
+    assert "observations were fine at 2400" in joined, joined
+    # And no effect size is printed at all.
+    assert not any("GATE" in line for line in readout.lines)
+
+
+def test_the_observations_floor_still_reports_first_when_both_fail():
+    primary = _uneven("c", 5, 1, 4, 10000) + _uneven("t", 5, 2, 4, 250)
+    readout = analyse_ab(
+        _spec(min_observations=2000, min_units=500), FakeReader(primary, _null_control())
+    )
+    joined = "\n".join(readout.lines)
+    assert "observations is below" in joined, joined
+    assert "units is below" not in joined, joined
+
+
+def test_the_units_floor_defaults_to_500_when_a_spec_is_silent():
+    """A spec that never heard of the floor still gets it. follow_seed's 239 would not pass."""
+    from graze_analysis.spec import spec_from_dict
+
+    body = {
+        "id": "silent",
+        "design": "ab",
+        "start": "2026-08-12T09:11:56Z",
+        "unit": "user",
+        "primary_metric": "like_rate",
+        "arms": {
+            "control": {"field": "params.max_total_sources", "value": 10000},
+            "treatment": {"field": "params.max_total_sources", "value": 250},
+        },
+        # Mandatory, and rightly so -- it caught both false positives in this system's history.
+        "negative_controls": [
+            {"name": "fallback", "reason": "no causal path", "where": "source = 'fallback'"}
+        ],
+    }
+    assert spec_from_dict(body).min_units == 500
+
+
+def test_both_floors_are_named_when_they_pass():
+    from graze_analysis.stats import Estimate, insufficient_data_gate
+
+    est = Estimate(
+        diff=0.01, rel=0.1, se=0.001, ci_low=0.0, ci_high=0.02, p_value=0.04,
+        method="test", n_units=2658, n_obs=79473,
+    )
+    thin, msg = insufficient_data_gate(est, 2000, 500)
+    assert not thin
+    assert "79473 observations / 2658 units" in msg, msg
+    assert "2000 / 500 minimums" in msg, msg


### PR DESCRIPTION
## The defect

`follow_seed` formed a verdict last night on `obs=2037` — clearing its 2,000-observation floor — drawn from **239 users**. Every estimand in this package is per-unit, so units are what the interval rests on. The observations floor had never been a units guard, and nothing in the code or the spec said so.

`insufficient_data_gate` now takes `min_units` and names *which* floor failed, so a reader isn't sent chasing the number that was fine:

```
WITHHELD: 264 units is below the 500 minimum (observations were fine at 2359). The estimand is
per-unit, so units are what the interval rests on; a few heavy users clearing an impression
floor is not evidence.
```

Default 500, so a spec that never heard of the floor still gets it; declared explicitly in `follow_seed.yaml`, because pre-registering a floor is worth more than inheriting one.

## ⚠️ This does not rescue follow_seed, and must not be read as doing so

Measured across the whole window, on both populations:

| metric | follow_seed (eligible) | holdout (all users) |
|---|---|---|
| units / impressions | 264 / 2,359 | 2,735 / 84,419 |
| **likes** | **1 event, from 1 user** | 2,844 events, 267 users |
| like base rate | 0.00013 | 0.01130 |
| gate width ÷ base rate | **14.3×** | **1.5× — usable** |
| requestLess | **0 events** | 49 events |
| requestMore | **0 events** | 7 events |

**The verdict of `diff=-0.0003 (-94.6%)` was one like.**

So no instrumented engagement metric can adjudicate this arm. That is not a floor problem, and it is not a "pick a better primary" problem either — there is no better primary in what we collect. Eligibility *is* "no like seed", so we select for users who do not engage and then measure engagement.

The floor stops us reporting a number built on a single event. It does **not** make the experiment answerable. That distinction is written into the gate's docstring and into the spec, so the next reader doesn't mistake a `WITHHELD` for "needs more time" — more time will not fix a 14.3× interval.

## What that leaves for the metric decision (not made here)

Deliberately left open, since it changes what the experiment measures:

1. **Accept coverage/dose as the decision quantity.** It is the one thing that *is* measured and is emphatic (`−90.34pp` `no_user_data`, `+56.84pp` personalized).
2. **Use an outcome whose denominator every unit has by construction** — impressions/user, i.e. the existing winsorized `scroll_depth`, which is the only outcome here that scales with units rather than with rare events.
3. Treat follow-seeding as justified on coverage grounds as a product decision rather than an engagement one.

What is *not* on the list: a sixth window reset. The window was never the problem.

## Verification

97 tests (4 new, covering the units-thin case, obs-floor precedence, the default, and the pass message). Validated against live ClickHouse via a `subPath` overlay including the edited spec — `follow_seed` correctly returns to `WITHHELD` at 264 units.

Image `sha256:8bbe3d69be10efe6e3e8c253b1b49817a96575ee65ce70c1133ed5f4796fc132` (`units-floor-20260902`). Rollback `sha256:457de73c066e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)