### PR TITLE
Record the live personalization-api objects as manifests

### DIFF
--- a/kube/api-deployment.yaml
+++ b/kube/api-deployment.yaml
@@ -1,119 +1,141 @@
+# The live `personalization-api` Deployment, as it actually runs on the DO sfo3 cluster.
+#
+# This file previously described a Deployment named `graze-personalization-api` running
+# `python -m graze_personalization api`. That object does not exist in the cluster, and no
+# `graze_personalization` Python module exists in this repo -- it was a pre-Rust fiction. Applying
+# it would not have touched the running service (different name); it would have stood up a second,
+# broken Deployment beside it.
+#
+# The running Deployment was created imperatively and has only ever been updated imperatively, so
+# until now its spec existed nowhere but in the cluster. Recorded here so it is recoverable and
+# reviewable.
+#
+# ── Before `kubectl apply -f` ──
+#
+# Verified against the cluster on 2026-09-02: `kubectl diff -f kube/api-deployment.yaml` returns
+# zero bytes and exit 0 against revision 58, so applying this file as written is a no-op. Re-run
+# that diff before trusting it -- it is the check, and it changes nothing:
+#
+#   kubectl diff -f kube/api-deployment.yaml
+#
+# The one field that WILL go stale is `image`. It is pinned to a digest, and deploys are
+# `kubectl set image ... @sha256:...`, so every release moves the cluster ahead of this file.
+# The digest below is the one live at revision 58 (2026-09-02, the build of 09402ab), which means
+# a later `apply` ROLLS BACK to it. Check what is actually running first:
+#
+#   kubectl get deploy personalization-api \
+#     -o jsonpath='{.spec.template.spec.containers[0].image}'
+#
+# Two live fields are deliberately absent, and neither causes a diff: the pod template's
+# `kubectl.kubernetes.io/restartedAt` annotation (cluster history from a past `rollout restart`,
+# not desired state -- `apply` leaves it alone because it is not in the object's
+# last-applied-configuration), and the API defaults the server fills in itself
+# (progressDeadlineSeconds, revisionHistoryLimit, dnsPolicy, terminationGracePeriodSeconds, ...).
+#
+# ── Not in this repo, also unmanaged ──
+#
+# Service `personalization-api` (ClusterIP, 80 -> 8080, selector app=personalization-api) and
+# PodDisruptionBudget `personalization-api-pdb` (minAvailable: 2) are live and have no manifest
+# here. `kube/service.yaml` describes a DIFFERENT, non-existent Service. The PDB is load-bearing
+# for the deploy policy: with 3 replicas and minAvailable 2, a rollout can only ever take one pod
+# at a time.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: graze-personalization-api
+  name: personalization-api
   labels:
-    app: graze-personalization
-    component: api
+    app: personalization-api
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: graze-personalization
-      component: api
+      app: personalization-api
+  # Surge-first, and this is the standing deploy policy rather than an incidental default: a new
+  # pod must be Ready before any old pod is taken down, so a rollout cannot dip below full
+  # capacity. Combined with the startupProbe below, a broken image stalls the rollout instead of
+  # draining the fleet.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
-        app: graze-personalization
-        component: api
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
-        prometheus.io/path: "/metrics"
+        app: personalization-api
     spec:
       containers:
-        - name: api
-          image: dgaff/graze-personalization:latest
-          command: ["python", "-m", "graze_personalization", "api"]
+        - name: personalization-api
+          # Pinned by digest, never by tag: `latest` and the short-SHA tag are both mutable, and
+          # concurrent release builds from different refs overwrite `latest`.
+          image: registry.digitalocean.com/graze-social-labs/personalization@sha256:26f088046186175db34b58cd7e32c9e5904c7f18d309787544d0099c9cd68048
+          # Explicit, and NOT the API default for a digest-pinned image (which is IfNotPresent).
+          imagePullPolicy: Always
+          command: ["/app/graze-api"]
           ports:
             - containerPort: 8080
