### PR TITLE
Make primary_metric real, and switch follow_seed's primary to scroll_depth

### DIFF
--- a/analysis/experiments/follow_seed.yaml
+++ b/analysis/experiments/follow_seed.yaml
@@ -35,7 +35,30 @@ design: ab
 start: "2026-08-31T16:49:48Z"
 
 unit: user
-primary_metric: like_rate
+# PRIMARY CHANGED 2026-09-02: like_rate -> scroll_depth.
+#
+# ⚠️ THIS WAS CHOSEN AFTER SEEING THE METRIC'S VALUE ON THIS WINDOW, and that must be on the
+# record. The pre-promotion reading was diff=-0.2173 (-3.2%), CI [-2.9344, +2.4999], WLS p=0.7861 --
+# null, so this is not a promoted winner; but the estimand was still selected post hoc, which is
+# the practice the winsorize_quantile note below exists to forbid. Treat any reading on the CURRENT
+# window as selection-contaminated. A clean pre-registered reading requires a new window, and that
+# call has not been made -- see the ledger.
+#
+# WHY the change: like_rate is unmeasurable on this population, and that is measured, not assumed.
+# Over the whole window the eligible population produced ONE like, from ONE user, across 264 units
+# and 2,359 impressions; request_less and request_more produced ZERO events each, and those three
+# are the entirety of METRIC_EVENTS. The like interval came out ~14.3x its own base rate. The
+# holdout population over the same period: 2,844 likes from 267 users, interval 1.5x base rate.
+# Eligibility IS "no like seed", so the arm selects for users who do not engage and then the
+# primary measured engagement.
+#
+# scroll_depth is the only outcome here whose denominator every unit has BY CONSTRUCTION -- it is
+# impressions per user, and an enrolled user has impressions or they would not be enrolled. So it
+# scales with units rather than with rare events, which is the only way this arm can ever resolve.
+# It is NOT unambiguously better when it moves: more scrolling could be engagement or could be
+# scanning (zero-seed users were measured paginating at a ~1s cadence). A move is a prompt to
+# investigate, not a verdict.
+primary_metric: scroll_depth
 
 # Direction: treatment = allowed to seed from follows. `params.follow_seed` is the ARM, assigned by a
 # per-user salted hash before anything is served — deliberately NOT the realised seed kind, which is
@@ -81,7 +104,12 @@ guardrails:
 scroll_depth:
   winsorize_quantile: 0.90
 
-cuped_covariate: pre_period_like_rate
+# Changed with the primary. A pre-period LIKE RATE cannot de-noise an impression COUNT on a
+# population whose like rate is ~0 -- measured, it bought 3.4% variance reduction against the
+# holdout's 46%. Past impressions predict future impressions, so the covariate now matches the
+# outcome. Still gated by the re-randomization balance check, and still withheld from the gate if
+# the treatment appears to have moved it.
+cuped_covariate: pre_period_impressions
 
 # REQUIRED, and not merely for the usual foreign-traffic reason. An absent JSON field extracts as
 # false, so without this every row written before the flag went live — and every unenrolled row —
@@ -91,7 +119,10 @@ population: >
   JSONHas(tryBase64Decode(interaction_feed_context), 'algo_id')
   AND JSONHas(tryBase64Decode(interaction_feed_context), 'follow_seed')
 
-min_observations: 2000
+# For a scroll_depth primary the denominator is 1 per unit, so observations ARE units and these two
+# floors coincide. 2000 was set for like_rate, where a unit carried ~8.5 impressions; keeping it
+# here would demand 2000 users, which at the observed ~5.7 users/hour is over two weeks.
+min_observations: 500
 
 # Units floor, declared separately because min_observations counts IMPRESSIONS while the estimand
 # is per-USER, and on this population the two diverge badly. Measured 2026-09-02: this spec cleared

--- a/analysis/graze_analysis/data.py
+++ b/analysis/graze_analysis/data.py
@@ -239,7 +239,7 @@ def rows_from_ab_result(
     )
 
 
