### PR TITLE
Give the interleaving readout a units floor, and read the self-check hourly

### DIFF
--- a/analysis/experiments/interleave_per_feed_vs_post_first.yaml
+++ b/analysis/experiments/interleave_per_feed_vs_post_first.yaml
@@ -34,6 +34,15 @@ negative_controls:
 
 min_observations: 200
 
+# Units floor on DECIDED USERS -- see the note in interleave_self_check.yaml. Higher than the
+# self-check's 40 because this spec forms a real verdict: 100 decided users resolves roughly a
+# 61/39 split.
+#
+# ⚠️ THIS SPEC'S `start` IS STILL A PLACEHOLDER AND MUST BE RESET WHEN IT IS ENABLED. It is not
+# scheduled and no arm has ever been served, so resetting it now would only invent a window during
+# which nothing ran.
+min_units: 100
+
 notes: >
   READ THE SEED KEEP RATE BEFORE THE PREFERENCE. The treatment shrinks the seed by construction, and
   there are two very different ways it can win or lose. If keep_rate is healthy (say >0.3) the result

--- a/analysis/experiments/interleave_self_check.yaml
+++ b/analysis/experiments/interleave_self_check.yaml
@@ -5,7 +5,11 @@
 # harness rather than of a ranker, and must be fixed before a real comparison is trusted.
 id: interleave_self_check
 design: interleaving
-start: "2026-08-13T00:00:00Z"
+# START, 2026-09-02T15:36:38Z -- the moment INTERLEAVE_ENABLED/SELF_CHECK went live on
+# personalization-api at TRAFFIC_PCT=10. Reset from a stale 2026-08-13 placeholder: rows from
+# before enrolment existed carry no ranker tag and would have been counted as clean when they were
+# merely absent.
+start: "2026-09-02T15:36:38Z"
 unit: user
 primary_metric: preference
 
@@ -23,6 +27,15 @@ negative_controls:
     where: "source = 'fallback'"
 
 min_observations: 100
+
+# Units floor. `min_observations` counts TAGGED IMPRESSIONS; the verdict is a sign test over
+# DECIDED USERS, and the two diverge freely. 40 decided users is the point at which a two-sided
+# sign test can resolve roughly a 67/33 preference split -- a floor against a verdict that is
+# simply wrong, not a power guarantee.
+#
+# It does NOT gate this spec's expected result. A clean self-check has zero decided users by
+# construction, which the runner reports as SELF-CHECK CLEAN before the floor is consulted.
+min_units: 40
 
 notes: >
   Expected outcome: zero tagged impressions and zero users with a preference. This validates

--- a/analysis/graze_analysis/runner.py
+++ b/analysis/graze_analysis/runner.py
@@ -392,6 +392,24 @@ def analyse_interleaving(spec: ExperimentSpec, reader: ClickHouseReader) -> Read
     """Per-user preference readout for a team-draft experiment."""
     rows = reader.query(interleaving_rows_sql(spec))
     if not rows:
+        # For a SELF-CHECK this is the PASS condition, not a shortfall: identical rankers produce
+        # identical lists, every item is shared, and a shared item is deliberately left untagged.
+        # Confirmed live 2026-09-02 -- every `interleave_draft` reported competitive_pairs=0 with
+        # control_scored == treatment_scored. Spelled out because "WITHHELD" otherwise reads as a
+        # failure and the distinction decides whether the harness is trusted.
+        control = spec.arms["control"]
+        treatment = next(a for n, a in spec.arms.items() if n != "control")
+        if control.value == treatment.value:
+            return Readout(
+                spec.id,
+                "SELF-CHECK CLEAN (no tagged impressions, as designed)",
+                [
+                    f"  both arms are {control.value!r}, so no competitive pair can form and no "
+                    "item may carry a ranker tag",
+                    "  zero tagged impressions is the expected result here -- the drafting, "
+                    "enrolment and provenance path are all exercised without tagging anything",
+                ],
+            )
         return Readout(spec.id, "WITHHELD (no tagged impressions)", ["  no interleaved items found"])
 
     tau = np.array([float(t) - float(c) for _, t, c, _ in rows])
@@ -421,6 +439,23 @@ def analyse_interleaving(spec: ExperimentSpec, reader: ClickHouseReader) -> Read
             "(the harness's own negative control)"
         )
         return Readout(spec.id, "NO PREFERENCE (self-check clean)", lines)
+
+    # UNITS FLOOR. `min_observations` above counts TAGGED IMPRESSIONS, but the verdict below is a
+    # sign test over DECIDED USERS, and the two diverge freely -- 200 tagged impressions
+    # concentrated in three users would otherwise produce a verdict from three data points. The A/B
+    # path got this floor on 2026-09-02 after forming a verdict from 239 units; this path never
+    # called `insufficient_data_gate` at all, so it did not inherit it.
+    #
+    # Placed AFTER the decided == 0 branch on purpose: a clean self-check legitimately has zero
+    # decided users, and gating it here would turn the harness's own pass condition into a
+    # permanent WITHHELD.
+    if decided < spec.min_units:
+        lines.append(
+            f"  only {decided} user(s) expressed a preference, below the {spec.min_units} "
+            "minimum. The sign test runs over decided users, so that is the number the verdict "
+            f"would rest on -- not the {tagged} tagged impressions."
+        )
+        return Readout(spec.id, "WITHHELD (too few decided users)", lines)
 
     # Sign test on users, which respects the unit of randomization.
     p = _two_sided_binomial(prefer_t, decided)