-              name: http
+              protocol: TCP
+          # Bulk config comes from the ConfigMap and secrets; the inline `env` below OVERRIDES and
+          # extends it. Anything set in both places resolves to the inline value, which is why
+          # reading the ConfigMap alone gives a wrong picture of what is live.
+          envFrom:
+            - configMapRef:
+                name: personalization-env
+            - secretRef:
+                name: app-secrets
+            - secretRef:
+                name: personalization-secrets
+          env:
+            # Pool-size gate (step 0 of compute_personalization). Lives here and NOT in the
+            # ConfigMap, which is easy to miss when checking whether the gate is enabled.
+            - name: MIN_CANDIDATE_POOL_FOR_PERSONALIZATION
+              value: "500"
+            - name: AUTHOR_AFFINITY_ENABLED
+              value: "false"
+            - name: DURABLE_PROFILE_SHADOW_MODE
+              value: "1"
+            - name: THOMPSON_PERSIST_ENABLED
+              value: "1"
+            - name: THOMPSON_PERSIST_INTERVAL_SECONDS
+              value: "30"
+            - name: AB_EXPERIMENT_ENABLED
+              value: "0"
+            - name: AB_EXPERIMENT_DIMENSION
+              value: max_sources
+            - name: AB_EXPERIMENT_VALUES
+              value: 250,10000
+            - name: AB_EXPERIMENT_TRAFFIC_PCT
+              value: "100"
+            - name: AB_EXPERIMENT_SALT
+              value: v1
+            # Randomization for the running holdout experiment. Changing this rate moves the arm
+            # boundary and therefore STARTS A NEW EXPERIMENT -- record a fresh start date in the
+            # spec if you touch it.
+            - name: PERSONALIZATION_HOLDOUT_RATE
+              value: "0.20"
+            - name: FOLLOW_SEED_EXPERIMENT_ENABLED
+              value: "1"
+            - name: FOLLOW_SEED_EXPERIMENT_TRAFFIC_PCT
+              value: "100"
+            - name: FOLLOW_SEED_EXPERIMENT_SALT
+              value: v1
+            - name: FOLLOW_SEED_WEIGHT_MODE
+              value: uniform
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "250m"
+              cpu: 100m
+              memory: 768Mi
             limits:
-              memory: "512Mi"
-              cpu: "1000m"
-          env:
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: graze-personalization-secrets
-                  key: redis-url
-            - name: CLICKHOUSE_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: graze-personalization-secrets
-                  key: clickhouse-host
-            - name: CLICKHOUSE_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: graze-personalization-config
-                  key: clickhouse-port
-            - name: CLICKHOUSE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: graze-personalization-secrets
-                  key: clickhouse-user
-            - name: CLICKHOUSE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: graze-personalization-secrets
-                  key: clickhouse-password
-            - name: CLICKHOUSE_SECURE
-              valueFrom:
-                configMapKeyRef:
-                  name: graze-personalization-config
-                  key: clickhouse-secure
-            - name: ADMIN_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: graze-personalization-secrets
-                  key: admin-api-key
-            - name: WORKER_TYPE
-              value: "api"
-            - name: HTTP_WORKERS
-              value: "1"
-            - name: PERSONALIZATION_HOLDOUT_RATE
-              value: "0"
-            - name: DEFAULT_MAX_USER_LIKES
-              valueFrom:
-                configMapKeyRef:
-                  name: graze-personalization-config
-                  key: default-max-user-likes
-            - name: DEFAULT_MAX_SOURCES_PER_POST
-              valueFrom:
-                configMapKeyRef:
-                  name: graze-personalization-config
-                  key: default-max-sources-per-post
-            - name: DEFAULT_MAX_TOTAL_SOURCES
-              valueFrom:
-                configMapKeyRef:
-                  name: graze-personalization-config
-                  key: default-max-total-sources
-            - name: DEFAULT_MIN_CO_LIKES
-              valueFrom:
-                configMapKeyRef:
-                  name: graze-personalization-config
-                  key: default-min-co-likes
-            - name: INVERTED_MIN_POST_LIKES
-              valueFrom:
-                configMapKeyRef:
-                  name: graze-personalization-config
-                  key: default-min-post-likes
-            - name: INVERTED_MAX_LIKERS_PER_POST
-              valueFrom:
-                configMapKeyRef:
-                  name: graze-personalization-config
-                  key: default-max-likers-per-post
+              cpu: 500m
+              memory: 2Gi
           # startupProbe, NOT readinessProbe, for the Redis-dependent check.
           #
           # /internal/ready returns 503 when a Redis ping fails. All replicas share one Valkey, so
-          # as a readinessProbe a single blip fails readiness on every pod simultaneously and empties
-          # the Service -- a correlated total outage, strictly worse than serving degraded responses.
-          # This repo already has that failure mode on record elsewhere: a readiness check tied to an
-          # upstream dependency is what wedged network-cache on grazer-prod2 for hours.
+          # as a readinessProbe a single blip fails readiness on every pod simultaneously and
+          # empties the Service -- a correlated total outage, strictly worse than serving degraded
+          # responses. This repo already has that failure mode on record elsewhere: a readiness
+          # check tied to an upstream dependency is what wedged network-cache on grazer-prod2 for
+          # hours.
           #
           # As a startupProbe it gates initial traffic until Redis is connected and is then never
           # evaluated again, so a later blip cannot take pods out of rotation. 3s x 40 = up to 120s