-def scroll_depth_sql(spec: ExperimentSpec, quantile: float) -> str:
+def scroll_depth_sql(spec: ExperimentSpec, quantile: float, where_extra: str = "") -> str:
     """One row per (unit, arm) carrying that unit's winsorized impression count.
 
     Shaped as numerator/denominator with a denominator of 1 so the same cluster-robust estimator can
@@ -248,6 +248,16 @@ def scroll_depth_sql(spec: ExperimentSpec, quantile: float) -> str:
 
     The cap is a POOLED quantile across both arms. Capping per arm would make the cap itself an
     outcome of the treatment and bias the comparison by construction.
+
+    ``where_extra`` exists so this metric can serve as a PRIMARY, not only a secondary: negative
+    controls are mandatory, and a control must be measured on the same metric as the primary it
+    guards. A like-rate control guarding a scroll-depth primary would be checking a surface the
+    verdict no longer rests on.
+
+    Note the CTE shape, which mirrors :func:`ab_rows_sql` for a reason: ``source`` is a JSON field
+    rather than a column, so a restriction like ``source IN ('pinned','rotating')`` can only be
+    applied where that field has been projected. Filtering inside the row scan also means the
+    pooled cap is computed over the restricted set, which is what a subset's quantile means.
     """
     control = spec.arms["control"]
     treatment = next(a for n, a in spec.arms.items() if n != "control")
@@ -257,26 +267,30 @@ def scroll_depth_sql(spec: ExperimentSpec, quantile: float) -> str:
     unit_col = "did" if spec.unit == "user" else "concat(did, '|', toString(occurred))"
     end_clause = f"AND occurred <= toDateTime('{spec.end:%Y-%m-%d %H:%M:%S}')" if spec.end else ""
     population = f"AND ({spec.population})" if spec.population else ""
+    extra = f"AND {where_extra}" if where_extra else ""
 
     return f"""
-WITH u AS (
+WITH d AS (
   SELECT
     {unit_col} AS unit_id,
     {arm_expr} AS arm_value,
-    count() AS impressions
+    JSONExtractString({decoded}, 'source') AS source
   FROM default.feed_interactions
   WHERE occurred >= toDateTime('{spec.start:%Y-%m-%d %H:%M:%S}')
     {end_clause}
     AND interaction_feed_context != ''
     {population}
     AND interaction_event = '{SEEN}'
+),
+u AS (
+  SELECT unit_id, arm_value, count() AS impressions
+  FROM d
+  WHERE arm_value IN ({_sql_literal(control.value)}, {_sql_literal(treatment.value)}) {extra}
   GROUP BY unit_id, arm_value
   HAVING impressions > 0
 ),
 cap AS (
-  SELECT quantile({quantile})(impressions) AS c
-  FROM u
-  WHERE arm_value IN ({_sql_literal(control.value)}, {_sql_literal(treatment.value)})
+  SELECT quantile({quantile})(impressions) AS c FROM u
 )
 SELECT
   unit_id,
@@ -284,5 +298,4 @@ SELECT
   least(toFloat64(impressions), (SELECT c FROM cap)) AS likes,
   1 AS seen
 FROM u
-WHERE arm_value IN ({_sql_literal(control.value)}, {_sql_literal(treatment.value)})
 """

