### PR TITLE
Blob v3: keep the count that produced each weight

### DIFF
--- a/crates/graze-lens-builder/src/builder.rs
+++ b/crates/graze-lens-builder/src/builder.rs
@@ -298,7 +298,17 @@ impl Builder {
             );
         }
 
-        let blob = map.encode_as(crate::scored::FACET_DOMAIN, interner.idspace(), now_secs());
+        // `seeds` here are the FEED's authors, not a viewer's follows — so
+        // domain's count is "how many of this feed's authors follow them",
+        // which is a different population from every viewer facet's count.
+        // That is why a threshold belongs to its layer and units never mix
+        // inside one comparison.
+        let blob = map.encode_as_with_seeds(
+            crate::scored::FACET_DOMAIN,
+            interner.idspace(),
+            now_secs(),
+            seeds.len(),
+        );
         info!(
             algo_id,
             authors = seeds.len(),
@@ -417,7 +427,12 @@ impl Builder {
         }
 
         let built_at = now_secs();
-        let blob = map.encode(interner.idspace(), built_at);
+        let blob = map.encode_as_with_seeds(
+            crate::scored::FACET_FOLLOWS2,
+            interner.idspace(),
+            built_at,
+            seeds.len(),
+        );
         info!(
             viewer,
             seeds = seeds.len(),
@@ -445,14 +460,27 @@ impl Builder {
         };
         let result = async {
             let ids = interner.intern_many(followees).await?;
-            let entries: Vec<(u32, u16)> = ids
+            // `follows` is the boolean facet: you follow someone or you do
+            // not. Its stored count is a literal 1 — true, so it cannot
+            // mislead a `>= 1` filter — but `KIND_BOOLEAN` is the real guard,
+            // and the reader refuses counts on it independently of the value.
+            //
+            // It is also the only facet with no bloom and no top-K cut: every
+            // followee is encoded. So "only people I follow" is an exact,
+            // false-positive-free membership test — the filter creators most
+            // want is the one that can be answered precisely.
+            let entries: Vec<(u32, u16, u16)> = ids
                 .values()
-                .map(|id| (*id, crate::scored::WEIGHT_MAX))
+                .map(|id| (*id, crate::scored::WEIGHT_MAX, 1u16))
                 .collect();
-            let blob = crate::scored::encode_in_space(
+            let seed_count = crate::scored::count_from_u32(entries.len() as u32);
+            let blob = crate::scored::encode_v3_in_space(
                 crate::scored::FACET_FOLLOWS,
                 interner.idspace(),
+                crate::scored::KIND_BOOLEAN,
                 now_secs(),
+                1,
+                seed_count,
                 entries,
             );
             self.publish_blob(viewer, facet, &blob).await
@@ -677,7 +705,7 @@ impl Builder {
         let Some(header_id) = facet_header_id(facet_name) else {
             anyhow::bail!("{facet_name} has no header id; dispatch and wire format disagree");
         };
-        let blob = map.encode_as(header_id, interner.idspace(), now_secs());
+        let blob = map.encode_as_with_seeds(header_id, interner.idspace(), now_secs(), seeds.len());
         info!(
             viewer,
             facet = facet_name,
@@ -778,6 +806,7 @@ impl Builder {
         let mut map = priors::parse_members_tsv(
             &self.query_text(&members_sql).await?,
             &affinity,
+            seeds.len(),
             self.config.second_degree_top_k,
         );
         second_degree::exclude_first_degree(&mut map, &seeds);

--- a/crates/graze-lens-builder/src/priors.rs
+++ b/crates/graze-lens-builder/src/priors.rs
@@ -151,7 +151,7 @@ pub fn community_members_query(database: &str, communities: &[u32], cap: usize) 
 /// Parse `(id, reach, score)` rows into a scored map, normalising weights
 /// against the viewer's own best score.
 pub fn parse_prior_tsv(text: &str, top_k: usize) -> SecondDegree {
-    let mut entries: Vec<(u32, u16)> = Vec::with_capacity(top_k.min(1024));
+    let mut entries: Vec<(u32, u16, u16)> = Vec::with_capacity(top_k.min(1024));
     let mut all_ids: Vec<u32> = Vec::new();
     let mut max_reach = 0u32;
     let mut max_score = 0f64;
@@ -180,7 +180,16 @@ pub fn parse_prior_tsv(text: &str, top_k: usize) -> SecondDegree {
             } else {
                 0.0
             };
-            entries.push((id, scored::weight_from_f32(w as f32)));
+            // The COUNT is the raw reach, not this prior's score: a threshold
+            // must mean "this many of your follows" on niche and popular alike,
+            // or a creator switching fame prior would silently change what
+            // "at least 5" asks for. The score is the weight; the reach is the
+            // count.
+            entries.push((
+                id,
+                scored::weight_from_f32(w as f32),
+                scored::count_from_u32(reach),
+            ));
         }
     }
 
@@ -219,10 +228,16 @@ pub fn parse_affinity_tsv(text: &str, seeds: usize) -> Vec<(u32, f32)> {
 
 /// Parse `(account, community, followers)` member rows, weighting each member
 /// by `affinity_share(community) × ln(2 + fame)`, normalised to the best.
-pub fn parse_members_tsv(text: &str, affinity: &[(u32, f32)], top_k: usize) -> SecondDegree {
+pub fn parse_members_tsv(
+    text: &str,
+    affinity: &[(u32, f32)],
+    seeds: usize,
+    top_k: usize,
+) -> SecondDegree {
     let share = |c: u32| affinity.iter().find(|(k, _)| *k == c).map(|(_, s)| *s);
-    let mut raw: Vec<(u32, f64)> = Vec::new();
+    let mut raw: Vec<(u32, f64, u16)> = Vec::new();
     let mut all_ids: Vec<u32> = Vec::new();
+    let mut max_reach = 0u32;
 
     for line in text.lines() {
         let mut cols = line.split('\t');
@@ -238,24 +253,35 @@ pub fn parse_members_tsv(text: &str, affinity: &[(u32, f32)], top_k: usize) -> S
         };
         let Some(sh) = share(c) else { continue };
         all_ids.push(a);
-        raw.push((a, sh as f64 * (2.0 + f as f64).ln()));
+        // The count community can honestly give: how many of the viewer's own
+        // follows sit in this member's community. `affinity` carries it as a
+        // share of the seed count, so multiplying it back recovers the integer
+        // it was computed from.
+        //
+        // Before this, community published `max_reach: 0`, which made
+        // `publish_scored`'s `max_reach <= seeds.len()` assert vacuous for the
+        // one facet whose logs showed a suspiciously constant reach. Giving it
+        // a real count makes that assert live for the first time.
+        let count = scored::count_from_u32((sh * seeds.max(1) as f32).round() as u32);
+        max_reach = max_reach.max(count as u32);
+        raw.push((a, sh as f64 * (2.0 + f as f64).ln(), count));
     }
 
     raw.sort_by(|x, y| y.1.partial_cmp(&x.1).unwrap_or(std::cmp::Ordering::Equal));
-    let max = raw.first().map(|(_, s)| *s).unwrap_or(0.0);
-    let entries: Vec<(u32, u16)> = raw
+    let max = raw.first().map(|(_, s, _)| *s).unwrap_or(0.0);
+    let entries: Vec<(u32, u16, u16)> = raw
         .into_iter()
         .take(top_k)
-        .map(|(a, s)| {
+        .map(|(a, s, count)| {
             let w = if max > 0.0 { s / max } else { 0.0 };
-            (a, scored::weight_from_f32(w as f32))
+            (a, scored::weight_from_f32(w as f32), count)
         })
         .collect();
 
     SecondDegree {
         entries,
         all_ids,
-        max_reach: 0,
+        max_reach,
     }
 }
 
@@ -382,7 +408,7 @@ mod tests {
         let affinity = vec![(5u32, 0.9f32), (9u32, 0.1f32)];
         // account 100: community 5, 1k followers. account 200: community 9, 5k.
         let tsv = "200\t9\t5000\n100\t5\t1000\n";
-        let m = parse_members_tsv(tsv, &affinity, 10);
+        let m = parse_members_tsv(tsv, &affinity, 100, 10);
         assert_eq!(m.entries[0].0, 100, "high-affinity community wins");
         assert!(
             m.all_ids.contains(&200),
@@ -392,7 +418,7 @@ mod tests {
 
     #[test]
     fn members_of_unknown_communities_are_dropped() {
-        let m = parse_members_tsv("100\t77\t1000\n", &[(5, 1.0)], 10);
+        let m = parse_members_tsv("100\t77\t1000\n", &[(5, 1.0)], 100, 10);
         assert!(
             m.is_empty(),
             "a member row for a community we did not ask about is a bug upstream"

--- a/crates/graze-lens-builder/src/scored.rs
+++ b/crates/graze-lens-builder/src/scored.rs
@@ -1,4 +1,4 @@
-//! The v2 scored lens blob.
+//! The scored lens blob: v2, and v3 which adds a count.
 //!
 //! A v1 lens was a Redis SET of DIDs: membership, yes or no. That cannot express
 //! "this author is in your second degree, reached by 40 of the people you
@@ -9,18 +9,46 @@
 //! # Layout
 //!
 //! ```text
-//! header, 16 bytes
-//!   0..4    magic  b"GLZ2"
-//!   4       version = 2
+//! header, 16 bytes (v2) or 20 bytes (v3)
+//!   0..4    magic  b"GLZ2" (v2) or b"GLZ3" (v3)
+//!   4       version = 2 | 3
 //!   5       facet id
 //!   6       id space (0 = the shared didint space, 1 = the lens-owned one)
-//!   7       reserved (zero)
+//!   7       kind (v3: 0 = boolean, 1 = countable; v2: reserved, zero)
 //!   8..12   entry count, u32 LE
 //!   12..16  built_at, u32 LE unix seconds
-//! entries, 6 bytes each, SORTED ASCENDING BY ID
+//!   16..18  max_count, u16 LE   (v3 only)
+//!   18..20  seed_count, u16 LE  (v3 only)
+//! entries, 6 bytes (v2) or 8 bytes (v3) each, SORTED ASCENDING BY ID
 //!   +0..4   didint, u32 LE
 //!   +4..6   weight, u16 LE fixed-point (65535 == 1.0)
+//!   +6..8   count, u16 LE saturating (v3 only)
 //! ```
+//!
+//! # Why v3 exists
+//!
+//! A weight is reach normalised against *this viewer's own* maximum, so "40 of
+//! your follows reach them" became 0.67 and the 40 was gone. Nothing
+//! downstream could express "at least 5 of the people I follow", because the 5
+//! no longer existed anywhere. v3 keeps the raw count beside the weight it
+//! produced.
+//!
+//! **The key name does NOT change with the version** — still
+//! `lens:v2:{facet}:{did}`. The header carries the version, and not renaming
+//! the key is what makes a builder rollback safe: republish v2 to the same key
+//! and every reader, rolled or not, picks it up. "Bump the key prefix too" is
+//! the tempting wrong move.
+//!
+//! # A count beside its id, not in its own section
+//!
+//! Array-of-structs costs a little cache locality against a split counts array,
+//! and is chosen for its failure mode: here a count cannot shear away from its
+//! id without also breaking the ascending id order, which the reader's
+//! integrity sample detects. A misaligned counts *section* would hand every
+//! author their neighbour's count with every id correct and every length check
+//! passing — silent wrongness of exactly the kind that has bitten this system
+//! three times (id-space mismatch, facet-byte mismatch, truncated backfills
+//! marked complete).
 //!
 //! Two choices worth defending:
 //!
@@ -41,9 +69,28 @@
 //! bytes.
 
 pub const MAGIC: &[u8; 4] = b"GLZ2";
+/// v3 magic. The key name does NOT change with the version — `lens:v2:{facet}:{did}`
+/// still — because the header carries the version and not renaming the key is
+/// what makes a builder rollback safe: publish v2 again and every reader,
+/// rolled or not, picks it up from the same place. "Bump the key prefix too" is
+/// the tempting wrong move.
+pub const MAGIC_V3: &[u8; 4] = b"GLZ3";
 pub const VERSION: u8 = 2;
+pub const VERSION_V3: u8 = 3;
 pub const HEADER_LEN: usize = 16;
+pub const HEADER_LEN_V3: usize = 20;
 pub const ENTRY_LEN: usize = 6;
+pub const ENTRY_LEN_V3: usize = 8;
+
+/// A signal that is present or absent, with no magnitude: `follows`.
+///
+/// Its stored count is a literal 1 — true, and so unable to mislead a `>= 1`
+/// filter — but `kind` is the guard that actually matters, and the reader
+/// checks it independently of the count.
+pub const KIND_BOOLEAN: u8 = 0;
+/// A signal with a meaningful magnitude: how many of the viewer's own follows
+/// reach this author.
+pub const KIND_COUNTABLE: u8 = 1;
 
 /// Which u32 id space this blob's entries belong to.
 ///
@@ -75,6 +122,65 @@ pub const WEIGHT_MAX: u16 = u16::MAX;
 pub fn weight_from_f32(v: f32) -> u16 {
     let clamped = v.clamp(0.0, 1.0);
     (clamped * WEIGHT_MAX as f32).round() as u16
+}
+
+/// Encode entries into a v3 blob, carrying a count beside each weight.
+///
+/// # Why a count at all
+///
+/// The reach that produces each weight is computed in ClickHouse and then
+/// thrown away: a weight is reach normalised against *this viewer's own*
+/// maximum, so "40 of your follows reach them" becomes 0.67 and the 40 is gone.
+/// Nothing downstream could express "at least 5 of the people I follow",
+/// because the 5 no longer existed. This keeps it.
+///
+/// `max_count` and `seed_count` are part of the wire contract, not diagnostics:
+/// the reader refuses to answer a threshold when `max_count` is zero (a facet
+/// whose query has no count to give), and `integrity_sample` checks
+/// `count <= max_count <= seed_count`.
+///
+/// ⚠️ `LENS_VELOCITY_DAYS` and `MAX_SEED_AUTHORS` become part of this contract
+/// too: changing either silently re-points every stored count, and requires a
+/// forced rebuild rather than a rolling one.
+#[allow(clippy::too_many_arguments)]
+pub fn encode_v3_in_space(
+    facet: u8,
+    idspace: u8,
+    kind: u8,
+    built_at: u32,
+    max_count: u16,
+    seed_count: u16,
+    mut entries: Vec<(u32, u16, u16)>,
+) -> Vec<u8> {
+    entries.sort_unstable_by_key(|(id, _, _)| *id);
+    entries.dedup_by_key(|(id, _, _)| *id);
+
+    let mut out = Vec::with_capacity(HEADER_LEN_V3 + entries.len() * ENTRY_LEN_V3);
+    out.extend_from_slice(MAGIC_V3);
+    out.push(VERSION_V3);
+    out.push(facet);
+    out.push(idspace);
+    out.push(kind);
+    out.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+    out.extend_from_slice(&built_at.to_le_bytes());
+    out.extend_from_slice(&max_count.to_le_bytes());
+    out.extend_from_slice(&seed_count.to_le_bytes());
+    for (id, weight, count) in entries {
+        out.extend_from_slice(&id.to_le_bytes());
+        out.extend_from_slice(&weight.to_le_bytes());
+        out.extend_from_slice(&count.to_le_bytes());
+    }
+    out
+}
+
+/// Saturating cast for a count that will not fit in the stored `u16`.
+///
+/// Saturates rather than wrapping: a viewer with more than 65,535 follows
+/// reaching one author is beyond what the field can say, and the honest answer
+/// is "at least this many" — wrapping would turn the strongest possible signal
+/// into a weak one, which is exactly the failure `weight_from_f32` clamps for.
+pub fn count_from_u32(v: u32) -> u16 {
+    v.min(u16::MAX as u32) as u16
 }
 
 /// Encode entries into a blob. Input need not be sorted; output always is.
@@ -110,10 +216,46 @@ pub fn encode_in_space(
 /// A blob's header, once validated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Header {
+    pub version: u8,
     pub facet: u8,
     pub idspace: u8,
+    /// `KIND_BOOLEAN` or `KIND_COUNTABLE`. v2 reports boolean, since byte 7 was
+    /// reserved-zero there.
+    pub kind: u8,
     pub count: u32,
     pub built_at: u32,
+    /// Largest count in the blob; zero on v2 and on a facet with no count.
+    pub max_count: u16,
+    /// Accounts the build started from — the ceiling any count must respect.
+    pub seed_count: u16,
+}
+
+impl Header {
+    pub fn header_len(self) -> usize {
+        if self.version >= VERSION_V3 {
+            HEADER_LEN_V3
+        } else {
+            HEADER_LEN
+        }
+    }
+
+    pub fn entry_len(self) -> usize {
+        if self.version >= VERSION_V3 {
+            ENTRY_LEN_V3
+        } else {
+            ENTRY_LEN
+        }
+    }
+
+    /// Whether this blob can answer a count threshold.
+    ///
+    /// False for v2, and false for a v3 blob whose `max_count` is zero: a facet
+    /// whose builder has no count to give publishes zeroes, and answering
+    /// "0 of your follows" for every author would fail every threshold rather
+    /// than admitting it does not know.
+    pub fn counts(self) -> bool {
+        self.version >= VERSION_V3 && self.kind == KIND_COUNTABLE && self.max_count > 0
+    }
 }
 
 /// Validate and read the header, or `None` if this is not a v2 blob.
@@ -121,7 +263,20 @@ pub struct Header {
 /// Returns `None` rather than erroring for a v1 set or truncated value, so a
 /// reader can fall back instead of failing.
 pub fn header(blob: &[u8]) -> Option<Header> {
-    if blob.len() < HEADER_LEN || &blob[0..4] != MAGIC || blob[4] != VERSION {
+    if blob.len() < 8 {
+        return None;
+    }
+    let magic: &[u8] = &blob[0..4];
+    let version = blob[4];
+    let (header_len, entry_len) = match (magic, version) {
+        (m, VERSION) if m == MAGIC => (HEADER_LEN, ENTRY_LEN),
+        (m, VERSION_V3) if m == MAGIC_V3 => (HEADER_LEN_V3, ENTRY_LEN_V3),
+        // A magic and a version that disagree mean one field was written and
+        // the other was not; the geometry is then ambiguous, and guessing reads
+        // every entry at the wrong stride.
+        _ => return None,
+    };
+    if blob.len() < header_len {
         return None;
     }
     let count = u32::from_le_bytes(blob[8..12].try_into().ok()?);
@@ -129,36 +284,71 @@ pub fn header(blob: &[u8]) -> Option<Header> {
     // trusting the count would read past the end. Longer is legal: the space
     // after the entries belongs to optional trailers (the bloom), which the
     // entries section — being exactly sized by `count` — safely delimits.
-    if blob.len() < HEADER_LEN + count as usize * ENTRY_LEN {
+    if blob.len() < header_len + count as usize * entry_len {
         return None;
     }
+    let (max_count, seed_count) = if version >= VERSION_V3 {
+        (
+            u16::from_le_bytes(blob[16..18].try_into().ok()?),
+            u16::from_le_bytes(blob[18..20].try_into().ok()?),
+        )
+    } else {
+        (0, 0)
+    };
     Some(Header {
+        version,
         facet: blob[5],
         idspace: blob[6],
+        kind: if version >= VERSION_V3 {
+            blob[7]
+        } else {
+            KIND_BOOLEAN
+        },
         count,
         built_at: u32::from_le_bytes(blob[12..16].try_into().ok()?),
+        max_count,
+        seed_count,
     })
+}
+
+/// The stored count for one id, or `None` when the blob cannot supply one.
+///
+/// `None` is deliberately not `Some(0)`: "this blob has no counts" and "no
+/// follows of yours reach them" are different facts, and only the second may
+/// fail a threshold.
+pub fn count_of(blob: &[u8], id: u32) -> Option<u16> {
+    let h = header(blob)?;
+    if !h.counts() {
+        return None;
+    }
+    let at = entry_offset(blob, id)?;
+    Some(u16::from_le_bytes(blob[at + 6..at + 8].try_into().ok()?))
+}
+
+/// Byte offset of the entry for `id`, by binary search over the raw bytes.
+fn entry_offset(blob: &[u8], id: u32) -> Option<usize> {
+    let h = header(blob)?;
+    let (header_len, entry_len) = (h.header_len(), h.entry_len());
+    let (mut lo, mut hi) = (0usize, h.count as usize);
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        let at = header_len + mid * entry_len;
+        let candidate = u32::from_le_bytes(blob[at..at + 4].try_into().ok()?);
+        match candidate.cmp(&id) {
+            std::cmp::Ordering::Less => lo = mid + 1,
+            std::cmp::Ordering::Greater => hi = mid,
+            std::cmp::Ordering::Equal => return Some(at),
+        }
+    }
+    None
 }
 
 /// The weight for one id, by binary search over the raw bytes.
 ///
 /// No decoding, no allocation. `None` means the author is not in this lens.
 pub fn weight_of(blob: &[u8], id: u32) -> Option<u16> {
-    let h = header(blob)?;
-    let (mut lo, mut hi) = (0usize, h.count as usize);
-    while lo < hi {
-        let mid = (lo + hi) / 2;
-        let at = HEADER_LEN + mid * ENTRY_LEN;
-        let candidate = u32::from_le_bytes(blob[at..at + 4].try_into().ok()?);
-        match candidate.cmp(&id) {
-            std::cmp::Ordering::Less => lo = mid + 1,
-            std::cmp::Ordering::Greater => hi = mid,
-            std::cmp::Ordering::Equal => {
-                return Some(u16::from_le_bytes(blob[at + 4..at + 6].try_into().ok()?));
-            }
-        }
-    }
-    None
+    let at = entry_offset(blob, id)?;
+    Some(u16::from_le_bytes(blob[at + 4..at + 6].try_into().ok()?))
 }
 
 // ---------------------------------------------------------------------------
@@ -222,7 +412,11 @@ pub fn append_bloom(blob: &mut Vec<u8>, members: &[u32]) {
 /// Where the bloom trailer starts, if the blob carries one.
 fn bloom_at(blob: &[u8]) -> Option<usize> {
     let h = header(blob)?;
-    let at = HEADER_LEN + h.count as usize * ENTRY_LEN;
+    // Geometry from the header, not the v2 constants: a v3 blob's entries are
+    // 8 bytes behind a 20-byte header, and looking for the trailer at the v2
+    // offset lands inside the entries and finds no magic — silently dropping
+    // the bloom for every v3 blob.
+    let at = h.header_len() + h.count as usize * h.entry_len();
     if blob.len() >= at + 12 && &blob[at..at + 4] == BLOOM_MAGIC {
         Some(at)
     } else {
@@ -466,5 +660,94 @@ mod tests {
         let blob = encode(FACET_FOLLOWS2, 0, (0..250_000).map(|i| (i, 1u16)).collect());
         assert_eq!(blob.len(), HEADER_LEN + 250_000 * 6);
         assert!(blob.len() < 1_600_000, "250k entries should be ~1.5 MB");
+    }
+
+    /// The v3 wire format as literal bytes — the SAME array asserted in
+    /// feeder-rs (`src/lens/scored.rs`, `v3_golden_bytes_are_the_wire_contract`).
+    ///
+    /// The existing `GOLDEN_VECTOR` style of test compares our encoder to our
+    /// own expectations, so a change made identically in both repos passes it.
+    /// These bytes were written down by hand and cannot drift with the code. If
+    /// this fails, the format changed: fix the encoder, do not regenerate the
+    /// array.
+    #[test]
+    fn v3_golden_bytes_are_the_cross_repo_contract() {
+        #[rustfmt::skip]
+        const GOLDEN: &[u8] = &[
+            0x47, 0x4c, 0x5a, 0x33, 0x03, 0x02, 0x01, 0x01,
+            0x03, 0x00, 0x00, 0x00, 0x00, 0xb7, 0x92, 0x6a,
+            0x09, 0x00, 0x78, 0x00, 0x2a, 0x00, 0x00, 0x00,
+            0xe8, 0x03, 0x03, 0x00, 0x72, 0xb0, 0x0a, 0x00,
+            0xff, 0xff, 0x09, 0x00, 0x9d, 0x63, 0x4a, 0x00,
+            0x00, 0x80, 0x05, 0x00,
+        ];
+
+        let ours = encode_v3_in_space(
+            FACET_FOLLOWS2,
+            IDSPACE_LENS,
+            KIND_COUNTABLE,
+            1_788_000_000,
+            9,
+            120,
+            vec![
+                (700_530, WEIGHT_MAX, 9),
+                (42, 1000, 3),
+                (4_875_165, 32_768, 5),
+            ],
+        );
+        assert_eq!(ours, GOLDEN, "the encoder must produce exactly these bytes");
+
+        let h = header(GOLDEN).expect("golden decodes");
+        assert_eq!(h.version, VERSION_V3);
+        assert_eq!(h.kind, KIND_COUNTABLE);
+        assert_eq!(h.max_count, 9);
+        assert_eq!(h.seed_count, 120);
+        assert!(h.counts());
+        assert_eq!(count_of(GOLDEN, 700_530), Some(9));
+        assert_eq!(weight_of(GOLDEN, 42), Some(1000));
+    }
+
+    /// A v2 blob declines to answer a count rather than answering zero.
+    ///
+    /// The v2 encoder stays for exactly this reason: rolling the builder back
+    /// must remain possible, and the key name does not change with the version,
+    /// so a rollback republishes v2 to the same key and every reader picks it
+    /// up. A reader must then read "no counts available", never "count zero".
+    #[test]
+    fn a_v2_blob_still_encodes_and_declines_to_answer_counts() {
+        let v2 = encode_in_space(FACET_FOLLOWS2, IDSPACE_LENS, 0, vec![(42, 1000)]);
+        let h = header(&v2).expect("v2 still decodes");
+        assert_eq!(h.version, VERSION);
+        assert!(!h.counts());
+        assert_eq!(weight_of(&v2, 42), Some(1000));
+        assert_eq!(count_of(&v2, 42), None, "not Some(0)");
+    }
+
+    /// `follows` is boolean, and `kind` disqualifies counts on its own — the
+    /// stored 1 is true but is not what the guard rests on.
+    #[test]
+    fn the_boolean_facet_refuses_counts_by_kind_not_by_value() {
+        let blob = encode_v3_in_space(
+            FACET_FOLLOWS,
+            IDSPACE_LENS,
+            KIND_BOOLEAN,
+            0,
+            1,
+            300,
+            vec![(42, WEIGHT_MAX, 1)],
+        );
+        assert!(!header(&blob).unwrap().counts());
+        assert_eq!(count_of(&blob, 42), None);
+    }
+
+    /// Counts saturate rather than wrap. A viewer whose follows number more
+    /// than u16 can hold gets "at least 65,535", which is true; wrapping would
+    /// turn the strongest possible signal into the weakest.
+    #[test]
+    fn counts_saturate_rather_than_wrapping() {
+        assert_eq!(count_from_u32(0), 0);
+        assert_eq!(count_from_u32(65_535), 65_535);
+        assert_eq!(count_from_u32(65_536), 65_535);
+        assert_eq!(count_from_u32(u32::MAX), 65_535);
     }
 }

--- a/crates/graze-lens-builder/src/second_degree.rs
+++ b/crates/graze-lens-builder/src/second_degree.rs
@@ -36,8 +36,16 @@ use crate::scored::{self, FACET_FOLLOWS2};
 
 /// A built second-degree map, before publishing.
 pub struct SecondDegree {
-    /// Top-K, scored and sorted by id, ready to encode.
-    pub entries: Vec<(u32, u16)>,
+    /// Top-K, scored and sorted by id, ready to encode: `(id, weight, count)`.
+    ///
+    /// `count` is the raw reach — how many of the viewer's own follows reach
+    /// this author — kept alongside the normalised weight rather than discarded
+    /// with it. niche and popular store the same raw reach here, NOT their own
+    /// prior-adjusted score, so "at least 5" means the same thing on every
+    /// viewer facet: five of your follows, whichever fame prior the creator
+    /// chose. The weight is what differs between them; the count is the common
+    /// currency.
+    pub entries: Vec<(u32, u16, u16)>,
     /// Every id reached, for the bloom tail.
     pub all_ids: Vec<u32>,
     pub max_reach: u32,
@@ -48,7 +56,7 @@ impl SecondDegree {
         self.all_ids.is_empty()
     }
 
-    /// Encode as a v2 blob: scored top-K plus a bloom over the whole tail.
+    /// Encode as a blob: scored top-K plus a bloom over the whole tail.
     pub fn encode(&self, idspace: u8, built_at: u32) -> Vec<u8> {
         self.encode_as(FACET_FOLLOWS2, idspace, built_at)
     }
@@ -60,7 +68,31 @@ impl SecondDegree {
     /// them refused at read time (the good failure) or, worse, accepted as a
     /// signal they are not.
     pub fn encode_as(&self, facet_id: u8, idspace: u8, built_at: u32) -> Vec<u8> {
-        let mut blob = scored::encode_in_space(facet_id, idspace, built_at, self.entries.clone());
+        self.encode_as_with_seeds(facet_id, idspace, built_at, 0)
+    }
+
+    /// Encode, declaring how many accounts the build started from.
+    ///
+    /// `seed_count` is the viewer's follow count, and it is the ceiling every
+    /// stored count must respect — the reader's `integrity_sample` asserts
+    /// `count <= max_count <= seed_count`, which is the invariant that caught a
+    /// corrupt id map once already (2,234 reach against 1,183 seeds).
+    pub fn encode_as_with_seeds(
+        &self,
+        facet_id: u8,
+        idspace: u8,
+        built_at: u32,
+        seed_count: usize,
+    ) -> Vec<u8> {
+        let mut blob = scored::encode_v3_in_space(
+            facet_id,
+            idspace,
+            scored::KIND_COUNTABLE,
+            built_at,
+            scored::count_from_u32(self.max_reach),
+            scored::count_from_u32(seed_count as u32),
+            self.entries.clone(),
+        );
         scored::append_bloom(&mut blob, &self.all_ids);
         blob
     }
@@ -73,7 +105,7 @@ impl SecondDegree {
 /// what lets a lens degrade smoothly past the top-K instead of falling off a
 /// cliff.
 pub fn parse_reach_tsv(text: &str, top_k: usize) -> SecondDegree {
-    let mut entries: Vec<(u32, u16)> = Vec::with_capacity(top_k.min(1024));
+    let mut entries: Vec<(u32, u16, u16)> = Vec::with_capacity(top_k.min(1024));
     let mut all_ids: Vec<u32> = Vec::new();
     let mut max_reach = 0u32;
 
@@ -100,7 +132,14 @@ pub fn parse_reach_tsv(text: &str, top_k: usize) -> SecondDegree {
             } else {
                 reach as f32 / max_reach as f32
             };
-            entries.push((id, scored::weight_from_f32(w)));
+            // The raw reach rides along with the weight it produced. Before
+            // this it was read, used for `max_reach`, and dropped — which is
+            // why no filter could ever say "at least 5 of your follows".
+            entries.push((
+                id,
+                scored::weight_from_f32(w),
+                scored::count_from_u32(reach),
+            ));
         }
     }
 
@@ -191,7 +230,7 @@ pub fn exclude_first_degree(map: &mut SecondDegree, first_degree: &[u32]) {
     let before = map.all_ids.len();
     map.all_ids.retain(|id| sorted.binary_search(id).is_err());
     map.entries
-        .retain(|(id, _)| sorted.binary_search(id).is_err());
+        .retain(|(id, _, _)| sorted.binary_search(id).is_err());
     debug!(
         removed = before - map.all_ids.len(),
         "excluded first degree from second"
@@ -316,7 +355,7 @@ mod tests {
         let mut m = parse_reach_tsv(tsv, 10);
         exclude_first_degree(&mut m, &[200]);
         assert_eq!(m.all_ids, vec![100, 300]);
-        assert!(m.entries.iter().all(|(id, _)| *id != 200));
+        assert!(m.entries.iter().all(|(id, _, _)| *id != 200));
     }
 
     #[test]

--- a/crates/graze-lens-builder/tests/community_repro.rs
+++ b/crates/graze-lens-builder/tests/community_repro.rs
@@ -61,7 +61,7 @@ fn community_entries_reflect_the_viewers_affinity() {
     println!("members rows parsed: {}", community_of.len());
 
     let top_k = 20_000;
-    let map = priors::parse_members_tsv(&mem_text, &affinity, top_k);
+    let map = priors::parse_members_tsv(&mem_text, &affinity, seeds, top_k);
     println!(
         "\n=== parse_members_tsv -> entries={} all_ids={} ===",
         map.entries.len(),
@@ -69,7 +69,7 @@ fn community_entries_reflect_the_viewers_affinity() {
     );
 
     let mut by_community: HashMap<u32, usize> = HashMap::new();
-    for (id, _) in &map.entries {
+    for (id, _, _) in &map.entries {
         *by_community
             .entry(community_of.get(id).copied().unwrap_or(u32::MAX))
             .or_default() += 1;
@@ -87,14 +87,14 @@ fn community_entries_reflect_the_viewers_affinity() {
     }
 
     // Which account set the normalisation max, and what it looks like.
-    if let Some((top_id, top_w)) = map.entries.iter().max_by_key(|(_, w)| *w) {
+    if let Some((top_id, top_w, _)) = map.entries.iter().max_by_key(|(_, w, _)| *w) {
         println!(
             "\nhighest-weight entry: account {top_id} weight {top_w} community {:?} followers {:?}",
             community_of.get(top_id),
             followers_of.get(top_id)
         );
     }
-    let scores: Vec<u16> = map.entries.iter().map(|(_, w)| *w).collect();
+    let scores: Vec<u16> = map.entries.iter().map(|(_, w, _)| *w).collect();
     println!(
         "weight range: {:?} .. {:?}",
         scores.iter().min(),
@@ -106,7 +106,7 @@ fn community_entries_reflect_the_viewers_affinity() {
         let body: String = map
             .entries
             .iter()
-            .map(|(id, w)| format!("{id}\t{w}\n"))
+            .map(|(id, w, _)| format!("{id}\t{w}\n"))
             .collect();
         std::fs::write(&out, body).expect("write dump");
         println!("dumped {} entries to {out}", map.entries.len());


### PR DESCRIPTION
Step 2 of the lens overhaul. Depends on the reader in graze-social/feeder-rs#9, which is already merged-ready and takes v2 and v3 both.

## Why

A weight is reach normalised against the viewer's **own** maximum, so *"40 of your follows reach this author"* became `0.67` and the 40 was gone. Nothing downstream could express *"at least 5 of the people I follow"*, because the 5 no longer existed anywhere.

The change is small because **the counts already arrive** — `parse_reach_tsv` and `parse_prior_tsv` both parsed `reach`, used it for `max_reach`, and dropped it.

## Units are the interesting part

- **niche / popular** store the raw reach as the *count*, not their own prior-adjusted score. So "at least 5" means the same thing on every viewer facet — *five of your follows* — whichever fame prior the creator picked. The weight is what differs; the count is the common currency.
- **domain**'s count is in different units (this feed's authors, not your follows), which is why thresholds belong to a layer and units never mix inside one comparison.
- **follows** is boolean: count `1`, `kind = BOOLEAN`, and the reader refuses counts *by kind rather than by value*. It's also the only facet with no bloom and no top-K cut, so "only people I follow" is an exact, false-positive-free membership test — the filter creators most want is the one that can be answered precisely.

## Two corrections to the design note

1. It warned that `refresh.rs`'s `FACETS` omits `domain`, so domain blobs would stay v2 for a week. **`FACETS` is the *viewer* facet list, keyed by DID** — domain is feed-scoped and `refresh.rs` already handles it separately (`SCAN lens:v2:domain:*`, enqueue by algo id). Adding domain to `FACETS` would have written meaningless `lens:v2:domain:{did}` keys; `delta.rs` asserts against exactly that.
2. It budgeted for **community** shipping with no count. It can have one: `parse_affinity_tsv` already held it as a share of the seed count, so multiplying back recovers the integer — how many of the viewer's follows are in this member's community. That also makes `publish_scored`'s `max_reach <= seeds.len()` assert **live for the first time**; community published `max_reach: 0`, making the check vacuous for the one facet whose logs showed a suspiciously constant reach.

## Rollback

**The key name does not change with the version** — still `lens:v2:{facet}:{did}`. The header carries the version, and not renaming the key is what makes a builder rollback safe: republish v2 to the same key and every reader, rolled or not, picks it up. The v2 encoder stays for that reason, with a test asserting a v2 blob reads back as *"no counts available"* and never as *"count zero"*.

## Layout

Array-of-structs rather than a separate counts section, chosen for its **failure mode**: a count cannot shear from its id without breaking id order, which the reader's integrity sample detects. A misaligned counts *section* would give every author their neighbour's count with every length check passing.

The v3 golden is a **hand-written byte literal, identical to the one in feeder-rs**, and this encoder produces exactly those bytes. That's the cross-repo check the existing golden cannot be — it compares our encoder to our own expectations, so a bug written the same way in both repos passes it.

51 tests pass, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)