### PR TITLE
Stop interleaving from overriding a gated result

### DIFF
--- a/crates/graze-api/src/algorithm/mod.rs
+++ b/crates/graze-api/src/algorithm/mod.rs
@@ -194,16 +194,21 @@ impl LinkLonkAlgorithm {
             } else {
                 // Need to compute fresh results
                 let audit_ref = audit.as_mut().map(|a| &mut **a);
-                let mut compute_result = self
+                let compute_result = self
                     .compute_personalization(&user_hash, algo_id, &params, audit_ref)
                     .await?;
 
                 // Interleaving: blend a second ranker's list into this one so the user acts as
                 // their own control. Runs only for enrolled users, and only on a fresh compute —
-                // cached pages replay the draft that was already stored.
-                if let Some((control, treatment, control_first)) =
-                    self.interleave_assignment(Some(user_did), algo_id)
-                {
+                // cached pages replay the draft that was already stored — and never past a gate
+                // (see `interleave_or_keep`).
+                let compute_result = Self::interleave_or_keep(compute_result, || async {
+                    let Some((control, treatment, control_first)) =
+                        self.interleave_assignment(Some(user_did), algo_id)
+                    else {
+                        return Ok(None);
+                    };
+
                     // Derive co-liker weights ONCE and score both arms from them, so the arms differ
                     // only by traversal. Deriving per arm reintroduces the seed-sampling shuffle as
                     // noise (see `score_with_ranker`).
@@ -221,23 +226,26 @@ impl LinkLonkAlgorithm {
                         )
                         .await?;
 
-                    if !weights.is_empty() {
-                        let control_result = self
-                            .score_with_ranker(&user_hash, algo_id, &params, &weights, control)
-                            .await?;
-                        let treatment_result = self
-                            .score_with_ranker(&user_hash, algo_id, &params, &weights, treatment)
-                            .await?;
-                        compute_result = self.apply_interleaving(
-                            control_result,
-                            treatment_result,
-                            control,
-                            treatment,
-                            control_first,
-                            limit,
-                        );
+                    if weights.is_empty() {
+                        return Ok(None);
                     }
-                }
+
+                    let control_result = self
+                        .score_with_ranker(&user_hash, algo_id, &params, &weights, control)
+                        .await?;
+                    let treatment_result = self
+                        .score_with_ranker(&user_hash, algo_id, &params, &weights, treatment)
+                        .await?;
+                    Ok(Some(self.apply_interleaving(
+                        control_result,
+                        treatment_result,
+                        control,
+                        treatment,
+                        control_first,
+                        limit,
+                    )))
+                })
+                .await?;
 
                 // Capture scoring stats before converting
                 let stats = Some((
@@ -440,6 +448,40 @@ impl LinkLonkAlgorithm {
         }
     }
 
+    /// Hand a computed ranking to the interleaving draft — unless a gate already fired.
+    ///
+    /// `compute_personalization` returns early from its pool-size and like-density gates with a
+    /// `skip_reason` and no ranking. Replacing that result with a draft broke both halves of what
+    /// the gates are for:
+    ///
+    /// * The label. Drafts come from `score_with_ranker`, which never sets `skip_reason`, so an
+    ///   interleaved response lost its `fallback_reason` — the defect PR #61 fixed, reintroduced
+    ///   through this path. Measured 2026-09-03 on revision 62: 15 `pool_density` early exits
+    ///   produced 14 labels, ~7% short, matching `INTERLEAVE_TRAFFIC_PCT=10`.
+    /// * The cost, which matters more. The gates exist to SKIP the co-liker walk on feeds that
+    ///   structurally cannot rank; drafting ran that walk plus two full scoring passes on exactly
+    ///   those feeds, so a gated feed cost *more* than an ungated one.
+    ///
+    /// `build_draft` is therefore a closure rather than a ready-made draft: all of that work lives
+    /// inside it and is never invoked once `skip_reason` is set. It returns `None` when the user is
+    /// not enrolled or has no co-liker weights, in which case the computed ranking stands as well.
+    ///
+    /// A gated pool is not a valid experiment arm either — both arms would be drawn from a pool the
+    /// engine has already judged unrankable — so nothing is lost by not enrolling it.
+    async fn interleave_or_keep<F, Fut>(
+        compute_result: ScoringResult,
+        build_draft: F,
+    ) -> Result<ScoringResult>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<Option<ScoringResult>>>,
+    {
+        if compute_result.skip_reason.is_some() {
+            return Ok(compute_result);
+        }
+        Ok(build_draft().await?.unwrap_or(compute_result))
+    }
+
     /// Team-draft the control and treatment lists into a single ranking.
     ///
     /// The draft order *is* the ranking, so `DIVERSITY_PRESERVE_ORDER` must be on for the
@@ -505,10 +547,10 @@ impl LinkLonkAlgorithm {
             // Whichever arm faceted the seed reported its keep rate; carry it so an interleaved
             // readout can still tell a ranking effect from a coverage collapse.
             seed_keep_rate: treatment.seed_keep_rate.or(control.seed_keep_rate),
-            // Neither draft can carry one — both come from `score_with_ranker`, which is only
-            // reached once the gates have passed. Propagated rather than hardcoded to `None` so
-            // that if a gate ever moves inside the ranker path, the reason survives the merge
-            // instead of being silently dropped here.
+            // Neither draft can carry one — both come from `score_with_ranker`, which
+            // `interleave_or_keep` only reaches once the gates have passed. Propagated rather than
+            // hardcoded to `None` so that if a gate ever moves inside the ranker path, the reason
+            // survives the merge instead of being silently dropped here.
             skip_reason: treatment.skip_reason.or(control.skip_reason),
         }
     }
@@ -1127,5 +1169,84 @@ impl LinkLonkAlgorithm {
     /// Get liker cache statistics.
     pub fn get_cache_stats(&self) -> CacheStats {
         self.liker_cache.get_stats()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn gated(reason: &'static str) -> ScoringResult {
+        ScoringResult {
+            skip_reason: Some(reason),
+            ..Default::default()
+        }
+    }
+
+    fn draft() -> ScoringResult {
+        ScoringResult {
+            scored_posts: vec![(1.0, "post".to_string())],
+            scored_count: 1,
+            requires_preserved_order: true,
+            ..Default::default()
+        }
+    }
+
+    /// The invariant: a gated `ScoringResult` must come out of the interleaving branch unchanged.
+    ///
+    /// Both halves matter. The label must survive, because the drafts cannot carry a
+    /// `skip_reason` and dropping it takes `fallback_reason` off the response. And the draft must
+    /// never be *built*, because the gate's whole point is to skip the co-liker walk and the two
+    /// scoring passes on a feed that cannot rank — a gated feed must cost less, not more.
+    #[tokio::test]
+    async fn a_gated_result_survives_the_interleaving_branch_untouched() {
+        for reason in ["pool_size", "pool_density", "no_colikers"] {
+            let built = Cell::new(false);
+            let out = LinkLonkAlgorithm::interleave_or_keep(gated(reason), || async {
+                built.set(true);
+                Ok(Some(draft()))
+            })
+            .await
+            .unwrap();
+
+            assert!(!built.get(), "{reason}: drafted past the gate");
+            assert_eq!(out.skip_reason, Some(reason), "{reason}: label dropped");
+            assert!(
+                out.scored_posts.is_empty(),
+                "{reason}: gated result replaced"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn an_ungated_result_is_replaced_by_the_draft() {
+        let built = Cell::new(false);
+        let out = LinkLonkAlgorithm::interleave_or_keep(ScoringResult::default(), || async {
+            built.set(true);
+            Ok(Some(draft()))
+        })
+        .await
+        .unwrap();
+
+        assert!(built.get(), "the draft was never built");
+        assert_eq!(out.scored_count, 1);
+        assert!(out.requires_preserved_order);
+    }
+
+    /// Not enrolled, or enrolled with no co-liker weights: the computed ranking stands.
+    #[tokio::test]
+    async fn an_ungated_result_stands_when_there_is_no_draft() {
+        let computed = ScoringResult {
+            scored_posts: vec![(2.0, "computed".to_string())],
+            scored_count: 1,
+            ..Default::default()
+        };
+        let out = LinkLonkAlgorithm::interleave_or_keep(computed, || async { Ok(None) })
+            .await
+            .unwrap();
+
+        assert_eq!(out.scored_posts, vec![(2.0, "computed".to_string())]);
+        assert!(!out.requires_preserved_order);
     }
 }


### PR DESCRIPTION
`personalize_with_audit` computed a ranking and then, for interleaving-enrolled users, replaced it wholesale:

```rust
let mut compute_result = self.compute_personalization(...).await?;
if let Some((control, treatment, control_first)) = self.interleave_assignment(...) {
    ...
    compute_result = self.apply_interleaving(...);   // discards the gated result
}
```

The pre-scoring gates in `compute_personalization` (step 0 `MIN_CANDIDATE_POOL_FOR_PERSONALIZATION`, step 0b `MIN_POOL_SCOREABLE_SHARE`) return early with a `skip_reason` and no ranking. That result was thrown away for any enrolled request.

## Two consequences

**Labelling.** The drafts come from `score_with_ranker`, which is only reached past the gates and never sets `skip_reason`, so `fallback_reason` went silently missing on those responses — the defect #61 fixed, reintroduced through this path. `apply_interleaving` already propagates `treatment.skip_reason.or(control.skip_reason)`, but that could not help: the reason lived on the result being discarded, not on the drafts.

**Cost, which matters more.** The gates exist to *skip* the co-liker walk on feeds that structurally cannot produce a ranking. This path ran `get_or_compute_colikes` plus two full `score_with_ranker` passes on exactly those feeds — so a gated feed cost more than an ungated one.

## Measurement

Production, 2026-09-03: over ~22h on revision 62, 15 `early_exit: pool like-density` log lines produced only 14 `fallback_reason=pool_density` labels. Tracing the missing one by request_id (`01a06782-2778-7ac3-a845-b3e0cdce63bb`) shows `early_exit: pool like-density` followed by two `scorer_completed` lines and `interleave_draft` — the gate fired and was then overridden. ~7% of gated requests, consistent with `INTERLEAVE_TRAFFIC_PCT=10`.

This fired with `INTERLEAVE_ENABLED=1` and `INTERLEAVE_SELF_CHECK=1`, control == treatment == `post_first` — the A/A self-check from #73, not a real experiment. `INTERLEAVE_ENABLED` was set to 0 on revision 63 (2026-09-03T14:08Z), so **the bypass is dormant right now**; it returns the moment interleaving or the self-check is switched back on.

## Fix

The branch is wrapped in `interleave_or_keep`, which returns the computed result untouched when `skip_reason` is set. The draft is passed as a *closure* rather than a ready-made value, so the co-liker walk and both scoring passes are never invoked past a gate — that is what makes this a cost fix and not just a labelling one. The closure returning `None` (not enrolled, or no co-liker weights) also keeps the computed result, which collapses the old nested `if let` / `if !weights.is_empty()` into two early returns.

`interleave_assignment` now sits inside the closure, so a gated feed is never enrolled at all. That answers the open question about whether assignment should consult the gates without teaching that function (config + a stable hash, no Redis) anything about pool state. Nothing is lost: both arms of a gated feed would be drawn from a pool the engine has already judged unrankable, so it is not a valid experiment either way.

## Test

`a_gated_result_survives_the_interleaving_branch_untouched` runs all three real skip reasons (`pool_size`, `pool_density`, `no_colikers`) and asserts the label survives, the posts are untouched, **and** the draft closure was never invoked — pinning the cost invariant alongside the labelling one. Two companion tests pin the other directions: an ungated result is replaced by the draft, and an ungated result stands when there is no draft.

Mutation-checked: flipping the guard to `if false` fails with `pool_size: drafted past the gate`.

`cargo test -p graze-api --lib` — 176 passed. `cargo fmt` and `cargo clippy --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)