--- a/analysis/graze_analysis/runner.py
+++ b/analysis/graze_analysis/runner.py
@@ -9,6 +9,7 @@ caveat second.
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,6 +18,7 @@ import numpy as np
 
 from .data import (
     METRIC_EVENTS,
+    Rows,
     scroll_depth_sql,
     ClickHouseReader,
     ab_rows_sql,
@@ -53,10 +55,53 @@ class Readout:
 
 
 
+#: How each supported primary metric is described on the gate line. The default label would call a
+#: winsorized impression COUNT a "rate", which it is not.
+PRIMARY_ESTIMANDS = {
+    "scroll_depth": "winsorized impressions/user",
+}
+
+
+def _primary_metric_rows(
+    spec: ExperimentSpec, reader: ClickHouseReader, where_extra: str = ""
+) -> "Rows":
+    """Rows for whichever metric the spec nominates as primary.
+
+    `primary_metric` was declared in every spec from the start and READ BY NOTHING: `analyse_ab`
+    called `ab_rows_sql(spec)`, whose numerator defaults to a like, so the primary was always the
+    like rate no matter what the YAML said. A spec asking for `request_more_rate` would have been
+    answered with like_rate, silently. Same failure shape as the rest of this file's history: a
+    declaration the code did not implement.
+
+    Negative controls route through here too, so a control is always measured on the same metric as
+    the primary it guards.
+    """
+    if spec.primary_metric == "scroll_depth":
+        quantile = spec.scroll_depth.winsorize_quantile
+        return rows_from_ab_result(
+            reader.query(scroll_depth_sql(spec, quantile, where_extra=where_extra)), spec
+        )
+    event = METRIC_EVENTS[spec.primary_metric]
+    return rows_from_ab_result(
+        reader.query(ab_rows_sql(spec, where_extra=where_extra, numerator_event=event)), spec
+    )
+
+
 def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
     lines: list[str] = []
 
-    primary_rows = rows_from_ab_result(reader.query(ab_rows_sql(spec)), spec)
+    # Unknown primary is FATAL, unlike an unknown guardrail (which is skipped loudly). There is no
+    # readout without a primary, and silently substituting one is how `primary_metric` came to be
+    # ignored in the first place.
+    if spec.primary_metric != "scroll_depth" and spec.primary_metric not in METRIC_EVENTS:
+        known = ", ".join(sorted({*METRIC_EVENTS, "scroll_depth"}))
+        return Readout(
+            spec.id,
+            "WITHHELD (unknown primary metric)",
+            [f"  primary_metric {spec.primary_metric!r} is not measurable here (known: {known})"],
+        )
+
+    primary_rows = _primary_metric_rows(spec, reader)
     primary = cluster_robust_rate_diff(
         primary_rows.unit_ids, primary_rows.arm, primary_rows.numerator, primary_rows.denominator
     )
@@ -69,7 +114,7 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
     # --- Gate 2: negative controls, before the effect is shown ---
     verdicts: list[ControlVerdict] = []
     for nc in spec.negative_controls:
-        rows = rows_from_ab_result(reader.query(ab_rows_sql(spec, where_extra=nc.where)), spec)
+        rows = _primary_metric_rows(spec, reader, where_extra=nc.where)
         est = cluster_robust_rate_diff(
             rows.unit_ids, rows.arm, rows.numerator, rows.denominator
         )
@@ -82,6 +127,25 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
             )
         )
         lines.append(f"  control {nc.name}: {est.describe()}")
+        # A control that passes only because it is too thin to reach significance is not
+        # protection, and it renders identically to a genuinely flat one. Measured 2026-09-02 on
+        # the scroll_depth primary: pinned_and_rotating had 44 units against the primary's 267 and
+        # a point estimate of -0.8727 against the primary's -0.4633 -- nearly double, same
+        # direction -- and cleared the gate purely for lack of significance. Say so, in the same
+        # spirit as the guardrail lines' event counts.
+        if (
+            not est.significant
+            and math.isfinite(est.diff)
+            and math.isfinite(primary.diff)
+            and abs(est.diff) >= abs(primary.diff)
+        ):
+            share = est.n_units / primary.n_units if primary.n_units else float("nan")
+            lines.append(
+                f"    !! this control's point estimate ({est.diff:+.4f}) is at least as large as "
+                f"the primary's ({primary.diff:+.4f}) and it passes only for lack of "
+                f"significance, on {est.n_units} units ({share:.0%} of the primary's). Weak "
+                "protection, not a clean placebo."
+            )
 
     withheld, gate_msg = negative_control_gate(verdicts)
     if withheld:
@@ -128,12 +192,22 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
     if spec.cuped_covariate:
         pre = {str(u): (float(l), float(s_)) for u, l, s_ in reader.query(cuped_covariate_sql(spec))}
         covered = np.array([u in pre and pre[u][1] > 0 for u in primary_rows.unit_ids])
-        cov = np.array(
-            [
-                (pre[u][0] / pre[u][1]) if u in pre and pre[u][1] else 0.0
-                for u in primary_rows.unit_ids
-            ]
-        )
+        # `pre_period_impressions` uses the raw pre-window impression count; anything else uses
+        # the pre-window like RATE. Which one is right depends on the primary: adjusting a
+        # winsorized impression count by a like rate buys almost nothing on a population whose
+        # like rate is ~0 (measured 3.4% reduction), while its own past impressions predict it
+        # strongly. The covariate must match the outcome or CUPED is decoration.
+        if spec.cuped_covariate == "pre_period_impressions":
+            cov = np.array(
+                [float(pre[u][1]) if u in pre else 0.0 for u in primary_rows.unit_ids]
+            )
+        else:
+            cov = np.array(
+                [
+                    (pre[u][0] / pre[u][1]) if u in pre and pre[u][1] else 0.0
+                    for u in primary_rows.unit_ids
+                ]
+            )
         imbalance, p_bal = covariate_balance(cov, treated, covered)
         adjusted, reduction = cuped_adjust(per_unit_rate, cov)
         # A covariate the treatment moved would subtract real signal. Fall back rather than guess.
