### PR TITLE
Label the empty-co-liker exit so absent fallback_reason means personalized

### DIFF
--- a/analysis/kube/coverage-cronjob.yaml
+++ b/analysis/kube/coverage-cronjob.yaml
@@ -2,6 +2,9 @@
 #
 # Exists because `fallback_reason` was only ever a log line until 2026-08-26, so the question "why
 # is this user not being personalized" could only be answered by scraping a few hours of pod logs.
+# The field arrived covering only some causes: the engine's pre-scoring bail-outs went on writing
+# nothing until 2026-09-01 (`pool_size`, `pool_density`) and 2026-09-02 (`no_colikers`), so the
+# UNLABELLED bucket below mixes builds from before each of those, not just from before 2026-08-26.
 # A 6-hour scrape put `no_user_data` at 73% of non-personalized responses; this repo has been burned
 # more than once by single-window traffic mix (the density histogram predicted a 53% skip rate and
 # measured 45%, and the dominant low-density feed changed identity between windows), so the figure
@@ -84,10 +87,23 @@ data:
     UNLABELLED = 'UNLABELLED (pre-instrumentation)'
     unlabelled = sum(r[1] for r in rows if r[0] == UNLABELLED)
     if unlabelled:
+        # Two populations, not one, which is why this bucket shrinks faster than feed-age decay
+        # alone would predict:
+        #   1. builds predating fallback_reason entirely (2026-08-26), echoed back by clients
+        #      scrolling feeds served before it -- decays with FEED age, not wall clock, so this
+        #      part is not expected to reach zero;
+        #   2. builds after that date but before the pre-scoring bail-outs were labelled, which
+        #      wrote no reason whenever the pool-size or like-density gate fired (both labelled
+        #      2026-09-01) or the co-liker walk came back empty (`no_colikers`, 2026-09-02).
+        # (2) stops being produced the moment those builds are rolled, so a drop here after such a
+        # deploy is instrumentation catching up, NOT coverage improving -- and the causes it was
+        # hiding appear as new named buckets above, which is where to look for the difference.
         print(f"\n  !! {unlabelled:,} impressions ({unlabelled/total*100:.1f}%) are UNLABELLED --")
-        print("     served by a build predating fallback_reason (2026-08-26), echoed back by clients")
-        print("     scrolling feeds served before it. This tail decays with FEED age, not wall clock,")
-        print("     so it is not expected to reach zero.")
+        print("     served either by a build predating fallback_reason (2026-08-26) or by one")
+        print("     predating the pre-scoring labels (pool_size/pool_density 2026-09-01,")
+        print("     no_colikers 2026-09-02), echoed back by clients scrolling feeds served then.")
+        print("     The first part decays with FEED age, not wall clock, so it is not expected to")
+        print("     reach zero; the second stops being produced once those builds are rolled.")
         print("     => The impression-share column ABOVE is diluted by it: read it as a lower bound.")
         print("     => The addressable composition and hourly check BELOW divide within the failure")
         print("        set, so they are NOT affected. Those are the numbers to quote.")

--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -717,7 +717,26 @@ impl LinkLonkAlgorithm {
                 use_author_affinity = params.use_author_affinity,
                 "early_exit: no coliker weights found"
             );
-            return Ok(ScoringResult::default());
+            // The last unlabelled early exit in this function, and so the one that stopped
+            // "no fallback_reason implies personalized" from being true. Everything above this
+            // point either returned a labelled skip or produced weights; reaching here means the
+            // walk ran and the graph gave back nothing.
+            //
+            // NOT `no_user_data`, deliberately. The feed handler already turned away every user
+            // without seed before `compute_personalization` was called, so anyone arriving here
+            // was admitted on seed the handler could see: like seed in the retention window, or
+            // follows when the follow-seed read is on. The seed exists and the graph around it is
+            // empty -- a connectivity failure, addressable by the co-liker parameters and the
+            // durable/follow seed work, whereas `no_user_data` is addressable only by getting the
+            // user to like something. Collapsing the two would hide which lever applies.
+            //
+            // Reached both from an empty co-liker walk (`coliker.rs`, "no co-likers found for any
+            // liked posts") and from the durable-profile and follow-seed hooks above declining to
+            // produce weights. Measured on the fleet 2026-09-02, 12h across 3 pods: 3 occurrences.
+            return Ok(ScoringResult {
+                skip_reason: Some("no_colikers"),
+                ..Default::default()
+            });
         }
 
         // Step 2: Score posts using co-liker weights