--- a/analysis/kube/analysis-cronjob.yaml
+++ b/analysis/kube/analysis-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             - name: dockerhub-secret
           containers:
             - name: analysis
-              image: dgaff/graze-analysis@sha256:cf397a9139eb24f622d8e72c0ba74d6dde36fd4e74774aecbbfaf14f0eb4d9d6
+              image: dgaff/graze-analysis@sha256:3c1d7b3647d6b6781b2c79ed55273a5366a1a69bee2ab1a612abf3a4074c7913
               # Override the entrypoint so one job runs both the experiment readouts and the
               # density-drift guard. The guard exits non-zero only on a *detection* (a feed that has
               # already stopped being personalized), so a real regression shows up as a failed Job
@@ -49,10 +49,17 @@ spec:
                     experiments/follow_seed.yaml \
                     experiments/max_sources_250_vs_10000.yaml
                   contract=$?
+                  # interleave_self_check is read but deliberately NOT contract-checked above.
+                  # The contract asserts a spec's arm field is present in live data; a CLEAN
+                  # self-check writes no `ranker` value at all, by design, so requiring the field
+                  # to be present would invert the test and fail exactly when the harness is
+                  # working. Its pass condition is "no tagged impressions", which the runner
+                  # reports as SELF-CHECK CLEAN.
                   python -m graze_analysis.runner \
                     experiments/personalization_holdout.yaml \
                     experiments/follow_seed.yaml \
-                    experiments/max_sources_250_vs_10000.yaml
+                    experiments/max_sources_250_vs_10000.yaml \
+                    experiments/interleave_self_check.yaml
                   readout=$?
                   python -m graze_analysis.drift
                   drift=$?

--- a/analysis/kube/coverage-cronjob.yaml
+++ b/analysis/kube/coverage-cronjob.yaml
@@ -226,7 +226,7 @@ spec:
                 name: personalization-coverage-src
           containers:
             - name: coverage
-              image: dgaff/graze-analysis@sha256:cf397a9139eb24f622d8e72c0ba74d6dde36fd4e74774aecbbfaf14f0eb4d9d6
+              image: dgaff/graze-analysis@sha256:3c1d7b3647d6b6781b2c79ed55273a5366a1a69bee2ab1a612abf3a4074c7913
               command: ["python", "/src/coverage.py"]
               volumeMounts:
                 - name: src

--- a/analysis/kube/dose-check-cronjob.yaml
+++ b/analysis/kube/dose-check-cronjob.yaml
@@ -145,7 +145,7 @@ spec:
                 name: personalization-dose-check-src
           containers:
             - name: dose
-              image: dgaff/graze-analysis@sha256:cf397a9139eb24f622d8e72c0ba74d6dde36fd4e74774aecbbfaf14f0eb4d9d6
+              image: dgaff/graze-analysis@sha256:3c1d7b3647d6b6781b2c79ed55273a5366a1a69bee2ab1a612abf3a4074c7913
               command: ["python", "/src/dose.py"]
               volumeMounts:
                 - name: src

--- a/analysis/tests/test_runner_gates.py
+++ b/analysis/tests/test_runner_gates.py
@@ -807,3 +807,69 @@ def test_a_genuinely_flat_control_gets_no_such_warning():
     readout = analyse_ab(_spec(), FakeReader(primary, flat))
     joined = "\n".join(readout.lines)
     assert "passes only for lack of" not in joined, joined