@@ -148,7 +222,10 @@ def analyse_ab(spec: ExperimentSpec, reader: ClickHouseReader) -> Readout:
         applied_reduction = 0.0
 
     seq = always_valid_diff_ci(
-        outcome[~treated], outcome[treated], variance_reduction=applied_reduction
+        outcome[~treated],
+        outcome[treated],
+        variance_reduction=applied_reduction,
+        estimand=PRIMARY_ESTIMANDS.get(spec.primary_metric, "unweighted per-unit rate"),
     )
 
     lines.insert(0, f"  GATE     : {seq.describe()}")
@@ -226,7 +303,9 @@ def _scroll_depth_lines(spec: ExperimentSpec, reader: ClickHouseReader) -> list[
     position a fixed-horizon test should not be trusted from. Being a secondary means it does not
     move the top-line verdict; it does not mean it may be read loosely.
     """
-    if spec.scroll_depth is None:
+    if spec.scroll_depth is None or spec.primary_metric == "scroll_depth":
+        # When it IS the primary it is already the gate; repeating it as a "secondary" would
+        # invite reading the same number twice as if it were corroboration.
         return []
     q = spec.scroll_depth.winsorize_quantile
     rows = rows_from_ab_result(reader.query(scroll_depth_sql(spec, q)), spec)

--- a/analysis/graze_analysis/spec.py
+++ b/analysis/graze_analysis/spec.py
@@ -239,6 +239,17 @@ def spec_from_dict(raw: dict[str, Any], source: str = "<dict>") -> ExperimentSpe
         else None
     )
 
+    # A scroll_depth primary needs the block that declares its cap, and the cap must be declared
+    # up front: it changes the estimand to a capped mean, so choosing it later is choosing it after
+    # seeing the answer. Checked here rather than at readout so a malformed spec fails on load.
+    if str(raw.get("primary_metric", "")) == "scroll_depth" and scroll_depth is None:
+        _raise(
+            SpecError(
+                f"{source}: primary_metric 'scroll_depth' requires a 'scroll_depth' block "
+                "declaring winsorize_quantile"
+            )
+        )
+
     return ExperimentSpec(
         id=str(require("id")),
         design=design,

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:8bbe3d69be10efe6e3e8c253b1b49817a96575ee65ce70c1133ed5f4796fc132
+              image: dgaff/graze-analysis@sha256:a706054d9700ad9e599d282db0494e7787b44d0a22dc411fc97c850a45a28a20
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job

--- a/analysis/kube/coverage-cronjob.yaml
+++ b/analysis/kube/coverage-cronjob.yaml
@@ -210,7 +210,7 @@ spec:
                 name: personalization-coverage-src
           containers:
             - name: coverage
-              image: dgaff/graze-analysis@sha256:8bbe3d69be10efe6e3e8c253b1b49817a96575ee65ce70c1133ed5f4796fc132
+              image: dgaff/graze-analysis@sha256:a706054d9700ad9e599d282db0494e7787b44d0a22dc411fc97c850a45a28a20
               command: ["python", "/src/coverage.py"]
               volumeMounts:
                 - name: src

--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -145,7 +145,7 @@ spec:
                 name: personalization-dose-check-src
           containers:
             - name: dose
-              image: dgaff/graze-analysis@sha256:8bbe3d69be10efe6e3e8c253b1b49817a96575ee65ce70c1133ed5f4796fc132
+              image: dgaff/graze-analysis@sha256:a706054d9700ad9e599d282db0494e7787b44d0a22dc411fc97c850a45a28a20
               command: ["python", "/src/dose.py"]
               volumeMounts:
                 - name: src

--- a/analysis/tests/test_runner_gates.py
+++ b/analysis/tests/test_runner_gates.py
@@ -269,7 +269,15 @@ def test_scroll_depth_sql_pools_the_cap_across_arms():
     sql = scroll_depth_sql(_scroll_spec(), 0.9)
     cap = sql[sql.index("cap AS ("): sql.index("SELECT\n  unit_id")]
     assert "quantile(0.9)" in cap
-    assert "arm_value IN (10000, 250)" in cap, "cap must be computed over BOTH arms"
+    # The cap aggregates the per-unit CTE in full, and that CTE is the only place arms are
+    # restricted -- to BOTH of them. Asserted structurally rather than by looking for the arm
+    # filter inside `cap`: the filter legitimately moved into `u` when scroll_depth gained a
+    # where_extra, and a per-arm cap would show up as a GROUP BY / extra predicate here.
+    assert "FROM u" in cap, cap
+    assert "arm_value" not in cap, f"cap must not restrict by arm: {cap}"
+    assert "GROUP BY" not in cap, f"cap must not be computed per arm: {cap}"
+    unit_cte = sql[sql.index("u AS ("): sql.index("cap AS (")]
+    assert "arm_value IN (10000, 250)" in unit_cte, unit_cte
     # The cast matters: least() on UInt64 and Float64 is an illegal-type error in ClickHouse.
     assert "least(toFloat64(impressions)" in sql
     # One row per unit, so the clustered SE reduces to the ordinary one.
@@ -635,3 +643,167 @@ def test_both_floors_are_named_when_they_pass():
     assert not thin
     assert "79473 observations / 2658 units" in msg, msg
     assert "2000 / 500 minimums" in msg, msg
+
+
+# --- primary_metric actually selects the metric --------------------------------------------------
+#
+# It was declared in every spec from the start and READ BY NOTHING: analyse_ab called
+# ab_rows_sql(spec), whose numerator defaults to a like, so the primary was always the like rate no
+# matter what the YAML said. These tests check the value REACHES the query, not merely that it
+# parses -- the distinction that let six earlier bugs through.
+
+
+class _RecordingReader:
+    """Captures every SQL it is asked for, so we can assert what was actually queried."""
+
+    def __init__(self, rows, control=None):
+        self.rows = rows
+        self.control = control or _null_control()
+        self.sqls = []
+
+    def query(self, sql):
+        self.sqls.append(sql)
+        if "source = 'fallback'" in sql or "source IN" in sql:
+            return self.control
+        return self.rows
+
+
+def _scroll_rows(prefix, n, count, arm):
+    """Scroll-depth shaped rows: the capped impression count, denominator 1."""
+    return [(f"{prefix}{i}", arm, count, 1) for i in range(n)]
+
+
+def test_primary_metric_selects_the_queried_event():
+    rows = _uneven("c", 150, 1, 20, 10000) + _uneven("t", 150, 2, 20, 250)
+    r = _RecordingReader(rows)
+    analyse_ab(_spec(primary_metric="request_more_rate"), r)
+    assert any("requestMore" in q for q in r.sqls), "primary_metric did not reach the query"
+    # And the like event is not what the primary was drawn from.
+    primary_sql = r.sqls[0]
+    assert "requestMore" in primary_sql, primary_sql
+    assert "interactionLike" not in primary_sql, primary_sql
+
+
+def test_an_unknown_primary_metric_is_fatal_not_substituted():
+    r = _RecordingReader(_uneven("c", 10, 1, 20, 10000))
+    readout = analyse_ab(_spec(primary_metric="vibes"), r)
+    assert "WITHHELD" in readout.verdict and "unknown primary metric" in readout.verdict
+    assert "'vibes' is not measurable" in "\n".join(readout.lines)
+    assert "scroll_depth" in "\n".join(readout.lines), "the known set should be listed"
+    # Nothing was queried, so nothing could be silently substituted.
+    assert r.sqls == []
+
+
+def _scroll_primary_spec(**over):
+    return _spec(
+        primary_metric="scroll_depth",
+        scroll_depth={"winsorize_quantile": 0.9},
+        min_observations=200,
+        min_units=100,
+        **over,
+    )
+
+
+def test_scroll_depth_as_primary_drives_the_gate_and_is_labelled_as_a_count():
+    rows = []
+    for k in range(3):
+        rows += _scroll_rows(f"c{k}_", 100, 6 + k, 10000)
+        rows += _scroll_rows(f"t{k}_", 100, 14 + k, 250)
+    r = _RecordingReader(rows)
+    readout = analyse_ab(_scroll_primary_spec(), r)
+
+    assert "cap AS (" in r.sqls[0], "the primary must come from the winsorized query"
+    gate = readout.lines[0]
+    assert "winsorized impressions/user" in gate, gate
+    assert "unweighted per-unit rate" not in gate, gate
+    assert "SEPARATED FROM ZERO" in gate, gate
+
+
+def test_scroll_depth_is_not_also_printed_as_a_secondary_when_it_is_the_primary():
+    """Repeating the same number as a 'secondary' would read as corroboration."""
+    rows = []
+    for k in range(3):
+        rows += _scroll_rows(f"c{k}_", 100, 6 + k, 10000)
+        rows += _scroll_rows(f"t{k}_", 100, 7 + k, 250)
+    readout = analyse_ab(_scroll_primary_spec(), _RecordingReader(rows))
+    assert not any("secondary outcome" in l for l in readout.lines), readout.render()
+    assert sum("winsorized" in l for l in readout.lines) == 1, readout.render()
+
+
+def test_the_negative_control_is_measured_on_the_primarys_metric():
+    """A like-rate control cannot guard a scroll-depth primary."""
+    rows = []
+    for k in range(3):
+        rows += _scroll_rows(f"c{k}_", 100, 6 + k, 10000)
+        rows += _scroll_rows(f"t{k}_", 100, 14 + k, 250)
+    r = _RecordingReader(rows, control=_scroll_rows("nc", 60, 4, 10000) + _scroll_rows("nt", 60, 4, 250))
+    analyse_ab(_scroll_primary_spec(), r)
+    control_sqls = [q for q in r.sqls if "source = 'fallback'" in q]
+    assert control_sqls, "no negative control was queried"
+    for q in control_sqls:
+        assert "cap AS (" in q, "control was measured on a different metric than the primary"
+
+
+def test_a_scroll_depth_primary_without_its_block_is_rejected_at_load():
+    from graze_analysis.spec import SpecError, spec_from_dict
+
+    body = {
+        "id": "t", "design": "ab", "start": "2026-08-12T09:11:56Z", "unit": "user",
+        "primary_metric": "scroll_depth",
+        "arms": {
+            "control": {"field": "params.max_total_sources", "value": 10000},
+            "treatment": {"field": "params.max_total_sources", "value": 250},
+        },
+        "negative_controls": [
+            {"name": "fallback", "reason": "no causal path", "where": "source = 'fallback'"}
+        ],
+    }
+    try:
+        spec_from_dict(body)
+    except SpecError as e:
+        assert "requires a 'scroll_depth' block" in str(e), str(e)
+    else:
+        raise AssertionError("a scroll_depth primary with no cap declared must not load")
+
+
+def test_a_control_that_passes_only_for_lack_of_power_says_so():
+    """A thin control renders identically to a flat one, which reads as protection it isn't.
+
+    Measured 2026-09-02 with the scroll_depth primary: pinned_and_rotating had 44 units against the
+    primary's 267 and a point estimate of -0.8727 against the primary's -0.4633 -- nearly double,
+    same direction -- and cleared the gate purely for lack of significance.
+    """
+    # Primary: a modest difference on many units. Control: a LARGER point estimate on far fewer,
+    # and high-variance (mostly zeros plus a few maxed-out users) so its SE keeps it insignificant.
+    # That combination -- not significant, yet moving more than the primary -- is the pathology.
+    primary = []
+    for k in range(3):
+        primary += _uneven(f"pc{k}_", 100, k, 20, 10000)
+        primary += _uneven(f"pt{k}_", 100, k + 1, 20, 250)
+    control = (
+        _uneven("kz", 20, 0, 20, 10000)
+        + _uneven("kh", 2, 20, 20, 10000)
+        + _uneven("tz", 20, 0, 20, 250)
+        + _uneven("th", 6, 20, 20, 250)
+    )
+
+    readout = analyse_ab(_spec(), FakeReader(primary, control))
+    joined = "\n".join(readout.lines)
+    # It must not have withheld -- the control is not significant...
+    assert "WITHHELD" not in readout.verdict, readout.render()
+    # ...but the reader must be told the pass was for lack of power.
+    assert "passes only for lack of" in joined, joined
+    assert "Weak protection, not a clean placebo" in joined, joined
+    assert "% of the primary's)" in joined, joined
+
+
+def test_a_genuinely_flat_control_gets_no_such_warning():
+    primary = []
+    for k in range(3):
+        primary += _uneven(f"pc{k}_", 100, k, 20, 10000)
+        primary += _uneven(f"pt{k}_", 100, k + 4, 20, 250)
+    # Same rate in both arms, on a healthy number of units.
+    flat = _uneven("fc", 150, 2, 20, 10000) + _uneven("ft", 150, 2, 20, 250)
+    readout = analyse_ab(_spec(), FakeReader(primary, flat))
+    joined = "\n".join(readout.lines)
+    assert "passes only for lack of" not in joined, joined


### PR DESCRIPTION
## `primary_metric` was decorative

It was declared in every spec from the start and **read by nothing**. `analyse_ab` called `ab_rows_sql(spec)`, whose numerator defaults to a like, so the primary was *always* the like rate whatever the YAML said — a spec asking for `request_more_rate` would have been answered with `like_rate`, silently. **Editing the field alone would have changed nothing.**

It now selects the metric, for the primary *and* for the negative controls, so a control is always measured on the same metric as the primary it guards. An unknown primary is **fatal** (unlike an unknown guardrail, which is skipped loudly) — there is no readout without a primary, and silently substituting one is how this went unnoticed.

## Why follow_seed moves off `like_rate`

Measured across the whole window, not assumed:

| | follow_seed (eligible) | holdout (all users) |
|---|---|---|
| units / impressions | 264 / 2,359 | 2,735 / 84,419 |
| **likes** | **1 event, from 1 user** | 2,844 events, 267 users |
| `request_less` / `request_more` | **0 / 0** | 49 / 7 |
| interval ÷ base rate | **14.3×** | 1.5× |

Those three events are the entirety of `METRIC_EVENTS`. Eligibility *is* "no like seed", so the arm selects for users who don't engage and the primary then measured engagement. `scroll_depth` is the only outcome whose denominator every unit has **by construction**, so it scales with units rather than with rare events.

## ⚠️ The promotion is post hoc, and the spec says so

`scroll_depth`'s value on this window was already visible — `-0.2173`, CI `[-2.9344, +2.4999]`, `p=0.7861` — before it became the primary. Null, so not a promoted winner, but selected *after* seeing it, which is exactly what the `winsorize_quantile` note in the same spec forbids. **Any reading on the current window is selection-contaminated.** A clean pre-registered reading needs a new window; that call is not mine to make and is flagged rather than taken.

## Carried with it

- **`scroll_depth_sql` takes `where_extra`**, with the CTE reshaped so `source` (a JSON field, not a column) is projected before being filtered, and the pooled cap computed over the restricted set.
- **CUPED gains `pre_period_impressions`.** A pre-period like *rate* cannot de-noise an impression *count* on a population whose like rate is ~0 — measured 3.4% reduction against the holdout's 46%.
- **`min_observations` 2000 → 500.** For this estimand the denominator is 1 per unit, so observations *are* units and the floors coincide; 2000 would have demanded 2000 users, over two weeks at ~5.7/hour.
- **`scroll_depth` is no longer also printed as a "secondary" when it is the primary** — the same number twice reads as corroboration.
- **A negative control that passes only for lack of significance now says so.** Measured with the new primary: `pinned_and_rotating` has 44 units against the primary's 267, and a point estimate of `-0.8727` against `-0.4633` — nearly double, same direction — clearing the gate purely because it cannot reach significance. It renders identically to a flat control and is not one.

## Verification

105 tests (8 new), including that `primary_metric` **reaches the query** rather than merely parsing — the distinction that let this bug live. Also run inside the built image. Validated against live ClickHouse: `follow_seed` correctly `WITHHELD` at 268 of the 500 units needed; holdout and max_sources unchanged.

Image `sha256:a706054d9700ad9e599d282db0494e7787b44d0a22dc411fc97c850a45a28a20`. Rollback `sha256:8bbe3d69be10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