--- a/crates/graze-api/src/algorithm/scorer.rs
+++ b/crates/graze-api/src/algorithm/scorer.rs
@@ -91,9 +91,16 @@ pub struct ScoringResult {
     /// Why scoring was skipped entirely before it ran, when it was.
     ///
     /// `pool_density` (the feed's like-density gate fired) | `pool_size` (the feed's candidate
-    /// pool is below the personalization gate). `None` whenever scoring actually ran, including
-    /// when it ran and produced nothing — "we refused to look" and "we looked and found nothing"
-    /// are different coverage failures and the whole point of this field is to keep them apart.
+    /// pool is below the personalization gate) | `no_colikers` (the co-liker walk, including the
+    /// durable-profile and follow-seed hooks, produced no weights to score from). `None` whenever
+    /// scoring actually ran, including when it ran and produced nothing — "we refused to look" and
+    /// "we looked and found nothing" are different coverage failures and the whole point of this
+    /// field is to keep them apart.
+    ///
+    /// The first two are feed-level config gates; `no_colikers` is not, and is kept separate from
+    /// `no_user_data` for the same reason. A user reaching that exit had seed — the feed handler
+    /// refuses everyone else before this function is called — so the failure is in the graph
+    /// around the seed, not in the seed's absence. Different lever, therefore different label.
     ///
     /// `&'static str` rather than `String` because every value is a compile-time constant, and
     /// because the consumer in `api::feed` needs a `'static` reason it can hold past the response

--- a/crates/graze-api/src/api/feed.rs
+++ b/crates/graze-api/src/api/feed.rs
@@ -123,10 +123,16 @@ fn graze_api_hash_experiment(config: &crate::config::Config) -> crate::algorithm
     }
 }
 
-/// Map a pre-scoring skip reported by the engine onto a provenance `fallback_reason`.
+/// Map a skip reported by the engine — a bail-out before any scoring ran — onto a provenance
+/// `fallback_reason`.
 ///
 /// Returns a `'static` reason so the caller can hold it in `fallback_reason` past the response it
 /// was read from — the reason is a compile-time constant on both sides, only the wire type differs.
+///
+/// Two of these are config gates (`pool_size`, `pool_density`) and one is not: `no_colikers` is the
+/// engine finding an empty graph around a seed that does exist. They share this channel because
+/// they share the symptom it was built for — an empty `ScoringResult` that the handler cannot tell
+/// apart from "scored and found nothing" — not because they have the same fix.
 ///
 /// A value this build does not recognise maps to `None` rather than being passed through:
 /// `fallback_reason` is a closed set that ClickHouse readouts group by, and an unknown category is
@@ -135,6 +141,7 @@ fn skip_reason_to_fallback_reason(skip: Option<&str>) -> Option<&'static str> {
     match skip {
         Some("pool_density") => Some("pool_density"),
         Some("pool_size") => Some("pool_size"),
+        Some("no_colikers") => Some("no_colikers"),
         _ => None,
     }
 }