@@ -126,9 +148,9 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 40
           # /internal/alive is a static 200, so it cannot correlate-fail on a dependency. This is
-          # what actually fixes the rollout gap: without any readinessProbe, Kubernetes marks a pod
-          # Ready the instant the container starts and routes traffic to it before the HTTP listener
-          # is accepting connections.
+          # what actually closes the rollout gap: with no readinessProbe at all, Kubernetes marks a
+          # pod Ready the instant the container starts and routes traffic to it before the HTTP
+          # listener is accepting connections.
           readinessProbe:
             httpGet:
               path: /internal/alive
@@ -136,11 +158,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-          securityContext:
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+      imagePullSecrets:
+        - name: dockerhub-secret
+        - name: docr-graze-social-labs

--- a/kube/api-pdb.yaml
+++ b/kube/api-pdb.yaml
@@ -1,0 +1,27 @@
+# Disruption budget for the live `personalization-api` Deployment.
+#
+# Created imperatively 2026-08-27 and existed nowhere but in the cluster until now. There is no
+# manifest for it elsewhere in this repo.
+#
+# This is load-bearing for the standing deploy policy, not decoration. With 3 replicas and
+# minAvailable 2, at most one pod can be unavailable at a time -- so a voluntary disruption (node
+# drain, cluster upgrade, `kubectl delete pod`) can never take two replicas down together. It
+# reinforces the Deployment's own maxSurge 1 / maxUnavailable 0 from the other direction: the
+# rollout strategy bounds what a DEPLOY does, and this bounds what the CLUSTER does to us.
+#
+# Consequence worth knowing: with exactly 3 replicas this leaves disruptionsAllowed=1, so a node
+# drain that needs two personalization pods evicted will block on the second until the first is
+# rescheduled and Ready. That is the intended trade -- the Deployment has no HPA and is fixed at 3,
+# so there is no headroom to give away.
+#
+# Verified against the cluster on 2026-09-02: `kubectl diff -f kube/api-pdb.yaml` returns zero
+# bytes and exit 0.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: personalization-api-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: personalization-api

--- a/kube/service.yaml
+++ b/kube/service.yaml
@@ -1,41 +1,66 @@
+# Network path to the live `personalization-api` Deployment: ClusterIP Service + public Ingress.
+#
+# This file previously described a Service named `graze-personalization-api` selecting
+# `app=graze-personalization,component=api` -- labels no pod in the cluster carries -- and an
+# Ingress on `personalization.internal.example.com`, a placeholder host. Neither object exists.
+# Applying the old file would have created a Service selecting nothing (silently: an empty
+# Endpoints list is not an error) alongside an Ingress routing a domain nobody owns.
+#
+# Both objects below were created imperatively and existed nowhere but in the cluster.
+#
+# Verified against the cluster on 2026-09-02: `kubectl diff -f kube/service.yaml` returns zero
+# bytes and exit 0. Re-run it before trusting this file; it changes nothing.
+#
+# See kube/api-deployment.yaml for the Deployment and kube/api-pdb.yaml for the disruption budget.
 apiVersion: v1
 kind: Service
 metadata:
-  name: graze-personalization-api
-  labels:
-    app: graze-personalization
-    component: api
+  name: personalization-api
 spec:
+  type: ClusterIP
+  # Matches the Deployment's pod label. In-cluster consumers reach this as
+  # `personalization-api` / `personalization-api.default.svc.cluster.local`.
   selector:
-    app: graze-personalization
-    component: api
+    app: personalization-api
   ports:
-    - name: http
-      port: 80
+    - port: 80
       targetPort: 8080
       protocol: TCP
-  type: ClusterIP
 ---
+# Public entrypoint. This is a real, externally-reachable hostname, not an internal one: the
+# service is an ATProto feed generator, so Bluesky's AppView calls getFeedSkeleton here directly.
+# `beta.graze.social` is also the host in FEED_GENERATOR_DID (did:web:beta.graze.social), so the
+# host is load-bearing for DID resolution -- changing it invalidates the service's identity to
+# every client, not just its routing.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: graze-personalization-ingress
-  labels:
-    app: graze-personalization
+  name: personalization-api-ingress
   annotations:
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
-    nginx.ingress.kubernetes.io/proxy-body-size: "1m"
+    # Reproduces live state. `kubernetes.io/ingress.class` is the deprecated form of
+    # `spec.ingressClassName`; it is what the cluster object actually carries, so it is what is
+    # recorded here. Migrating it is a live change, not a documentation change.
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: '*'
+    nginx.ingress.kubernetes.io/cors-allow-headers: '*'
+    nginx.ingress.kubernetes.io/cors-allow-origin: '"https://graze.social", "https://*.graze.social", "https://www.graze.social", "https://preprod.graze.social", "https://sky-feeder-git-astro-graze.vercel.app/*", "https://www.sky-feeder-git-astro-graze.vercel.app/*"'
 spec:
-  ingressClassName: nginx
   rules:
-    - host: personalization.internal.example.com
+    - host: beta.graze.social
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: graze-personalization-api
+                name: personalization-api
                 port:
                   number: 80
+  tls:
+    - hosts:
+        - beta.graze.social
+      # Managed by cert-manager via the issuer annotation above; not created by this file.
+      secretName: personalization-api-tls


### PR DESCRIPTION
The `kube/` manifests for the personalization API describe a service that does
not exist. The objects that *do* serve production were all created imperatively
and existed nowhere but in the cluster, so revision 58 was neither reviewable
nor recoverable from this repo.

This replaces the fiction with the live spec. **Every file is verified, not
transcribed by eye:** `kubectl diff -f <file>` returns zero bytes and exit 0
against the live objects for all three. Applying this branch as written is a
no-op.

## What was there

| repo file | described | exists in cluster? |
|---|---|---|
| `kube/api-deployment.yaml` | Deployment `graze-personalization-api`, `python -m graze_personalization api` | **no** |
| `kube/service.yaml` | Service `graze-personalization-api`, selector `app=graze-personalization,component=api` | **no** |
| `kube/service.yaml` | Ingress on `personalization.internal.example.com` | **no** |

No `graze_personalization` Python module exists anywhere in this repo either —
this is pre-Rust fiction that outlived the rewrite.

Because every name differs from the live objects, applying the old files would
not have touched production. It would have stood up a **parallel broken stack**:
a Deployment running a nonexistent Python entrypoint, a Service selecting labels
no pod carries (which fails *silently* — an empty Endpoints list is not an
error), and an Ingress for a domain nobody owns.

## What is now recorded

- **Deployment `personalization-api`** — Rust, `/app/graze-api`, DOCR image
  pinned by digest, 3 replicas, `maxSurge 1 / maxUnavailable 0`, the
  startupProbe/readinessProbe pair, resources, and the 16 inline env vars.
- **Service `personalization-api`** — ClusterIP 80 → 8080.
- **Ingress `personalization-api-ingress`** — `beta.graze.social`, TLS via
  cert-manager, nginx CORS allow-list.
- **PodDisruptionBudget `personalization-api-pdb`** — `minAvailable: 2`.

## Three things written down that were not recorded anywhere

1. **The inline `env` block overrides the ConfigMap.** This is how
   `MIN_CANDIDATE_POOL_FOR_PERSONALIZATION=500` hides: it is on the container,
   not in `personalization-env`, so reading the ConfigMap alone misreports which
   personalization gates are live. That cost real time to discover.
2. **`beta.graze.social` is not just routing.** It is the host in
   `FEED_GENERATOR_DID` (`did:web:beta.graze.social`), so changing the Ingress
   host invalidates the service's identity to every ATProto client, not merely
   its traffic path.
3. **The PDB is load-bearing for the deploy policy.** It bounds what the
   *cluster* does (drains, upgrades) the way the rollout strategy bounds what a
   *deploy* does. At 3 replicas it leaves `disruptionsAllowed=1`, so a drain
   needing two pods evicted blocks on the second until the first is Ready.

## Deliberately not fixed here

`kube/hpa.yaml` defines `graze-personalization-api-hpa` targeting the
nonexistent `graze-personalization-api` — and **no HorizontalPodAutoscaler
exists for `personalization-api` at all.** The file implies autoscaling from 3 to
10 replicas that has never existed.

Left in place rather than deleted on my own judgment, because it wants either
removal or a *real* HPA and that is a capacity decision, not a documentation
one. Worth weighing: this Deployment is pinned at 3 replicas with `cpu: 500m`
limits, while the neighbouring `api` deployment sits at 113% of its 75% CPU
target on a 4–8 replica HPA.

## Caveat on the pinned digest

`image` records the digest live at revision 58 (the `09402ab` build). Deploys are
`kubectl set image ... @sha256:...`, so the cluster moves ahead of this file on
every release and a later `apply` would **roll back** to this digest. Noted in
the file header along with the command to check what is actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)