### PR TITLE
Reset the follow_seed window for the scroll_depth estimand

### DIFF
--- a/analysis/experiments/follow_seed.yaml
+++ b/analysis/experiments/follow_seed.yaml
@@ -29,10 +29,34 @@ design: ab
 # under-powered, it was measuring a different and less meaningful quantity, so nothing interpretable
 # is discarded by resetting.
 #
-# The four windows before this measured nothing at all -- see the git history of this file: the arm
+# The four windows before that measured nothing at all -- see the git history of this file: the arm
 # never reached the seed step, then was absent from no_user_data rows, then hung off a disabled
 # branch, then was blocked by the pre-personalization seed gate.
-start: "2026-08-31T16:49:48Z"
+#
+# ---------------------------------------------------------------------------------------------
+# START, 2026-09-02T14:37:55Z. SIXTH start, and the first reset for a reason unrelated to the
+# arms: the ESTIMAND changed. primary_metric moved like_rate -> scroll_depth (PR #69, merged at
+# exactly this timestamp), and that metric's value on the previous window had already been read
+# (-0.2173, CI [-2.9344, +2.4999], p=0.7861) before it was promoted. Judging a primary on the
+# data used to choose it is what the winsorize_quantile note below forbids, so that data is
+# discarded rather than reinterpreted.
+#
+# ⚠️ NOTE WHAT DID *NOT* CHANGE. FOLLOW_SEED_EXPERIMENT_SALT is still v1 and TRAFFIC_PCT still
+# 100, so the hash boundary has NOT moved and NO USER IS REASSIGNED. Unlike the five resets
+# above, this one re-randomizes nothing; it only drops already-inspected rows. Enrolment,
+# eligibility and delivery are untouched, and the dose evidence stands.
+#
+# ⚠️ THE DOSE CHECK'S `FOLLOW_SEED_FLIP_AT` IS DELIBERATELY LEFT AT 2026-08-31 16:49:48 AND MUST
+# NOT BE "FIXED" TO MATCH THIS. That bound exists because rows written before the arm was ever
+# assigned carry no `follow_seed` key, and an absent JSON field extracts as false -- it is about
+# arm PRESENCE, not about the estimand. The arms did not change here, so all delivery evidence
+# since the original flip remains valid, and moving the bound would discard two days of dose data
+# for nothing. The two timestamps differ on purpose; that is not drift.
+#
+# COST, stated plainly: the 268 units accrued under the old primary are discarded. At the observed
+# ~5.7 eligible users/hour the 500-unit floor is roughly 88 hours (~3.7 days) out. Nothing to do
+# in the meantime -- WITHHELD is the correct state and does not mean "check again sooner".
+start: "2026-09-02T14:37:55Z"
 
 unit: user
 # PRIMARY CHANGED 2026-09-02: like_rate -> scroll_depth.

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:a706054d9700ad9e599d282db0494e7787b44d0a22dc411fc97c850a45a28a20
+              image: dgaff/graze-analysis@sha256:cf397a9139eb24f622d8e72c0ba74d6dde36fd4e74774aecbbfaf14f0eb4d9d6
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job

--- a/analysis/kube/coverage-cronjob.yaml
+++ b/analysis/kube/coverage-cronjob.yaml
@@ -210,7 +210,7 @@ spec:
                 name: personalization-coverage-src
           containers:
             - name: coverage
-              image: dgaff/graze-analysis@sha256:a706054d9700ad9e599d282db0494e7787b44d0a22dc411fc97c850a45a28a20
+              image: dgaff/graze-analysis@sha256:cf397a9139eb24f622d8e72c0ba74d6dde36fd4e74774aecbbfaf14f0eb4d9d6
               command: ["python", "/src/coverage.py"]
               volumeMounts:
                 - name: src

--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -145,7 +145,7 @@ spec:
                 name: personalization-dose-check-src
           containers:
             - name: dose
-              image: dgaff/graze-analysis@sha256:a706054d9700ad9e599d282db0494e7787b44d0a22dc411fc97c850a45a28a20
+              image: dgaff/graze-analysis@sha256:cf397a9139eb24f622d8e72c0ba74d6dde36fd4e74774aecbbfaf14f0eb4d9d6
               command: ["python", "/src/dose.py"]
               volumeMounts:
                 - name: src


### PR DESCRIPTION
Sixth start, and the first reset for a reason unrelated to the arms.

## Why

`primary_metric` moved `like_rate` → `scroll_depth` in #69, and **that metric's value on the previous window had already been read before it was promoted** (`-0.2173`, CI `[-2.9344, +2.4999]`, `p=0.7861`). Judging a primary on the data used to choose it is exactly what the `winsorize_quantile` note in this same spec forbids, so that data is discarded rather than reinterpreted.

The new start is the **merge timestamp of #69** — the moment the estimand became the repo's truth — so every row judged from here was collected after the choice was made.

## What did *not* change, which is the important half

`FOLLOW_SEED_EXPERIMENT_SALT` is still `v1` and `TRAFFIC_PCT` still `100`. **The hash boundary has not moved and no user is reassigned.** The five resets above this one all re-randomized; this one re-randomizes nothing and only drops already-inspected rows. Enrolment, eligibility and delivery are untouched.

The dose check's `FOLLOW_SEED_FLIP_AT` is **deliberately left at `2026-08-31 16:49:48`**, and the spec now says so in capitals so that nobody reconciles the two. That bound exists because rows written before the arm existed carry no `follow_seed` key, and an absent JSON field extracts as `false` — it is about arm *presence*, not the estimand. Since the arms did not change, two days of delivery evidence remain valid, and moving the bound would discard it for nothing. **The two timestamps differ on purpose; that is not drift.**

## Cost, stated rather than glossed

The 268 units accrued under the old primary are gone. At the observed ~5.7 eligible users/hour, the 500-unit floor is roughly **88 hours (~3.7 days)** away. `WITHHELD` is the correct state until then and does not mean "check again sooner".

## Why this needs a rebuild

Specs are **baked into the image** — there is no ConfigMap overlay (see `a108420`, which removed one). A spec-only edit that skipped the rebuild would leave the cluster reading the old start date while the repo claimed otherwise. Verified by grepping the baked file inside the pushed image:

```
start: "2026-09-02T14:37:55Z"
primary_metric: scroll_depth
```

105 tests pass. Image `sha256:cf397a9139eb24f622d8e72c0ba74d6dde36fd4e74774aecbbfaf14f0eb4d9d6`. Rollback `sha256:a706054d9700`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