@@ -1224,9 +1231,9 @@ pub async fn get_feed_skeleton(
                             .collect();
                         was_personalized = !base_posts_tagged.is_empty();
 
-                        // A pre-scoring gate returns Ok with nothing scored, so this response is
-                        // fallback — and until the engine reported *why*, it was fallback with no
-                        // reason recorded at all, which is the one case `fallback_reason` could not
+                        // A skip returns Ok with nothing scored, so this response is fallback —
+                        // and until the engine reported *why*, it was fallback with no reason
+                        // recorded at all, which is the one case `fallback_reason` could not
                         // decompose. Only fills a slot nothing else has claimed, so a reason set
                         // earlier on this path (holdout, exhausted) still wins.
                         if fallback_reason.is_none() {
@@ -1765,7 +1772,7 @@ mod tests {
     /// here shows up as an obviously-unfinished change rather than as a silently unlabelled row.
     #[test]
     fn every_engine_skip_reason_maps_to_a_fallback_reason() {
-        for reason in ["pool_density", "pool_size"] {
+        for reason in ["pool_density", "pool_size", "no_colikers"] {
             assert_eq!(
                 skip_reason_to_fallback_reason(Some(reason)),
                 Some(reason),

--- a/crates/graze-common/src/models/feed_context.rs
+++ b/crates/graze-common/src/models/feed_context.rs
@@ -91,15 +91,21 @@ pub struct FeedContextProvenance {
     /// `no_algo_posts` (the feed's candidate pool is empty) | `personalization_holdout` |
     /// `personalization_error` | `pool_density` (the feed's candidate pool carries too little like
     /// signal to rank — `MIN_POOL_SCOREABLE_SHARE`) | `pool_size` (the feed's candidate pool is
-    /// below `MIN_CANDIDATE_POOL_FOR_PERSONALIZATION`). `None` when the response *was*
-    /// personalized.
+    /// below `MIN_CANDIDATE_POOL_FOR_PERSONALIZATION`) | `no_colikers` (the user had seed but the
+    /// co-liker walk derived no weights from it). `None` when the response *was* personalized.
     ///
-    /// The last two are the gates the engine applies *before* scoring, and they were added later
-    /// than the rest: both returned an empty result indistinguishable from "scored and found
-    /// nothing", so a gated response was served as fallback carrying no reason at all. Verified on
+    /// The last three are bail-outs the engine takes *before* scoring, and they were added later
+    /// than the rest: each returned an empty result indistinguishable from "scored and found
+    /// nothing", so the response was served as fallback carrying no reason at all. Verified on
     /// feed 6445 on 2026-09-01: 22 of the 24 items served at 18:00Z had `source=fallback` and no
-    /// `fallback_reason`. Rows written before that fix carry no reason for these two causes, so a
-    /// readout spanning the deploy must not read absence as "personalized".
+    /// `fallback_reason`. Rows written before those fixes carry no reason for these three causes,
+    /// so a readout spanning either deploy must not read absence as "personalized".
+    ///
+    /// `no_colikers` is deliberately not merged into `no_user_data`. Every user who reaches it was
+    /// admitted by the handler's seed check, so their seed exists and it is the graph around it
+    /// that is empty — a connectivity failure the co-liker parameters and the durable/follow seed
+    /// work address, as against a seed-availability failure only the user can fix. Low volume:
+    /// measured on the fleet 2026-09-02, 3 occurrences in 12h across 3 pods.
     ///
     /// Exists because this reason was previously only ever written to a log line, so coverage
     /// failures could not be decomposed in ClickHouse and every experiment silently mixed users

--- a/crates/graze-common/src/models/responses.rs
+++ b/crates/graze-common/src/models/responses.rs
@@ -94,15 +94,19 @@ pub struct ResponseMeta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scoring_time_ms: Option<f64>,
 
-    /// Why scoring was skipped entirely before it ran: `pool_density` | `pool_size`. Absent when
-    /// scoring ran, including when it ran and returned nothing.
+    /// Why scoring was skipped entirely before it ran: `pool_density` | `pool_size` |
+    /// `no_colikers`. Absent when scoring ran, including when it ran and returned nothing.
     ///
-    /// Exists so `api::feed` can turn a pre-scoring gate into a `fallback_reason` on the
-    /// provenance blob. Before this, both gates returned an empty `ScoringResult` that was
-    /// indistinguishable from "scored and found nothing", so the response was served as fallback
-    /// with no reason recorded at all and the coverage failure could not be decomposed in
-    /// ClickHouse. Verified on feed 6445 on 2026-09-01: 22 of 24 items carried `source=fallback`
-    /// with no `fallback_reason`.
+    /// Exists so `api::feed` can turn a bail-out that happened before scoring into a
+    /// `fallback_reason` on the provenance blob. Before this, each of them returned an empty
+    /// `ScoringResult` that was indistinguishable from "scored and found nothing", so the response
+    /// was served as fallback with no reason recorded at all and the coverage failure could not be
+    /// decomposed in ClickHouse. Verified on feed 6445 on 2026-09-01: 22 of 24 items carried
+    /// `source=fallback` with no `fallback_reason`.
+    ///
+    /// `pool_density` and `pool_size` are feed-level config gates. `no_colikers` is not: it is the
+    /// co-liker walk returning nothing for a user who did have seed, which is why it is a separate
+    /// value from `no_user_data` rather than folded into it.
     ///
     /// `Option<String>` rather than `&'static str` because this crosses the wire on
     /// `/v1/personalize`; the reasons themselves are constants on `ScoringResult::skip_reason`.


### PR DESCRIPTION
`compute_personalization` returns `ScoringResult::default()` when the co-liker walk produces no weights (reached after the durable-profile and follow-seed hooks also decline to produce any). The feed handler cannot tell that apart from "scored and found nothing", so the response was served as fallback with **no `fallback_reason` at all** — the same defect #61 fixed for the two pre-scoring config gates, in the one named early exit that PR did not reach.

Measured on the fleet 2026-09-02, 12h of logs across 3 pods: 3 occurrences of `early_exit: no coliker weights found` and 3 of `early_exit: no co-likers found for any liked posts` (`coliker.rs`, which returns empty weights and flows into the same exit). Low volume, but it was the last unlabelled early exit in the personalization path, and so the only thing standing between the enum and the property it exists for: **absence of `fallback_reason` implying personalized.**

## Not `no_user_data`

Deliberately a separate value. The feed handler gates on `has_like_seed || (follow_seed_eligible && allow_follow_seed)` before `compute_personalization` is called at all, so the two are **disjoint by construction** — anyone reaching this exit was admitted on seed the handler could see. The seed exists and the graph around it is empty.

That is a connectivity failure, addressable by the co-liker parameters and the durable/follow seed work. `no_user_data` is a seed-availability failure, addressable only by the user liking something. Collapsing them would hide which lever applies — the same ambiguity the field was added to remove.

(The follow-admitted case does land here: no likes, follows present, follow-seed hook returned nothing. Documented explicitly rather than describing the bucket as purely "has likes".)

## What changed

- `skip_reason: Some("no_colikers")` at the exit in `algorithm/mod.rs`.
- The arm in `skip_reason_to_fallback_reason` and its entry in the `every_engine_skip_reason_maps_to_a_fallback_reason` table.
- The value documented on `FeedContextProvenance::fallback_reason`, `ScoringResult::skip_reason`, and `ResponseMeta::skip_reason`, each stating why it is not `no_user_data`.

No plumbing changes — it rides the channel #61 built. Two invariants checked rather than assumed:

- **Gated computes still write no cache.** The only write to `Keys::cached_result` on this path is inside the scorer, which this exit never reaches, so a `no_colikers` request cannot come back later as an unlabelled cache hit. The existing comment at `mod.rs:190` holds for the new value.
- **`apply_interleaving` cannot mislabel.** If interleaving re-derives non-empty weights, scoring genuinely ran and the merged result's `skip_reason` is `None`, which is correct.

## Coverage CronJob docstring

Corrected while in here. It attributed the whole UNLABELLED bucket to builds predating `fallback_reason` (2026-08-26). That is now incomplete: post-08-26 builds also wrote unlabelled rows whenever a pool gate fired (labelled 09-01) or the walk came back empty (09-02), so the bucket shrinks faster than pure feed-age decay predicts. The runtime print now names both populations and notes that **a drop after rolling these builds is instrumentation catching up, not coverage improving** — the causes it was hiding show up as new named buckets above.

## Readout caveat

Rows that carry no reason today start carrying `no_colikers`, so a readout spanning the deploy must classify personalization positively rather than by absence of `fallback_reason`. The coverage CronJob already does, and `no_colikers` lands in its addressable set, which is correct.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` clean; 173 graze-api + 64 graze-common lib tests pass; `kubectl apply --dry-run=client` accepts the CronJob and the embedded Python compiles.

Unrelated, not fixed here: `cargo fmt --all` wants to strip a trailing blank line from `crates/graze-lens-builder/src/priors.rs:395`. That drift is already on `main`; I reverted it to keep this diff scoped, but it will fail a `cargo fmt --check` in CI if one runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)