+
+
+# --- The interleaving readout's units floor -----------------------------------------------------
+#
+# `min_observations` counts TAGGED IMPRESSIONS; the verdict is a sign test over DECIDED USERS, and
+# the two diverge freely. The A/B path got a units floor on 2026-09-02 after forming a verdict from
+# 239 units; this path never called `insufficient_data_gate`, so it did not inherit one.
+
+
+def _il_spec():
+    from graze_analysis.spec import load_spec
+
+    return load_spec("experiments/interleave_self_check.yaml")
+
+
+class _IlReader:
+    """(unit_id, treatment_wins, control_wins, tagged_impressions)"""
+
+    def __init__(self, rows):
+        self.rows = rows
+
+    def query(self, sql):
+        return self.rows
+
+
+def test_many_tagged_impressions_from_few_users_is_withheld():
+    """The pathology: the impression floor clears while the sign test rests on three people."""
+    spec = _il_spec()
+    # 3 decided users carrying 100 tagged impressions each -> 300 tagged, over the 100 floor.
+    readout = run(spec, _IlReader([(f"u{i}", 4, 0, 100) for i in range(3)]))
+    assert "WITHHELD" in readout.verdict, readout.render()
+    assert "too few decided users" in readout.verdict, readout.verdict
+    joined = "\n".join(readout.lines)
+    assert "only 3 user(s) expressed a preference" in joined, joined
+    # It must name the number the verdict would have rested on, and distinguish it from impressions.
+    assert "not the 300 tagged impressions" in joined, joined
+    # No verdict may leak out.
+    assert "TREATMENT WINS" not in readout.verdict
+
+
+def test_the_units_floor_does_not_block_a_clean_self_check():
+    """A clean self-check has ZERO decided users -- the floor must not turn its pass into a hold."""
+    spec = _il_spec()
+    readout = run(spec, _IlReader([(f"u{i}", 0, 0, 5) for i in range(60)]))
+    assert "NO PREFERENCE" in readout.verdict, readout.render()
+    assert "WITHHELD" not in readout.verdict
+
+
+def test_no_tagged_impressions_reads_as_a_self_check_pass_not_a_shortfall():
+    """Confirmed live 2026-09-02: identical rankers gave competitive_pairs=0 on every draft."""
+    spec = _il_spec()
+    readout = run(spec, _IlReader([]))
+    assert "SELF-CHECK CLEAN" in readout.verdict, readout.render()
+    joined = "\n".join(readout.lines)
+    assert "no competitive pair can form" in joined, joined
+    # The bare "WITHHELD (no tagged impressions)" wording must not be what a self-check shows.
+    assert readout.verdict != "WITHHELD (no tagged impressions)"
+
+
+def test_a_real_comparison_with_no_tagged_rows_is_still_withheld():
+    """Only a SELF-check may read zero-tagged as a pass; differing arms cannot."""
+    from graze_analysis.spec import load_spec
+
+    spec = load_spec("experiments/interleave_per_feed_vs_post_first.yaml")
+    readout = run(spec, _IlReader([]))
+    assert readout.verdict == "WITHHELD (no tagged impressions)", readout.render()


### PR DESCRIPTION
Phase 2 of the interleaving enablement scoped earlier today. **Phase 1 (env only) is already live** — `INTERLEAVE_ENABLED=1`, `SELF_CHECK=1`, both arms `post_first`, `TRAFFIC_PCT=10`, from `2026-09-02T15:36:38Z`.

## Phase 1 passed, and the anomaly is explained

Every `interleave_draft` line reports `competitive_pairs=0`, `shared_items=N`, `control_scored == treatment_scored` — exactly what identical rankers must produce — and ClickHouse confirms **zero tagged rows since the flip**. `team_draft` is not buggy.

**The 7 tagged impressions that made the self-check look broken were never a self-check.** All 7 rows date from an 8-minute window on **2026-08-13 16:52–17:00** and carry:

| ranker | rows | users |
|---|---:|---:|
| `sampled_walk` | 4 | 3 |
| `post_first` | 3 | 2 |

That is a brief **real comparison between two different rankers**, during which tagging worked correctly. The stale `start: 2026-08-13` in the spec was picking those rows up — which is why a working harness reported a number its own design says is impossible. Resetting the window to the flip moment removes them.

## The units floor

`min_observations` counts **tagged impressions**; the verdict is a sign test over **decided users**, and the two diverge freely — 300 tagged impressions concentrated in three users would have produced a verdict from three data points. The A/B path got this floor earlier today (after forming a verdict from 239 units); this path never called `insufficient_data_gate`, so it did not inherit one.

Placed **after** the `decided == 0` branch deliberately: a clean self-check has zero decided users, and gating there would turn the harness's own pass condition into a permanent `WITHHELD`.

Zero tagged impressions now reads as **`SELF-CHECK CLEAN`** rather than `WITHHELD (no tagged impressions)` when both arms name the same ranker — that is the pass condition and it should not look like a shortfall. A real comparison with no tagged rows is still `WITHHELD`; there is a test for each.

## Wiring

The self-check is now **read** by the hourly job but deliberately **not contract-checked**. The contract asserts a spec's arm field is present in live data, and a clean self-check writes no `ranker` value at all — requiring its presence would invert the test and fail precisely when the harness works.

Floors are declared rather than inherited: `interleave_self_check` `min_units: 40` (a two-sided sign test resolves ~67/33 there), `interleave_per_feed_vs_post_first` `min_units: 100` (~61/39). The per-feed spec's `start` is left as a placeholder **with a warning** — it is unscheduled and no arm has ever been served, so resetting it now would invent a window in which nothing ran.

## Latency at 10%

No regression detectable: **p99 416ms after vs 1151ms before**. But that is on only 52 post-flip rows and is confounded by an unrelated `personalization-api` deploy ten minutes earlier, so read it as *no regression visible*, **not** as evidence interleaving is faster. Separately worth noting: the pre-flip p99 above 500ms is its own pre-existing question, unrelated to this change.

## Verification

109 tests (4 new), also run inside the built image, which was grepped to confirm the baked spec carries the new window and floor.

Image `sha256:3c1d7b3647d6b6781b2c79ed55273a5366a1a69bee2ab1a612abf3a4074c7913`. Rollback: previous digest, plus `INTERLEAVE_ENABLED=0` for Phase 1 (env only, no rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
